### PR TITLE
Add reverse-related to Poison Counter

### DIFF
--- a/tokens.xml
+++ b/tokens.xml
@@ -4444,6 +4444,77 @@ Whenever a card is put into your graveyard from anywhere, you may return it to y
             <tablerow>1</tablerow>
             <text></text>
             <token>1</token>
+            <reverse-related>Blackcleave Goblin</reverse-related>
+            <reverse-related>Blight Mamba</reverse-relatedL>
+            <reverse-related>Blighted Agent</reverse-related>
+            <reverse-related>Blightsteel Colossus</reverse-related>
+            <reverse-related>Blightwidow</reverse-related>
+            <reverse-related>Caress of Phyrexia</reverse-related>
+            <reverse-related>Chained Throatseeker</reverse-related>
+            <reverse-related>Contagious Nim</reverse-related>
+            <reverse-related>Core Prowler</reverse-related>
+            <reverse-related>Corpse Cur</reverse-related>
+            <reverse-related>Corrupted Conscience</reverse-related>
+            <reverse-related>Crypt Cobra</reverse-related>
+            <reverse-related>Cystbearer</reverse-related>
+            <reverse-related>Decimator Web</reverse-related>
+            <reverse-related>Fallen Ferromancer</reverse-related>
+            <reverse-related>Flensermite</reverse-related>
+            <reverse-related>Flesh-Eater Imp</reverse-related>
+            <reverse-related>Glistener Elf</reverse-related>
+            <reverse-related>Glistening Oil</reverse-related>
+            <reverse-related>Grafted Exoskeleton</reverse-related>
+            <reverse-related>Hand of the Praetors</reverse-related>
+            <reverse-related>Ichor Rats</reverse-related>
+            <reverse-related>Ichorclaw Myr</reverse-related>
+            <reverse-related>Inkmoth Nexus</reverse-related>
+            <reverse-related>Insect</reverse-related>
+            <reverse-related>Lost Leonin</reverse-related>
+            <reverse-related>Marsh Viper</reverse-related>
+            <reverse-related>Necropede</reverse-related>
+            <reverse-related>Ogre Menial</reverse-related>
+            <reverse-related>Pestilent Souleater</reverse-related>
+            <reverse-related>Phyresis</reverse-related>
+            <reverse-related>Phyrexian Crusader</reverse-related>
+            <reverse-related>Phyrexian Digester</reverse-related>
+            <reverse-related>Phyrexian Hydra</reverse-related>
+            <reverse-related>Phyrexian Juggernaut</reverse-related>
+            <reverse-related>Phyrexian Swarmlord</reverse-related>
+            <reverse-related>Phyrexian Unlife</reverse-related>
+            <reverse-related>Phyrexian Vatmother</reverse-related>
+            <reverse-related>Pistus Strike</reverse-related>
+            <reverse-related>Pit Scorpion</reverse-related>
+            <reverse-related>Plague Myr</reverse-related>
+            <reverse-related>Plague Stinger</reverse-related>
+            <reverse-related>Priests of Norn</reverse-related>
+            <reverse-related>Putrefax</reverse-related>
+            <reverse-related>Razor Swine</reverse-related>
+            <reverse-related>Reaper of Sheoldred</reverse-related>
+            <reverse-related>Relic Putrescence</reverse-related>
+            <reverse-related>Rot Wolf</reverse-related>
+            <reverse-related>Sabertooth Cobra</reverse-related>
+            <reverse-related>Scourge Servant</reverse-related>
+            <reverse-related>Septic Rats</reverse-related>
+            <reverse-related>Shriek Raptor</reverse-related>
+            <reverse-related>Skithiryx, the Blight Dragon</reverse-related>
+            <reverse-related>Snake </reverse-related>
+            <reverse-related>Snake Cult Initiation</reverse-related>
+            <reverse-related>Spinebiter</reverse-related>
+            <reverse-related>Suq'Ata Assassin</reverse-related>
+            <reverse-related>Swamp Mosquito</reverse-related>
+            <reverse-related>Tainted Strike</reverse-related>
+            <reverse-related>Tangle Angler</reverse-related>
+            <reverse-related>Tel-Jilad Fallen</reverse-related>
+            <reverse-related>Tine Shrike</reverse-related>
+            <reverse-related>Toxic Nim</reverse-related>
+            <reverse-related>Triumph of the Hordes</reverse-related>
+            <reverse-related>Vector Asp</reverse-related>
+            <reverse-related>Viral Drake</reverse-related>
+            <reverse-related>Viridian Betrayers</reverse-related>
+            <reverse-related>Viridian Corrupter</reverse-related>
+            <reverse-related>Virulent Sliver</reverse-related>
+            <reverse-related>Virulent Wound</reverse-related>
+            <reverse-related>Whispering Specter</reverse-related>
         </card>
     </cards>
 </cockatrice_carddatabase>


### PR DESCRIPTION
Fixes #7

Adds cards with Infect:
 - not listed since that's the intent of #7

Adds cards with Poisonous:
 - Virulent Sliver
 - Snake Cult Initiation

Adds cards that use poison counters but do not have the infect keyword:
- Crypt Cobra
- Sabertooth Cobra
- Pistus Strike
- Marsh Viper
- Relic Putrescence
- Swamp Mosquito
- Caress of Phyrexia
- Suq'Ata Assassin
- Pit Scorpion
- Virulent Wound