### PR TITLE
Add "count" attribute to reverse-related

### DIFF
--- a/tokens.xml
+++ b/tokens.xml
@@ -376,7 +376,7 @@
             <text>Flying</text>
             <token>1</token>
             <reverse-related>Battle Screech</reverse-related>
-            <reverse-related>Beck // Call</reverse-related>
+            <reverse-related count="4">Beck // Call</reverse-related>
             <reverse-related>Emeria Angel</reverse-related>
             <reverse-related>Jötun Owl Keeper</reverse-related>
             <reverse-related>Migratory Route</reverse-related>
@@ -4367,7 +4367,7 @@ Sacrifice this creature: This creature deals 1 damage to target creature or play
             <reverse-related>Empty the Pits</reverse-related>
             <reverse-related>Endless Ranks of the Dead</reverse-related>
             <reverse-related>Feast or Famine</reverse-related>
-            <reverse-related>From Under the Floorboards</reverse-related>
+            <reverse-related count="3">From Under the Floorboards</reverse-related>
             <reverse-related>Ghoulcaller Gisa</reverse-related>
             <reverse-related>Ghoulcaller's Accomplice</reverse-related>
             <reverse-related count="2">Gisa's Bidding</reverse-related>

--- a/tokens.xml
+++ b/tokens.xml
@@ -33,7 +33,7 @@
             <set picURL="http://magiccards.info/extras/token/conflux/angel.jpg">CON</set>
             <set picURL="http://magiccards.info/extras/token/player-rewards-2004/angel.jpg">SCG</set>
             <color>W</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Angel</type>
             <pt>4/4</pt>
             <tablerow>2</tablerow>
@@ -56,7 +56,7 @@
             <name>Angel </name>
             <set picURL="http://cdn.staticneo.com/w/mtg/b/bb/Angel3.jpg">APC</set>
             <color>B</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Angel</type>
             <pt>3/3</pt>
             <tablerow>2</tablerow>
@@ -68,7 +68,7 @@
             <name>Angel  </name>
             <set picURL="http://media.wizards.com/2015/ogw_239nCi30ks3/en_3sSk9R7ZqJ.png">OGW</set>
             <color>W</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Angel</type>
             <pt>3/3</pt>
             <tablerow>2</tablerow>
@@ -80,7 +80,7 @@
             <name>Antelope</name>
             <set picURL="http://s8.postimg.org/t5pmpgout/ANTELOPE.jpg">VAN</set>
             <color>G</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Antelope</type>
             <pt>2/3</pt>
             <tablerow>2</tablerow>
@@ -92,11 +92,11 @@
             <set picURL="http://magiccards.info/extras/token/commander-2014/ape.jpg">C14</set>
             <set picURL="http://cdn.staticneo.com/w/mtg/d/db/Ape.jpg">PLC</set>
             <color>G</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Ape</type>
             <pt>3/3</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Pongify</reverse-related>
         </card>
@@ -104,11 +104,11 @@
             <name>Ashaya, the Awoken World</name>
             <set picURL="http://media.wizards.com/2015/images/daily/en_ygup3uo7vv.png">ORI</set>
             <color>G</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Legendary Creature — Elemental</type>
             <pt>4/4</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Nissa, Sage Animist</reverse-related>
         </card>
@@ -117,19 +117,19 @@
             <set picURL="http://magiccards.info/extras/token/duel-decks-jace-vs-vraska/assassin.jpg">DDM</set>
             <set picURL="http://magiccards.info/extras/token/return-to-ravnica/assassin.jpg">RTR</set>
             <color>B</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Assassin</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
             <text>Whenever this creature deals combat damage to a player, that player loses the game.</text>
             <token>1</token>
-            <reverse-related>Vraska the Unseen</reverse-related>
+            <reverse-related count="3">Vraska the Unseen</reverse-related>
         </card>
         <card>
             <name>Assassin </name>
             <set picURL="http://media.wizards.com/2016/azetllnwjpxztp2b_CN2/en_6ho4wbGR0y.png">CN2</set>
             <color>B</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Assassin</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
@@ -140,11 +140,11 @@
         <card>
             <name>Assembly-Worker </name>
             <set picURL="http://cdn.staticneo.com/w/mtg/d/dd/Assembly-Worker.jpg">TSP</set>
-            <manacost></manacost>
+            <manacost />
             <type>Token Artifact Creature — Assembly-Worker</type>
             <pt>2/2</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Urza's Factory</reverse-related>
         </card>
@@ -154,7 +154,7 @@
             <set picURL="http://magiccards.info/extras/token/magic-2010/avatar.jpg">M10</set>
             <set picURL="http://magiccards.info/extras/token/lorwyn/avatar.jpg">LRW</set>
             <color>W</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Avatar</type>
             <pt>*/*</pt>
             <tablerow>2</tablerow>
@@ -166,20 +166,20 @@
             <name>Bat</name>
             <set picURL="http://magiccards.info/extras/token/modern-masters/bat.jpg">MMA</set>
             <color>B</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Bat</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
             <text>Flying</text>
             <token>1</token>
-            <reverse-related>Belfry Spirit</reverse-related>
-            <reverse-related>Skeletal Vampire</reverse-related>
+            <reverse-related count="2">Belfry Spirit</reverse-related>
+            <reverse-related count="2">Skeletal Vampire</reverse-related>
         </card>
         <card>
             <name>Bat </name>
             <set picURL="http://cdn.staticneo.com/w/mtg/2/20/Bat.jpg">TSP</set>
             <color>B</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Bat</type>
             <pt>1/2</pt>
             <tablerow>2</tablerow>
@@ -194,15 +194,15 @@
             <set picURL="http://magiccards.info/extras/token/player-rewards-2001/bear.jpg">ODY</set>
             <set picURL="http://magiccards.info/extras/token/player-rewards-2003/bear.jpg">ONS</set>
             <color>G</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Bear</type>
             <pt>2/2</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Bearscape</reverse-related>
             <reverse-related>Caller of the Claw</reverse-related>
-            <reverse-related>Grizzly Fate</reverse-related>
+            <reverse-related count="2">Grizzly Fate</reverse-related>
             <reverse-related>Kamahl's Summons</reverse-related>
             <reverse-related>Words of Wilding</reverse-related>
         </card>
@@ -210,11 +210,11 @@
             <name>Bear </name>
             <set picURL="http://magiccards.info/extras/token/khans-of-tarkir/bear.jpg">KTK</set>
             <color>G</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Bear</type>
             <pt>4/4</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Bear's Companion</reverse-related>
         </card>
@@ -236,15 +236,15 @@
             <set picURL="http://magiccards.info/extras/token/lorwyn/beast.jpg">LRW</set>
             <set picURL="http://magiccards.info/extras/token/player-rewards-2004/beast.jpg">DST</set>
             <color>G</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Beast</type>
             <pt>3/3</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Beast Within</reverse-related>
             <reverse-related>Bringer of the Green Dawn</reverse-related>
-            <reverse-related>Feral Incarnation</reverse-related>
+            <reverse-related count="3">Feral Incarnation</reverse-related>
             <reverse-related>Fresh Meat</reverse-related>
             <reverse-related>Garruk Wildspeaker</reverse-related>
             <reverse-related>Garruk, Primal Hunter</reverse-related>
@@ -263,11 +263,11 @@
             <set picURL="http://magiccards.info/extras/token/duel-decks-garruk-vs-liliana/beast-2.jpg">DDD</set>
             <set picURL="http://magiccards.info/extras/token/player-rewards-2001/beast.jpg">ODY</set>
             <color>G</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Beast</type>
             <pt>4/4</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Baloth Cage Trap</reverse-related>
             <reverse-related>Beast Attack</reverse-related>
@@ -281,11 +281,11 @@
             <color>R</color>
             <color>G</color>
             <color>W</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Beast</type>
             <pt>8/8</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Godsire</reverse-related>
         </card>
@@ -293,11 +293,11 @@
             <name>Beast   </name>
             <set picURL="http://cdn.staticneo.com/w/mtg/c/cd/Beast5.jpg">EXO</set>
             <color>G</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Beast</type>
             <pt>2/2</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Keeper of the Beasts</reverse-related>
         </card>
@@ -305,11 +305,11 @@
             <name>Beast    </name>
             <set picURL="http://cdn.staticneo.com/w/mtg/a/a6/Beast4.jpg">MRD</set>
             <color>G</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Beast</type>
             <pt>5/5</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>One Dozen Eyes</reverse-related>
         </card>
@@ -317,7 +317,7 @@
             <name>Beast     </name>
             <set picURL="http://s17.postimg.org/63464zbtr/Beast4.png">C13</set>
             <color>G</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Beast</type>
             <pt>5/5</pt>
             <tablerow>2</tablerow>
@@ -329,7 +329,7 @@
             <name>Beast      </name>
             <set picURL="http://media.wizards.com/images/magic/daily/arcana/0005_MTGM15_TOK_EN%20copy.png">M15</set>
             <color>B</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Beast</type>
             <pt>3/3</pt>
             <tablerow>2</tablerow>
@@ -340,11 +340,11 @@
         <card>
             <name>Beast       </name>
             <set picURL="http://media.wizards.com/2016/bVvMNuiu2i_KLD/en_t4SGoWqjbW.png">KLD</set>
-            <manacost></manacost>
+            <manacost />
             <type>Token Artifact Creature — Beast</type>
             <pt>6/6</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Architect of the Untamed</reverse-related>
         </card>
@@ -353,7 +353,7 @@
             <set picURL="http://cdn.staticneo.com/w/mtg/3/37/Bird2.jpg">DIS</set>
             <color>W</color>
             <color>U</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Bird</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
@@ -369,7 +369,7 @@
             <set picURL="http://magiccards.info/extras/token/zendikar/bird.jpg">ZEN</set>
             <set picURL="http://magiccards.info/extras/token/return-to-ravnica/bird.jpg">RTR</set>
             <color>W</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Bird</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
@@ -388,7 +388,7 @@
             <set picURL="http://magiccards.info/extras/token/eventide/bird.jpg">EVE</set>
             <set picURL="http://magiccards.info/extras/token/player-rewards-2001/bird.jpg">INV</set>
             <color>U</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Bird</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
@@ -402,7 +402,7 @@
             <set picURL="http://magiccards.info/extras/token/magic-2012/bird.jpg">M12</set>
             <set picURL="http://magiccards.info/extras/token/magic-2011/bird.jpg">M11</set>
             <color>W</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Bird</type>
             <pt>3/3</pt>
             <tablerow>2</tablerow>
@@ -415,7 +415,7 @@
             <set picURL="http://media.wizards.com/2016/bn8f9t2zc_C16/x6wvejvxOl_EN.png">C16</set>
             <set picURL="http://magiccards.info/extras/token/theros/bird.jpg">THS</set>
             <color>U</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Bird</type>
             <pt>2/2</pt>
             <tablerow>2</tablerow>
@@ -427,7 +427,7 @@
             <name>Bird     </name>
             <set picURL="http://magiccards.info/extras/token/born-of-the-gods/bird-2.jpg">BNG</set>
             <color>U</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Enchantment Creature — Bird</type>
             <pt>2/2</pt>
             <tablerow>2</tablerow>
@@ -440,7 +440,7 @@
             <name>Bird      </name>
             <set picURL="http://magiccards.info/extras/token/player-rewards-2003/rukh.jpg">8ED</set>
             <color>R</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Bird</type>
             <pt>4/4</pt>
             <tablerow>2</tablerow>
@@ -452,7 +452,7 @@
             <name>Bird       </name>
             <set picURL="http://magiccards.info/extras/token/khans-of-tarkir/bird.jpg">KTK</set>
             <color>W</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Bird</type>
             <pt>3/4</pt>
             <tablerow>2</tablerow>
@@ -464,7 +464,7 @@
             <name>Bird Soldier</name>
             <set picURL="http://magiccards.info/extras/token/alara-reborn/bird-soldier.jpg">ARB</set>
             <color>W</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Bird Soldier</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
@@ -476,11 +476,11 @@
             <name>Boar</name>
             <set picURL="http://media-dominaria.cursecdn.com/attachments/102/31/635032498723573408.jpg">PC2</set>
             <color>G</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Boar</type>
             <pt>3/3</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Brindle Shoat</reverse-related>
         </card>
@@ -488,11 +488,11 @@
             <name>Boar </name>
             <set picURL="http://magiccards.info/extras/token/theros/boar.jpg">THS</set>
             <color>G</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Boar</type>
             <pt>2/2</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Curse of the Swine</reverse-related>
         </card>
@@ -500,7 +500,7 @@
             <name>Butterfly</name>
             <set picURL="http://cdn.staticneo.com/w/mtg/7/77/Butterfly.jpg">VIS</set>
             <color>G</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Insect</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
@@ -512,11 +512,11 @@
             <name>Camarid</name>
             <set picURL="http://cdn.staticneo.com/w/mtg/b/b8/Camarid.jpg">FEM</set>
             <color>U</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Camarid</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Homarid Spawning Bed</reverse-related>
         </card>
@@ -524,11 +524,11 @@
             <name>Caribou</name>
             <set picURL="http://cdn.staticneo.com/w/mtg/f/fd/Caribou.jpg">ME2</set>
             <color>W</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Caribou</type>
             <pt>0/1</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Caribou Range</reverse-related>
         </card>
@@ -536,11 +536,11 @@
             <name>Carnivore</name>
             <set picURL="http://media.wizards.com/2016/adhfianalodifdj2_EMA/en_PHBsdfmt0I.png">EMA</set>
             <color>R</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Beast</type>
             <pt>3/1</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Tooth and Claw</reverse-related>
         </card>
@@ -552,11 +552,11 @@
             <set picURL="http://magiccards.info/extras/token/magic-2013/cat.jpg">M13</set>
             <set picURL="http://magiccards.info/extras/token/scars-of-mirrodin/cat.jpg">SOM</set>
             <color>W</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Cat</type>
             <pt>2/2</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Ajani's Chosen</reverse-related>
             <reverse-related>Ajani, Caller of the Pride</reverse-related>
@@ -567,11 +567,11 @@
             <name>Cat </name>
             <set picURL="http://cdn.staticneo.com/w/mtg/0/08/Cat2.jpg">APC</set>
             <color>B</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Cat</type>
             <pt>2/1</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Penumbra Bobcat</reverse-related>
         </card>
@@ -579,11 +579,11 @@
             <name>Cat  </name>
             <set picURL="http://cdn.staticneo.com/w/mtg/d/d1/Cat.jpg">6ED</set>
             <color>G</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Cat</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Waiting in the Weeds</reverse-related>
         </card>
@@ -591,7 +591,7 @@
             <name>Cat Soldier</name>
             <set picURL="http://magiccards.info/extras/token/born-of-the-gods/cat-soldier.jpg">BNG</set>
             <color>W</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Cat Soldier</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
@@ -604,7 +604,7 @@
             <name>Cat Warrior</name>
             <set picURL="http://cdn.staticneo.com/w/mtg/2/2d/Cat_Warrior.jpg">PLC</set>
             <color>G</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Cat Warrior</type>
             <pt>2/2</pt>
             <tablerow>2</tablerow>
@@ -616,11 +616,11 @@
             <name>Centaur</name>
             <set picURL="http://magiccards.info/extras/token/return-to-ravnica/centaur-1.jpg">RTR</set>
             <color>G</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Centaur</type>
             <pt>3/3</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Alive // Well</reverse-related>
             <reverse-related>Call of the Conclave</reverse-related>
@@ -633,7 +633,7 @@
             <name>Centaur </name>
             <set picURL="http://cdn.staticneo.com/w/mtg/c/c5/Centaur.jpg">RAV</set>
             <color>G</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Centaur</type>
             <pt>3/3</pt>
             <tablerow>2</tablerow>
@@ -645,11 +645,11 @@
             <name>Centaur   </name>
             <set picURL="http://magiccards.info/extras/token/born-of-the-gods/centaur.jpg">BNG</set>
             <color>G</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Enchantment Creature — Centaur</type>
             <pt>3/3</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Fated Intervention</reverse-related>
             <reverse-related>Pheres-Band Raiders</reverse-related>
@@ -658,21 +658,21 @@
             <name>Citizen</name>
             <set picURL="http://cdn.staticneo.com/w/mtg/1/15/Citizen.jpg">6ED</set>
             <color>W</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Citizen</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
-            <reverse-related>Icatian Crier</reverse-related>
-            <reverse-related>Icatian Town</reverse-related>
+            <reverse-related count="2">Icatian Crier</reverse-related>
+            <reverse-related count="4">Icatian Town</reverse-related>
         </card>
         <card>
             <name>Cleric</name>
             <set picURL="http://magiccards.info/extras/token/gatecrash/cleric.jpg">GTC</set>
             <color>W</color>
             <color>B</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Cleric</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
@@ -684,11 +684,11 @@
             <name>Cleric </name>
             <set picURL="http://magiccards.info/extras/token/theros/cleric.jpg">THS</set>
             <color>W</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Enchantment Creature — Cleric</type>
             <pt>2/1</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Heliod, God of the Sun</reverse-related>
         </card>
@@ -696,7 +696,7 @@
             <name>Cloud Sprite (token)</name>
             <set picURL="http://cdn.staticneo.com/w/mtg/a/a7/Cloud_Sprite.jpg">FUT</set>
             <color>U</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Faerie</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
@@ -713,7 +713,7 @@ Cloud Sprite can block only creatures with flying.</text>
             <set picURL="http://media.wizards.com/2016/aksdjciawolkcc0_soi/en_V2yqkDIY0I.png">SOI</set>
             <set picURL="http://media.wizards.com/2016/aksdjciawolkcc0_soi/en_hFK9CuGyR3.png">SOI</set>
             <set picURL="http://media.wizards.com/2016/aksdjciawolkcc0_soi/en_hFK9CuGyR3.png">SOI</set>
-            <manacost></manacost>
+            <manacost />
             <type>Token Artifact — Clue</type>
             <tablerow>1</tablerow>
             <text>{2}, Sacrifice this artifact: Draw a card.</text>
@@ -746,7 +746,7 @@ Cloud Sprite can block only creatures with flying.</text>
         <card>
             <name>Construct</name>
             <set picURL="http://magiccards.info/extras/token/worldwake/construct.jpg">WWK</set>
-            <manacost></manacost>
+            <manacost />
             <type>Token Artifact Creature — Construct</type>
             <pt>6/12</pt>
             <tablerow>2</tablerow>
@@ -758,7 +758,7 @@ Cloud Sprite can block only creatures with flying.</text>
             <name>Construct </name>
             <set picURL="http://media.wizards.com/2016/azetllnwjpxztp2b_CN2/en_d3hA3fK2vj.png">CN2</set>
             <set picURL="http://magiccards.info/extras/token/conspiracy/construct.jpg">CNS</set>
-            <manacost></manacost>
+            <manacost />
             <type>Token Artifact Creature — Construct</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
@@ -772,11 +772,11 @@ Cloud Sprite can block only creatures with flying.</text>
             <name>Construct  </name>
             <set picURL="http://media.wizards.com/2016/bVvMNuiu2i_KLD/en_ROHZBBAJrp.png">KLD</set>
             <set picURL="http://media.wizards.com/2016/bVvMNuiu2i_KLD/en_fCSrpoVGcO.png">KLD</set>
-            <manacost></manacost>
+            <manacost />
             <type>Token Artifact Creature — Construct</type>
             <pt>*/*</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Metallurgic Summonings</reverse-related>
             <reverse-related>Oviya Pashiri, Sage Lifecrafter</reverse-related>
@@ -790,7 +790,7 @@ Cloud Sprite can block only creatures with flying.</text>
             <set picURL="http://magiccards.info/extras/token/innistrad/demon.jpg">ISD</set>
             <set picURL="http://magiccards.info/extra/token/player-rewards-2003/demon.jpg">MIR</set>
             <color>B</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Demon</type>
             <pt>5/5</pt>
             <tablerow>2</tablerow>
@@ -808,7 +808,7 @@ Cloud Sprite can block only creatures with flying.</text>
             <set picURL="http://magiccards.info/extras/token/duel-decks-divine-vs-demonic/demon.jpg">DDC</set>
             <set picURL="http://magiccards.info/extras/token/player-rewards-2003/demon.jpg">MIR</set>
             <color>B</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Demon</type>
             <pt>*/*</pt>
             <tablerow>2</tablerow>
@@ -821,11 +821,11 @@ Cloud Sprite can block only creatures with flying.</text>
             <name>Deserter</name>
             <set picURL="http://i1013.photobucket.com/albums/af260/lovesoldier99/DESERTERTOKEN.jpg">ME2</set>
             <color>W</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Deserter</type>
             <pt>0/1</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Kjeldoran Home Guard</reverse-related>
         </card>
@@ -833,20 +833,20 @@ Cloud Sprite can block only creatures with flying.</text>
             <name>Devil</name>
             <set picURL="http://media.wizards.com/2016/aksdjciawolkcc0_soi/en_qhIEFoclOO.png">SOI</set>
             <color>R</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Devil</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
             <text>When this creature dies, it deals 1 damage to target creature or player.</text>
             <token>1</token>
-            <reverse-related>Dance with Devils</reverse-related>
-            <reverse-related>Devils' Playground</reverse-related>
+            <reverse-related count="2">Dance with Devils</reverse-related>
+            <reverse-related count="4">Devils' Playground</reverse-related>
             <reverse-related>Make Mischief</reverse-related>
         </card>
         <card>
             <name>Djinn</name>
             <set picURL="http://cdn.staticneo.com/w/mtg/0/0a/Djinn.jpg">ME4</set>
-            <manacost></manacost>
+            <manacost />
             <type>Token Artifact Creature — Djinn</type>
             <pt>5/5</pt>
             <tablerow>2</tablerow>
@@ -858,7 +858,7 @@ Cloud Sprite can block only creatures with flying.</text>
             <name>Djinn Monk</name>
             <set picURL="http://magiccards.info/extras/token/dragons-of-tarkir/djinn-monk.jpg">DTK</set>
             <color>U</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Djinn Monk</type>
             <pt>2/2</pt>
             <tablerow>2</tablerow>
@@ -876,7 +876,7 @@ Cloud Sprite can block only creatures with flying.</text>
             <set picURL="http://magiccards.info/extras/token/tenth-edition/dragon.jpg">10E</set>
             <set picURL="http://magiccards.info/extras/token/player-rewards-2002/dragon.jpg">ONS</set>
             <color>R</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Dragon</type>
             <pt>5/5</pt>
             <tablerow>2</tablerow>
@@ -898,7 +898,7 @@ Cloud Sprite can block only creatures with flying.</text>
             <set picURL="http://magiccards.info/extras/token/modern-masters/dragon.jpg">MMA</set>
             <set picURL="http://magiccards.info/extras/token/shards-of-alara/dragon.jpg">ALA</set>
             <color>R</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Dragon</type>
             <pt>4/4</pt>
             <tablerow>2</tablerow>
@@ -915,7 +915,7 @@ Cloud Sprite can block only creatures with flying.</text>
             <set picURL="http://magiccards.info/extras/token/alara-reborn/dragon.jpg">ARB</set>
             <color>R</color>
             <color>G</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Dragon</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
@@ -927,7 +927,7 @@ Cloud Sprite can block only creatures with flying.</text>
             <name>Dragon   </name>
             <set picURL="http://magiccards.info/extras/token/return-to-ravnica/dragon.jpg">RTR</set>
             <color>R</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Dragon</type>
             <pt>6/6</pt>
             <tablerow>2</tablerow>
@@ -941,7 +941,7 @@ Cloud Sprite can block only creatures with flying.</text>
             <set picURL="http://media.wizards.com/images/magic/daily/arcana/0007_MTGM15_TOK_EN%20copy.png">M15</set>
             <set picURL="http://magiccards.info/extras/token/magic-2014/dragon.jpg">M14</set>
             <color>R</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Dragon</type>
             <pt>2/2</pt>
             <tablerow>2</tablerow>
@@ -955,7 +955,7 @@ Cloud Sprite can block only creatures with flying.</text>
             <name>Dragon Spirit</name>
             <set picURL="http://img.photobucket.com/albums/v237/Xand0r/dragon-spirit-token3_champions_300.jpg">CHK</set>
             <color>U</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Dragon Spirit</type>
             <pt>5/5</pt>
             <tablerow>2</tablerow>
@@ -968,13 +968,13 @@ Cloud Sprite can block only creatures with flying.</text>
             <set picURL="http://media.wizards.com/2015/c15_9dsm28ccakCDSk2/en_YQgzJqST41.png">C15</set>
             <set picURL="http://magiccards.info/extras/token/magic-2013/drake.jpg">M13</set>
             <color>U</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Drake</type>
             <pt>2/2</pt>
             <tablerow>2</tablerow>
             <text>Flying</text>
             <token>1</token>
-            <reverse-related>Talrand's Invocation</reverse-related>
+            <reverse-related count="2">Talrand's Invocation</reverse-related>
             <reverse-related>Talrand, Sky Summoner</reverse-related>
         </card>
         <card>
@@ -982,7 +982,7 @@ Cloud Sprite can block only creatures with flying.</text>
             <set picURL="http://i37.photobucket.com/albums/e81/FirePenguinMaster/38e6fa3f.jpg">DIS</set>
             <color>G</color>
             <color>U</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Drake</type>
             <pt>2/2</pt>
             <tablerow>2</tablerow>
@@ -993,18 +993,18 @@ Cloud Sprite can block only creatures with flying.</text>
         <card>
             <name>Eldrazi</name>
             <set picURL="http://media.wizards.com/2015/images/daily/kWadJiABeY.png">BFZ</set>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Eldrazi</type>
             <pt>10/10</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Desolation Twin</reverse-related>
         </card>
         <card>
             <name>Eldrazi </name>
             <set picURL="http://oi41.tinypic.com/2e37pmq.jpg">PC2</set>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Eldrazi</type>
             <pt>7/7</pt>
             <tablerow>2</tablerow>
@@ -1015,11 +1015,11 @@ Cloud Sprite can block only creatures with flying.</text>
         <card>
             <name>Eldrazi Horror</name>
             <set picURL="http://media.wizards.com/2016/ouhtebrpjwxcnw5_EMN/en_r0E8h7Sx7s.png">EMN</set>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Eldrazi Horror</type>
             <pt>3/2</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Desperate Sentry</reverse-related>
             <reverse-related>Emrakul's Evangel</reverse-related>
@@ -1027,7 +1027,7 @@ Cloud Sprite can block only creatures with flying.</text>
             <reverse-related>Extricator of Flesh</reverse-related>
             <reverse-related>Extricator of Sin</reverse-related>
             <reverse-related>Foul Emissary</reverse-related>
-            <reverse-related>Hanweir, the Writhing Township</reverse-related>
+            <reverse-related count="2">Hanweir, the Writhing Township</reverse-related>
             <reverse-related>Howling Chorus</reverse-related>
             <reverse-related>Otherworldly Outburst</reverse-related>
             <reverse-related>Wharf Infiltrator</reverse-related>
@@ -1043,7 +1043,7 @@ Cloud Sprite can block only creatures with flying.</text>
             <set picURL="http://media.wizards.com/2015/images/daily/jzkBRlkQ2X.png">BFZ</set>
             <set picURL="http://media.wizards.com/2015/images/daily/pAT2ZVOJYc.png">BFZ</set>
             <set picURL="http://media.wizards.com/2015/images/daily/ERZfWSN2Kh.png">BFZ</set>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Eldrazi Scion</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
@@ -1051,23 +1051,23 @@ Cloud Sprite can block only creatures with flying.</text>
             <token>1</token>
             <reverse-related>Abstruse Interference</reverse-related>
             <reverse-related>Adverse Conditions</reverse-related>
-            <reverse-related>Birthing Hulk</reverse-related>
-            <reverse-related>Blight Herder</reverse-related>
+            <reverse-related count="2">Birthing Hulk</reverse-related>
+            <reverse-related count="3">Blight Herder</reverse-related>
             <reverse-related>Blisterpod</reverse-related>
             <reverse-related>Brood Butcher</reverse-related>
-            <reverse-related>Brood Monitor</reverse-related>
-            <reverse-related>Call the Scions</reverse-related>
+            <reverse-related count="3">Brood Monitor</reverse-related>
+            <reverse-related count="2">Call the Scions</reverse-related>
             <reverse-related>Carrier Thrall</reverse-related>
             <reverse-related>Catacomb Sifter</reverse-related>
-            <reverse-related>Drowner of Hope</reverse-related>
+            <reverse-related count="2">Drowner of Hope</reverse-related>
             <reverse-related>Eldrazi Skyspawner</reverse-related>
-            <reverse-related>Eyeless Watcher</reverse-related>
+            <reverse-related count="2">Eyeless Watcher</reverse-related>
             <reverse-related>From Beyond</reverse-related>
             <reverse-related>Grave Birthing</reverse-related>
             <reverse-related>Incubator Drone</reverse-related>
             <reverse-related>Scion Summoner</reverse-related>
             <reverse-related>Sifter of Skulls</reverse-related>
-            <reverse-related>Spawning Bed</reverse-related>
+            <reverse-related count="3">Spawning Bed</reverse-related>
             <reverse-related>Vile Redeemer</reverse-related>
             <reverse-related>Void Attendant</reverse-related>
             <reverse-related>Warping Wail</reverse-related>
@@ -1080,40 +1080,40 @@ Cloud Sprite can block only creatures with flying.</text>
             <set picURL="http://magiccards.info/extras/token/rise-of-the-eldrazi/eldrazi-spawn-1.jpg">ROE</set>
             <set picURL="http://magiccards.info/extras/token/rise-of-the-eldrazi/eldrazi-spawn-2.jpg">ROE</set>
             <set picURL="http://magiccards.info/extras/token/rise-of-the-eldrazi/eldrazi-spawn-3.jpg">ROE</set>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Eldrazi Spawn</type>
             <pt>0/1</pt>
             <tablerow>2</tablerow>
             <text>Sacrifice this creature: Add {C} to your mana pool.</text>
             <token>1</token>
             <reverse-related>Awakening Zone</reverse-related>
-            <reverse-related>Brood Birthing</reverse-related>
-            <reverse-related>Corpsehatch</reverse-related>
-            <reverse-related>Dread Drone</reverse-related>
-            <reverse-related>Emrakul's Hatcher</reverse-related>
-            <reverse-related>Essence Feed</reverse-related>
+            <reverse-related count="3">Brood Birthing</reverse-related>
+            <reverse-related count="2">Corpsehatch</reverse-related>
+            <reverse-related count="2">Dread Drone</reverse-related>
+            <reverse-related count="3">Emrakul's Hatcher</reverse-related>
+            <reverse-related count="3">Essence Feed</reverse-related>
             <reverse-related>Growth Spasm</reverse-related>
-            <reverse-related>Kozilek's Predator</reverse-related>
+            <reverse-related count="2">Kozilek's Predator</reverse-related>
             <reverse-related>Nest Invader</reverse-related>
             <reverse-related>Pawn of Ulamog</reverse-related>
             <reverse-related>Rapacious One</reverse-related>
-            <reverse-related>Skittering Invasion</reverse-related>
+            <reverse-related count="5">Skittering Invasion</reverse-related>
             <reverse-related>Spawning Breath</reverse-related>
-            <reverse-related>Spawnsire of Ulamog</reverse-related>
+            <reverse-related count="2">Spawnsire of Ulamog</reverse-related>
         </card>
         <card>
             <name>Elemental</name>
             <set picURL="http://media.wizards.com/2016/adhfianalodifdj2_EMA/en_43rUaKSbgs.png">EMA</set>
             <set picURL="http://magiccards.info/extras/token/magic-2014/elemental-1.jpg">M14</set>
             <color>R</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Elemental</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Elemental Mastery</reverse-related>
-            <reverse-related>Molten Birth</reverse-related>
+            <reverse-related count="2">Molten Birth</reverse-related>
             <reverse-related>Tempt with Vengeance</reverse-related>
             <reverse-related>Young Pyromancer</reverse-related>
         </card>
@@ -1122,11 +1122,11 @@ Cloud Sprite can block only creatures with flying.</text>
             <set picURL="http://media.wizards.com/2015/ogw_239nCi30ks3/en_lrSfRX41Ri.png">OGW</set>
             <set picURL="http://magiccards.info/extras/token/conflux/elemental.jpg">DIS</set>
             <color>R</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Elemental</type>
             <pt>3/1</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Chandra, Flamecaller</reverse-related>
             <reverse-related>Feral Lightning</reverse-related>
@@ -1138,11 +1138,11 @@ Cloud Sprite can block only creatures with flying.</text>
             <name>Elemental    </name>
             <set picURL="http://magiccards.info/extras/token/rise-of-the-eldrazi/elemental.jpg">ROE</set>
             <color>R</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Elemental</type>
             <pt>*/*</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Devastating Summons</reverse-related>
         </card>
@@ -1150,7 +1150,7 @@ Cloud Sprite can block only creatures with flying.</text>
             <name>Elemental     </name>
             <set picURL="http://magiccards.info/extras/token/zendikar/elemental.jpg">ZEN</set>
             <color>R</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Elemental</type>
             <pt>7/1</pt>
             <tablerow>2</tablerow>
@@ -1163,11 +1163,11 @@ Cloud Sprite can block only creatures with flying.</text>
             <name>Elemental      </name>
             <set picURL="http://cdn.staticneo.com/w/mtg/0/0a/Elemental8.jpg">DST</set>
             <color>R</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Elemental</type>
             <pt>3/3</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Wand of the Elements</reverse-related>
         </card>
@@ -1176,11 +1176,11 @@ Cloud Sprite can block only creatures with flying.</text>
             <set picURL="http://magiccards.info/extras/token/modern-masters/elemental.jpg">MMA</set>
             <set picURL="http://magiccards.info/extras/token/lorwyn/elemental-1.jpg">LRW</set>
             <color>G</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Elemental</type>
             <pt>4/4</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Eyes of the Wisent</reverse-related>
             <reverse-related>Walker of the Grove</reverse-related>
@@ -1189,11 +1189,11 @@ Cloud Sprite can block only creatures with flying.</text>
             <name>Elemental        </name>
             <set picURL="http://media.wizards.com/2015/ogw_239nCi30ks3/en_P1vyxE48Sl.png">OGW</set>
             <color>G</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Elemental</type>
             <pt>*/*</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Dokai, Weaver of Life</reverse-related>
             <reverse-related>Marath, Will of the Wild</reverse-related>
@@ -1203,7 +1203,7 @@ Cloud Sprite can block only creatures with flying.</text>
             <name>Elemental         </name>
             <set picURL="http://magiccards.info/extras/token/duel-decks-elves-vs-goblins/elemental.jpg">EVG</set>
             <color>G</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Elemental</type>
             <pt>7/7</pt>
             <tablerow>2</tablerow>
@@ -1216,7 +1216,7 @@ Cloud Sprite can block only creatures with flying.</text>
             <set picURL="http://media.wizards.com/2016/bn8f9t2zc_C16/hLbATbkzqS_EN.png">C16</set>
             <set picURL="http://magiccards.info/extras/token/lorwyn/elemental-2.jpg">LRW</set>
             <color>W</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Elemental</type>
             <pt>4/4</pt>
             <tablerow>2</tablerow>
@@ -1228,7 +1228,7 @@ Cloud Sprite can block only creatures with flying.</text>
             <name>Elemental           </name>
             <set picURL="http://cdn.staticneo.com/w/mtg/8/89/Elemental7.jpg">DST</set>
             <color>U</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Elemental</type>
             <pt>2/2</pt>
             <tablerow>2</tablerow>
@@ -1241,11 +1241,11 @@ Cloud Sprite can block only creatures with flying.</text>
             <set picURL="http://magiccards.info/extras/token/shadowmoor/elemental-2.jpg">SHM</set>
             <color>B</color>
             <color>R</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Elemental</type>
             <pt>5/5</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Din of the Fireherd</reverse-related>
         </card>
@@ -1256,7 +1256,7 @@ Cloud Sprite can block only creatures with flying.</text>
             <set picURL="http://magiccards.info/extras/token/eventide/elemental.jpg">EVE</set>
             <color>U</color>
             <color>R</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Elemental</type>
             <pt>5/5</pt>
             <tablerow>2</tablerow>
@@ -1269,7 +1269,7 @@ Cloud Sprite can block only creatures with flying.</text>
             <set picURL="http://magiccards.info/extras/token/return-to-ravnica/elemental.jpg">RTR</set>
             <color>G</color>
             <color>W</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Elemental</type>
             <pt>8/8</pt>
             <tablerow>2</tablerow>
@@ -1282,7 +1282,7 @@ Cloud Sprite can block only creatures with flying.</text>
             <set picURL="http://magiccards.info/extras/token/dragons-maze/elemental.jpg">DGM</set>
             <color>G</color>
             <color>W</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Elemental</type>
             <pt>*/*</pt>
             <tablerow>2</tablerow>
@@ -1294,11 +1294,11 @@ Cloud Sprite can block only creatures with flying.</text>
             <name>Elemental                </name>
             <set picURL="http://magiccards.info/extras/token/theros/elemental.jpg">THS</set>
             <color>U</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Elemental</type>
             <pt>1/0</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Master of Waves</reverse-related>
         </card>
@@ -1306,11 +1306,11 @@ Cloud Sprite can block only creatures with flying.</text>
             <name>Elemental                 </name>
             <set picURL="http://magiccards.info/extras/token/born-of-the-gods/elemental.jpg">BNG</set>
             <color>R</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Enchantment Creature — Elemental</type>
             <pt>3/1</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Satyr Nyx-Smith</reverse-related>
         </card>
@@ -1318,11 +1318,11 @@ Cloud Sprite can block only creatures with flying.</text>
             <name>Elemental                  </name>
             <set picURL="http://magiccards.info/extras/token/commander-2014/elemental.jpg">C14</set>
             <color>G</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Elemental</type>
             <pt>5/3</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Titania, Protector of Argoth</reverse-related>
         </card>
@@ -1330,11 +1330,11 @@ Cloud Sprite can block only creatures with flying.</text>
             <name>Elemental                   </name>
             <set picURL="http://media.wizards.com/2015/images/daily/en_jvbnzml9rt.png">ORI</set>
             <color>G</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Elemental</type>
             <pt>2/2</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Zendikar's Roil</reverse-related>
         </card>
@@ -1342,7 +1342,7 @@ Cloud Sprite can block only creatures with flying.</text>
             <name>Elemental                     </name>
             <set picURL="http://media.wizards.com/2015/images/daily/mam91uW2Ld.png">BFZ</set>
             <color>R</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Elemental</type>
             <pt>3/1</pt>
             <tablerow>2</tablerow>
@@ -1355,11 +1355,11 @@ Cloud Sprite can block only creatures with flying.</text>
             <set picURL="http://media.wizards.com/2015/images/daily/es6ELrarbB.png">BFZ</set>
             <color>R</color>
             <color>G</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Elemental</type>
             <pt>5/5</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Omnath, Locus of Rage</reverse-related>
         </card>
@@ -1367,11 +1367,11 @@ Cloud Sprite can block only creatures with flying.</text>
             <name>Elemental                       </name>
             <set>ARC</set>
             <color>G</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Elemental</type>
             <pt>3/3</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Evil Comes to Fruition</reverse-related>
         </card>
@@ -1379,11 +1379,11 @@ Cloud Sprite can block only creatures with flying.</text>
             <name>Elemental Cat</name>
             <set picURL="http://cdn.staticneo.com/w/mtg/4/42/Elemental_Cat.jpg">JUD</set>
             <color>R</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Elemental Cat</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Firecat Blitz</reverse-related>
         </card>
@@ -1393,13 +1393,13 @@ Cloud Sprite can block only creatures with flying.</text>
             <set picURL="http://magiccards.info/extras/token/duel-decks-jace-vs-chandra/elemental-shaman.jpg">DD2</set>
             <set picURL="http://magiccards.info/extras/token/lorwyn/elemental-shaman.jpg">LRW</set>
             <color>R</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Elemental Shaman</type>
             <pt>3/1</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
-            <reverse-related>Hearthcage Giant</reverse-related>
+            <reverse-related count="2">Hearthcage Giant</reverse-related>
             <reverse-related>Hostility</reverse-related>
             <reverse-related>Rebellion of the Flamekin</reverse-related>
         </card>
@@ -1415,11 +1415,11 @@ Cloud Sprite can block only creatures with flying.</text>
             <set picURL="http://magiccards.info/extras/token/player-rewards-2001/elephant.jpg">INV</set>
             <set picURL="http://magiccards.info/extras/token/player-rewards-2002/elephant.jpg">ODY</set>
             <color>G</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Elephant</type>
             <pt>3/3</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Assault // Battery</reverse-related>
             <reverse-related>Bestial Menace</reverse-related>
@@ -1427,7 +1427,7 @@ Cloud Sprite can block only creatures with flying.</text>
             <reverse-related>Elephant Ambush</reverse-related>
             <reverse-related>Elephant Guide</reverse-related>
             <reverse-related>Elephant Resurgence</reverse-related>
-            <reverse-related>Kazandu Tuskcaller</reverse-related>
+            <reverse-related count="2">Kazandu Tuskcaller</reverse-related>
             <reverse-related>Selvala's Charge</reverse-related>
             <reverse-related>Terastodon</reverse-related>
         </card>
@@ -1435,7 +1435,7 @@ Cloud Sprite can block only creatures with flying.</text>
             <name>Elf Druid</name>
             <set picURL="http://magiccards.info/extras/token/commander-2014/elf-druid.jpg">C14</set>
             <color>G</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Elf Druid</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
@@ -1453,18 +1453,18 @@ Cloud Sprite can block only creatures with flying.</text>
             <set picURL="http://magiccards.info/extras/token/duel-decks-elves-vs-goblins/elf-warrior.jpg">EVG</set>
             <set picURL="http://magiccards.info/extras/token/lorwyn/elf-warrior.jpg">LRW</set>
             <color>G</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Elf Warrior</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Ambassador Oak</reverse-related>
             <reverse-related>Dwynen's Elite</reverse-related>
             <reverse-related>Elvish Promenade</reverse-related>
             <reverse-related>Flourishing Defenses</reverse-related>
-            <reverse-related>Gilt-Leaf Ambush</reverse-related>
-            <reverse-related>Hunting Triad</reverse-related>
+            <reverse-related count="2">Gilt-Leaf Ambush</reverse-related>
+            <reverse-related count="3">Hunting Triad</reverse-related>
             <reverse-related>Imperious Perfect</reverse-related>
             <reverse-related>Lys Alana Huntmaster</reverse-related>
             <reverse-related>Nath of the Gilt-Leaf</reverse-related>
@@ -1477,11 +1477,11 @@ Cloud Sprite can block only creatures with flying.</text>
             <set picURL="http://magiccards.info/extras/token/shadowmoor/elf-warrior-2.jpg">SHM</set>
             <color>G</color>
             <color>W</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Elf Warrior</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Mercy Killing</reverse-related>
             <reverse-related>Rhys the Redeemed</reverse-related>
@@ -1489,7 +1489,7 @@ Cloud Sprite can block only creatures with flying.</text>
         <card>
             <name>Etherium Cell</name>
             <set picURL="http://media.wizards.com/2016/c1lRLirbrl_AER/en_jFEx2smDi8.png">AER</set>
-            <manacost></manacost>
+            <manacost />
             <type>Token Artifact</type>
             <tablerow>1</tablerow>
             <text>{T}, Sacrifice this artifact: Add one mana of any color to your mana pool.</text>
@@ -1500,7 +1500,7 @@ Cloud Sprite can block only creatures with flying.</text>
             <name>Faerie</name>
             <set picURL="http://cdn.staticneo.com/w/mtg/e/e8/Faerie.jpg">RAV</set>
             <color>U</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Faerie</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
@@ -1513,7 +1513,7 @@ Cloud Sprite can block only creatures with flying.</text>
             <set picURL="http://media.wizards.com/2015/mm2_9vgauji43t9a/en_6IOrNA1GbG.png">MM2</set>
             <set picURL="http://magiccards.info/extras/token/morningtide/faerie-rogue.jpg">MOR</set>
             <color>B</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Faerie Rogue</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
@@ -1529,7 +1529,7 @@ Cloud Sprite can block only creatures with flying.</text>
             <set picURL="http://magiccards.info/extras/token/shadowmoor/faerie-rogue.jpg">SHM</set>
             <color>U</color>
             <color>B</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Faerie Rogue</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
@@ -1541,7 +1541,7 @@ Cloud Sprite can block only creatures with flying.</text>
             <name>Festering Goblin (token)</name>
             <set picURL="http://cdn.staticneo.com/w/mtg/2/24/Festering_Goblin.jpg">FUT</set>
             <color>B</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Zombie Goblin</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
@@ -1553,7 +1553,7 @@ Cloud Sprite can block only creatures with flying.</text>
             <name>Fish</name>
             <set picURL="http://magiccards.info/extras/token/commander-2014/fish.jpg">C14</set>
             <color>U</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Fish</type>
             <pt>3/3</pt>
             <tablerow>2</tablerow>
@@ -1567,11 +1567,11 @@ Cloud Sprite can block only creatures with flying.</text>
             <set picURL="http://media.wizards.com/2015/c15_9dsm28ccakCDSk2/en_ezDepR29P8.png">C15</set>
             <set picURL="http://magiccards.info/extras/token/gatecrash/frog-lizard.jpg">GTC</set>
             <color>G</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Frog Lizard</type>
             <pt>3/3</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Rapid Hybridization</reverse-related>
         </card>
@@ -1579,7 +1579,7 @@ Cloud Sprite can block only creatures with flying.</text>
             <name>Gargoyle</name>
             <set picURL="http://magiccards.info/extras/token/commander-2014/gargoyle.jpg">C14</set>
             <set picURL="http://magiccards.info/extras/token/magic-2010/gargoyle.jpg">M10</set>
-            <manacost></manacost>
+            <manacost />
             <type>Token Artifact Creature — Gargoyle</type>
             <pt>3/4</pt>
             <tablerow>2</tablerow>
@@ -1595,11 +1595,11 @@ Cloud Sprite can block only creatures with flying.</text>
             <set picURL="http://magiccards.info/extras/token/commander-2014/germ.jpg">C14</set>
             <set picURL="http://magiccards.info/extras/token/mirrodin-besieged/germ.jpg">MBS</set>
             <color>B</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Germ</type>
             <pt>0/0</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Batterskull</reverse-related>
             <reverse-related>Bonehoard</reverse-related>
@@ -1617,11 +1617,11 @@ Cloud Sprite can block only creatures with flying.</text>
             <name>Giant</name>
             <set picURL="http://cdn.staticneo.com/w/mtg/4/4c/Giant.jpg">FUT</set>
             <color>R</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Giant</type>
             <pt>4/4</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Pact of the Titan</reverse-related>
         </card>
@@ -1630,11 +1630,11 @@ Cloud Sprite can block only creatures with flying.</text>
             <set picURL="http://magiccards.info/extras/token/morningtide/giant-warrior.jpg">MOR</set>
             <set picURL="http://magiccards.info/extras/token/modern-masters/giant-warrior.jpg">MMA</set>
             <color>W</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Giant Warrior</type>
             <pt>5/5</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Feudkiller's Verdict</reverse-related>
         </card>
@@ -1643,7 +1643,7 @@ Cloud Sprite can block only creatures with flying.</text>
             <set picURL="http://magiccards.info/extras/token/shadowmoor/giant-warrior.jpg">SHM</set>
             <color>R</color>
             <color>G</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Giant Warrior</type>
             <pt>4/4</pt>
             <tablerow>2</tablerow>
@@ -1654,13 +1654,13 @@ Cloud Sprite can block only creatures with flying.</text>
         <card>
             <name>Gnome</name>
             <set picURL="http://cdn.staticneo.com/w/mtg/1/12/Gnome.jpg">USG</set>
-            <manacost></manacost>
+            <manacost />
             <type>Token Artifact Creature — Gnome</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
-            <reverse-related>Metrognome</reverse-related>
+            <reverse-related count="4">Metrognome</reverse-related>
         </card>
         <card>
             <name>Goat</name>
@@ -1670,11 +1670,11 @@ Cloud Sprite can block only creatures with flying.</text>
             <set picURL="http://magiccards.info/extras/token/magic-2013/goat.jpg">M13</set>
             <set picURL="http://magiccards.info/extras/token/eventide/goat.jpg">EVE</set>
             <color>W</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Goat</type>
             <pt>0/1</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Goldmeadow</reverse-related>
             <reverse-related>Springjack Pasture</reverse-related>
@@ -1701,37 +1701,37 @@ Cloud Sprite can block only creatures with flying.</text>
             <set picURL="http://magiccards.info/extras/token/return-to-ravnica/goblin.jpg">RTR</set>
             <set picURL="http://magiccards.info/extras/token/player-rewards-2003/goblin.jpg">LGN</set>
             <color>R</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Goblin</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
-            <reverse-related>Beetleback Chief</reverse-related>
+            <reverse-related count="2">Beetleback Chief</reverse-related>
             <reverse-related>Chancellor of the Forge</reverse-related>
-            <reverse-related>Dragon Fodder</reverse-related>
-            <reverse-related>Empty the Warrens</reverse-related>
+            <reverse-related count="2">Dragon Fodder</reverse-related>
+            <reverse-related count="2">Empty the Warrens</reverse-related>
             <reverse-related>Goblin Assault</reverse-related>
-            <reverse-related>Goblin Marshal</reverse-related>
+            <reverse-related count="2">Goblin Marshal</reverse-related>
             <reverse-related>Goblin Offensive</reverse-related>
             <reverse-related>Goblin Rabblemaster</reverse-related>
-            <reverse-related>Goblin Rally</reverse-related>
-            <reverse-related>Goblin Warrens</reverse-related>
+            <reverse-related count="4">Goblin Rally</reverse-related>
+            <reverse-related count="3">Goblin Warrens</reverse-related>
             <reverse-related>Goblinslide</reverse-related>
-            <reverse-related>Hordeling Outburst</reverse-related>
+            <reverse-related count="3">Hordeling Outburst</reverse-related>
             <reverse-related>Hunted Phantasm</reverse-related>
-            <reverse-related>Ib Halfheart, Goblin Tactician</reverse-related>
-            <reverse-related>Jund</reverse-related>
-            <reverse-related>Kathari Bomber</reverse-related>
-            <reverse-related>Krenko's Command</reverse-related>
+            <reverse-related count="2">Ib Halfheart, Goblin Tactician</reverse-related>
+            <reverse-related count="2">Jund</reverse-related>
+            <reverse-related count="2">Kathari Bomber</reverse-related>
+            <reverse-related count="2">Krenko's Command</reverse-related>
             <reverse-related>Krenko, Mob Boss</reverse-related>
-            <reverse-related>Kuldotha Rebirth</reverse-related>
+            <reverse-related count="3">Kuldotha Rebirth</reverse-related>
             <reverse-related>Mardu Ascendancy</reverse-related>
-            <reverse-related>Mogg Alarm</reverse-related>
+            <reverse-related count="2">Mogg Alarm</reverse-related>
             <reverse-related>Mogg Infestation</reverse-related>
             <reverse-related>Mogg War Marshal</reverse-related>
-            <reverse-related>Ponyback Brigade</reverse-related>
-            <reverse-related>Siege-Gang Commander</reverse-related>
+            <reverse-related count="3">Ponyback Brigade</reverse-related>
+            <reverse-related count="3">Siege-Gang Commander</reverse-related>
             <reverse-related>Survey the Wreckage</reverse-related>
             <reverse-related>Warbreak Trumpeter</reverse-related>
         </card>
@@ -1739,7 +1739,7 @@ Cloud Sprite can block only creatures with flying.</text>
             <name>Goblin </name>
             <set picURL="http://media.wizards.com/2016/azetllnwjpxztp2b_CN2/en_d4N21UwrYX.png">CN2</set>
             <color>R</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Goblin</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
@@ -1751,7 +1751,7 @@ Cloud Sprite can block only creatures with flying.</text>
             <name>Goblin  </name>
             <set picURL="http://cdn.staticneo.com/w/mtg/8/80/Goblin4.jpg">DIS</set>
             <color>R</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Goblin</type>
             <pt>2/1</pt>
             <tablerow>2</tablerow>
@@ -1763,7 +1763,7 @@ Cloud Sprite can block only creatures with flying.</text>
             <name>Goblin   </name>
             <set picURL="http://media.wizards.com/2016/bn8f9t2zc_C16/nW8u7HgucU_EN.png">C16</set>
             <color>R</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Goblin</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
@@ -1776,28 +1776,28 @@ Cloud Sprite can block only creatures with flying.</text>
             <set picURL="http://magiccards.info/extras/token/modern-masters/goblin-rogue.jpg">MMA</set>
             <set picURL="http://magiccards.info/extras/token/lorwyn/goblin-rogue.jpg">LRW</set>
             <color>B</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Goblin Rogue</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Boggart Mob</reverse-related>
-            <reverse-related>Marsh Flitter</reverse-related>
+            <reverse-related count="2">Marsh Flitter</reverse-related>
             <reverse-related>Warren Weirding</reverse-related>
-            <reverse-related>Weirding Shaman</reverse-related>
+            <reverse-related count="2">Weirding Shaman</reverse-related>
         </card>
         <card>
             <name>Goblin Scout</name>
             <set picURL="http://cdn.staticneo.com/w/mtg/b/bd/Goblin_Scout.jpg">MIR</set>
             <color>R</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Goblin Scout</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
             <text>Mountainwalk</text>
             <token>1</token>
-            <reverse-related>Goblin Scouts</reverse-related>
+            <reverse-related count="3">Goblin Scouts</reverse-related>
         </card>
         <card>
             <name>Goblin Soldier</name>
@@ -1806,13 +1806,13 @@ Cloud Sprite can block only creatures with flying.</text>
             <set picURL="http://magiccards.info/extras/token/player-rewards-2001/goblin-soldier.jpg">APC</set>
             <color>R</color>
             <color>W</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Goblin Soldier</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
-            <reverse-related>Goblin Trenches</reverse-related>
+            <reverse-related count="2">Goblin Trenches</reverse-related>
             <reverse-related>Rise of the Hobgoblins</reverse-related>
         </card>
         <card>
@@ -1820,19 +1820,19 @@ Cloud Sprite can block only creatures with flying.</text>
             <set picURL="http://magiccards.info/extras/token/shadowmoor/goblin-warrior.jpg">SHM</set>
             <color>R</color>
             <color>G</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Goblin Warrior</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
-            <reverse-related>Wort, the Raidmother</reverse-related>
+            <reverse-related count="2">Wort, the Raidmother</reverse-related>
         </card>
         <card>
             <name>Gold</name>
             <set picURL="http://media.wizards.com/2015/c15_9dsm28ccakCDSk2/en_tqOTRxQqlD.png">C15</set>
             <set picURL="http://magiccards.info/extras/token/born-of-the-gods/gold.jpg">BNG</set>
-            <manacost></manacost>
+            <manacost />
             <type>Token Artifact</type>
             <tablerow>1</tablerow>
             <text>Sacrifice this artifact: Add one mana of any color to your mana pool.</text>
@@ -1844,7 +1844,7 @@ Cloud Sprite can block only creatures with flying.</text>
             <name>Goldmeadow Harrier (token)</name>
             <set picURL="http://cdn.staticneo.com/w/mtg/0/0c/Goldmeadow_Harrier.jpg">FUT</set>
             <color>W</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Kithkin Soldier</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
@@ -1857,18 +1857,18 @@ Cloud Sprite can block only creatures with flying.</text>
             <set picURL="http://media.wizards.com/2015/mm2_9vgauji43t9a/en_FFbEKgocU5.png">MM2</set>
             <set picURL="http://magiccards.info/extras/token/new-phyrexia/golem.jpg">NPH</set>
             <set picURL="http://magiccards.info/extras/token/scars-of-mirrodin/golem.jpg">SOM</set>
-            <manacost></manacost>
+            <manacost />
             <type>Token Artifact Creature — Golem</type>
             <pt>3/3</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Blade Splicer</reverse-related>
             <reverse-related>Conversion Chamber</reverse-related>
             <reverse-related>Golem Foundry</reverse-related>
             <reverse-related>Master Splicer</reverse-related>
-            <reverse-related>Maul Splicer</reverse-related>
-            <reverse-related>Precursor Golem</reverse-related>
+            <reverse-related count="2">Maul Splicer</reverse-related>
+            <reverse-related count="2">Precursor Golem</reverse-related>
             <reverse-related>Sensor Splicer</reverse-related>
             <reverse-related>Vital Splicer</reverse-related>
             <reverse-related>Wing Splicer</reverse-related>
@@ -1876,33 +1876,33 @@ Cloud Sprite can block only creatures with flying.</text>
         <card>
             <name>Golem </name>
             <set picURL="http://magiccards.info/extras/token/mirrodin-besieged/golem.jpg">MBS</set>
-            <manacost></manacost>
+            <manacost />
             <type>Token Artifact Creature — Golem</type>
             <pt>9/9</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Titan Forge</reverse-related>
         </card>
         <card>
             <name>Golem  </name>
             <set>ARC</set>
-            <manacost></manacost>
+            <manacost />
             <type>Token Artifact Creature — Golem</type>
             <pt>4/6</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>The Iron Guardian Stirs</reverse-related>
         </card>
         <card>
             <name>Golem    </name>
             <set picURL="http://magiccards.info/extras/token/theros/golem.jpg">THS</set>
-            <manacost></manacost>
+            <manacost />
             <type>Token Enchantment Artifact Creature — Golem</type>
             <pt>3/3</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Hammer of Purphoros</reverse-related>
         </card>
@@ -1911,7 +1911,7 @@ Cloud Sprite can block only creatures with flying.</text>
             <set picURL="http://i167.photobucket.com/albums/u148/Ruja/Magic%20Tokens/Coldsnap/5.jpg">CSP</set>
             <color>B</color>
             <color>R</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Graveborn</type>
             <pt>3/1</pt>
             <tablerow>2</tablerow>
@@ -1924,11 +1924,11 @@ Cloud Sprite can block only creatures with flying.</text>
             <name>Gremlin</name>
             <set picURL="http://media.wizards.com/2016/c1lRLirbrl_AER/en_EBAuYV3Zn3.png">AER</set>
             <color>R</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Gremlin</type>
             <pt>2/2</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Gremlin Infestation</reverse-related>
             <reverse-related>Release the Gremlins</reverse-related>
@@ -1938,7 +1938,7 @@ Cloud Sprite can block only creatures with flying.</text>
             <set picURL="http://magiccards.info/extras/token/duel-decks-ajani-vs-nicol-bolas/griffin.jpg">DDH</set>
             <set picURL="http://magiccards.info/extras/token/duel-decks-heroes-vs-monsters/griffin.jpg">DDL</set>
             <color>W</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Griffin</type>
             <pt>2/2</pt>
             <tablerow>2</tablerow>
@@ -1950,7 +1950,7 @@ Cloud Sprite can block only creatures with flying.</text>
             <name>Harpy</name>
             <set picURL="http://magiccards.info/extras/token/theros/harpy.jpg">THS</set>
             <color>B</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Harpy</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
@@ -1963,11 +1963,11 @@ Cloud Sprite can block only creatures with flying.</text>
             <set picURL="http://magiccards.info/extras/token/rise-of-the-eldrazi/hellion.jpg">ROE</set>
             <set picURL="http://magiccards.info/extras/token/magic-2013/hellion.jpg">M13</set>
             <color>R</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Hellion</type>
             <pt>4/4</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Hellion Crucible</reverse-related>
             <reverse-related>Hellion Eruption</reverse-related>
@@ -1976,11 +1976,11 @@ Cloud Sprite can block only creatures with flying.</text>
             <name>Hippo</name>
             <set picURL="http://img.photobucket.com/albums/v18/qtinator/Hippo.jpg">ALL</set>
             <color>G</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Hippo</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Phelddagrif</reverse-related>
             <reverse-related>Questing Phelddagrif</reverse-related>
@@ -1989,11 +1989,11 @@ Cloud Sprite can block only creatures with flying.</text>
             <name>Homunculus</name>
             <set picURL="http://magiccards.info/extras/token/innistrad/homunculus.jpg">ISD</set>
             <color>U</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Homunculus</type>
             <pt>2/2</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Stitcher's Apprentice</reverse-related>
         </card>
@@ -2001,18 +2001,18 @@ Cloud Sprite can block only creatures with flying.</text>
             <name>Homunculus </name>
             <set picURL="http://magiccards.info/extras/token/shards-of-alara/homunculus.jpg">ALA</set>
             <color>U</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Artifact Creature — Homunculus</type>
             <pt>0/1</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Puppet Conjurer</reverse-related>
         </card>
         <card>
             <name>Hornet</name>
             <set picURL="http://magiccards.info/extras/token/duel-decks-phyrexia-vs-the-coalition/hornet.jpg">DDE</set>
-            <manacost></manacost>
+            <manacost />
             <type>Token Artifact Creature — Insect</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
@@ -2024,11 +2024,11 @@ Cloud Sprite can block only creatures with flying.</text>
             <name>Horror</name>
             <set picURL="http://media.wizards.com/2016/bn8f9t2zc_C16/FcpMah0evd_EN.png">C16</set>
             <set picURL="http://magiccards.info/extras/token/mirrodin-besieged/horror.jpg">MBS</set>
-            <manacost></manacost>
+            <manacost />
             <type>Token Artifact Creature — Horror</type>
             <pt>*/*</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Phyrexian Rebirth</reverse-related>
         </card>
@@ -2037,7 +2037,7 @@ Cloud Sprite can block only creatures with flying.</text>
             <set picURL="http://magiccards.info/extras/token/gatecrash/horror.jpg">GTC</set>
             <color>U</color>
             <color>B</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Horror</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
@@ -2049,11 +2049,11 @@ Cloud Sprite can block only creatures with flying.</text>
             <name>Horror  </name>
             <set picURL="http://cdn.staticneo.com/w/mtg/e/e6/Horror2.jpg">RAV</set>
             <color>B</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Horror</type>
             <pt>4/4</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Hunted Lammasu</reverse-related>
         </card>
@@ -2061,11 +2061,11 @@ Cloud Sprite can block only creatures with flying.</text>
             <name>Horror   </name>
             <set picURL="http://magiccards.info/extras/token/commander-2014/horror.jpg">C14</set>
             <color>B</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Horror</type>
             <pt>*/*</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Flesh Carver</reverse-related>
             <reverse-related>Spoils of Blood</reverse-related>
@@ -2074,13 +2074,13 @@ Cloud Sprite can block only creatures with flying.</text>
             <name>Hound</name>
             <set picURL="http://cdn.staticneo.com/w/mtg/c/cd/Hound.jpg">TMP</set>
             <color>G</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Hound</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
-            <reverse-related>Mongrel Pack</reverse-related>
+            <reverse-related count="4">Mongrel Pack</reverse-related>
         </card>
         <card>
             <name>Human</name>
@@ -2088,15 +2088,15 @@ Cloud Sprite can block only creatures with flying.</text>
             <set picURL="http://magiccards.info/extras/token/friday-night-magic/human.jpg">pFNM</set>
             <set picURL="http://magiccards.info/extras/token/dark-ascension/human.jpg">DKA</set>
             <color>W</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Human</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Commander's Authority</reverse-related>
-            <reverse-related>Gather the Townsfolk</reverse-related>
-            <reverse-related>Increasing Devotion</reverse-related>
+            <reverse-related count="2">Gather the Townsfolk</reverse-related>
+            <reverse-related count="5">Increasing Devotion</reverse-related>
             <reverse-related>Thraben Doomsayer</reverse-related>
             <reverse-related>Voice of the Provinces</reverse-related>
         </card>
@@ -2105,7 +2105,7 @@ Cloud Sprite can block only creatures with flying.</text>
             <set picURL="http://media.wizards.com/2016/ouhtebrpjwxcnw5_EMN/en_nQw4fq2DYT.png">EMN</set>
             <set picURL="http://magiccards.info/extras/token/avacyn-restored/human-2.jpg">AVR</set>
             <color>R</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Human</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
@@ -2118,11 +2118,11 @@ Cloud Sprite can block only creatures with flying.</text>
             <set picURL="http://media.wizards.com/2016/aksdjciawolkcc0_soi/en_9BXzi51Vmy.png">SOI</set>
             <color>W</color>
             <color>B</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Human Cleric</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Westvale Abbey</reverse-related>
             <reverse-related>Westvale Cult Leader</reverse-related>
@@ -2131,11 +2131,11 @@ Cloud Sprite can block only creatures with flying.</text>
             <name>Human Soldier</name>
             <set picURL="http://media.wizards.com/2016/aksdjciawolkcc0_soi/en_fPCM1CDouX.png">SOI</set>
             <color>W</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Human Soldier</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Sigarda, Heron's Grace</reverse-related>
             <reverse-related>Strength of Arms</reverse-related>
@@ -2146,11 +2146,11 @@ Cloud Sprite can block only creatures with flying.</text>
             <name>Human Wizard</name>
             <set picURL="http://media.wizards.com/2016/ouhtebrpjwxcnw5_EMN/en_E3kNrs8HWP.png">EMN</set>
             <color>U</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Human Wizard</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Docent of Perfection</reverse-related>
             <reverse-related>Final Iteration</reverse-related>
@@ -2159,11 +2159,11 @@ Cloud Sprite can block only creatures with flying.</text>
             <name>Hydra</name>
             <set picURL="http://magiccards.info/extras/token/journey-into-nyx/hydra.jpg">JOU</set>
             <color>G</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Hydra</type>
             <pt>*/*</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Hydra Broodmaster</reverse-related>
         </card>
@@ -2171,11 +2171,11 @@ Cloud Sprite can block only creatures with flying.</text>
             <name>Illusion</name>
             <set picURL="http://magiccards.info/extras/token/zendikar/illusion.jpg">ZEN</set>
             <color>U</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Illusion</type>
             <pt>2/2</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Summoner's Bane</reverse-related>
         </card>
@@ -2183,7 +2183,7 @@ Cloud Sprite can block only creatures with flying.</text>
             <name>Illusion </name>
             <set picURL="http://magiccards.info/extras/token/modern-masters/illusion.jpg">MMA</set>
             <color>U</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Illusion</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
@@ -2195,13 +2195,13 @@ Cloud Sprite can block only creatures with flying.</text>
             <name>Insect</name>
             <set picURL="http://magiccards.info/extras/token/scars-of-mirrodin/insect.jpg">SOM</set>
             <color>G</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Insect</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
             <text>Infect</text>
             <token>1</token>
-            <reverse-related>Carrion Call</reverse-related>
+            <reverse-related count="2">Carrion Call</reverse-related>
             <reverse-related>Phyrexian Swarmlord</reverse-related>
             <reverse-related>Trigon of Infestation</reverse-related>
         </card>
@@ -2209,7 +2209,7 @@ Cloud Sprite can block only creatures with flying.</text>
             <name>Insect </name>
             <set picURL="http://media.wizards.com/images/magic/daily/arcana/0010_MTGM15_TOK_EN%20copy.png">M15</set>
             <color>G</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Insect</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
@@ -2226,11 +2226,11 @@ Cloud Sprite can block only creatures with flying.</text>
             <set picURL="http://magiccards.info/extras/token/magic-2010/insect.jpg">M10</set>
             <set picURL="http://magiccards.info/extras/token/player-rewards-2003/insect.jpg">ONS</set>
             <color>G</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Insect</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Ant Queen</reverse-related>
             <reverse-related>Beacon of Creation</reverse-related>
@@ -2252,7 +2252,7 @@ Cloud Sprite can block only creatures with flying.</text>
             <name>Insect   </name>
             <set picURL="http://cdn.staticneo.com/w/mtg/2/23/Insect4.jpg">PLC</set>
             <color>G</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Insect</type>
             <pt>6/1</pt>
             <tablerow>2</tablerow>
@@ -2264,22 +2264,22 @@ Cloud Sprite can block only creatures with flying.</text>
             <name>Insect    </name>
             <set picURL="http://cdn.staticneo.com/w/mtg/d/df/Insect3.jpg">MIR</set>
             <color>B</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Insect</type>
             <pt>0/1</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Carrion</reverse-related>
         </card>
         <card>
             <name>Kaldra</name>
             <set picURL="http://cdn.staticneo.com/w/mtg/3/3d/Kaldra.jpg">DST</set>
-            <manacost></manacost>
+            <manacost />
             <type>Token Legendary Creature — Avatar</type>
             <pt>4/4</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Helm of Kaldra</reverse-related>
         </card>
@@ -2287,11 +2287,11 @@ Cloud Sprite can block only creatures with flying.</text>
             <name>Kavu</name>
             <set picURL="http://cdn.staticneo.com/w/mtg/4/42/Kavu.jpg">APC</set>
             <color>B</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Kavu</type>
             <pt>3/3</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Penumbra Kavu</reverse-related>
         </card>
@@ -2299,7 +2299,7 @@ Cloud Sprite can block only creatures with flying.</text>
             <name>Kelp</name>
             <set picURL="http://img295.imageshack.us/img295/4162/kelpfullmy7.jpg">ME2</set>
             <color>U</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Plant Wall</type>
             <pt>0/1</pt>
             <tablerow>2</tablerow>
@@ -2313,20 +2313,20 @@ Cloud Sprite can block only creatures with flying.</text>
             <set picURL="http://magiccards.info/extras/token/shadowmoor/kithkin-soldier.jpg">SHM</set>
             <set picURL="http://magiccards.info/extras/token/lorwyn/kithkin-soldier.jpg">LRW</set>
             <color>W</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Kithkin Soldier</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
-            <reverse-related>Cenn's Enlistment</reverse-related>
-            <reverse-related>Cloudgoat Ranger</reverse-related>
-            <reverse-related>Guardian of Cloverdell</reverse-related>
+            <reverse-related count="2">Cenn's Enlistment</reverse-related>
+            <reverse-related count="3">Cloudgoat Ranger</reverse-related>
+            <reverse-related count="3">Guardian of Cloverdell</reverse-related>
             <reverse-related>Gwyllion Hedge-Mage</reverse-related>
             <reverse-related>Kinsbaile Borderguard</reverse-related>
             <reverse-related>Militia's Pride</reverse-related>
             <reverse-related>Patrol Signaler</reverse-related>
-            <reverse-related>Repel Intruders</reverse-related>
+            <reverse-related count="2">Repel Intruders</reverse-related>
         </card>
         <card>
             <name>Knight</name>
@@ -2334,14 +2334,14 @@ Cloud Sprite can block only creatures with flying.</text>
             <set picURL="http://media.wizards.com/2015/images/daily/en_ai1c87k93o.png">ORI</set>
             <set picURL="http://magiccards.info/extras/token/return-to-ravnica/knight.jpg">RTR</set>
             <color>W</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Knight</type>
             <pt>2/2</pt>
             <tablerow>2</tablerow>
             <text>Vigilance</text>
             <token>1</token>
-            <reverse-related>Gideon's Phalanx</reverse-related>
-            <reverse-related>Knight Watch</reverse-related>
+            <reverse-related count="4">Gideon's Phalanx</reverse-related>
+            <reverse-related count="2">Knight Watch</reverse-related>
             <reverse-related>Knightly Valor</reverse-related>
             <reverse-related>Righteous Confluence</reverse-related>
             <reverse-related>Security Blockade</reverse-related>
@@ -2354,7 +2354,7 @@ Cloud Sprite can block only creatures with flying.</text>
             <set picURL="http://media.wizards.com/2015/c15_9dsm28ccakCDSk2/en_dEwDCo3Xh2.png">C15</set>
             <set picURL="http://cdn.staticneo.com/w/mtg/3/33/Knight1.jpg">RAV</set>
             <color>W</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Knight</type>
             <pt>2/2</pt>
             <tablerow>2</tablerow>
@@ -2366,11 +2366,11 @@ Cloud Sprite can block only creatures with flying.</text>
             <name>Knight  </name>
             <set picURL="http://img.photobucket.com/albums/v18/qtinator/knight2.jpg">USG</set>
             <color>W</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Knight</type>
             <pt>2/2</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Waylay</reverse-related>
         </card>
@@ -2378,7 +2378,7 @@ Cloud Sprite can block only creatures with flying.</text>
             <name>Knight   </name>
             <set picURL="http://img.photobucket.com/albums/v18/qtinator/Knight1.jpg">ME2</set>
             <color>W</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Knight</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
@@ -2390,7 +2390,7 @@ Cloud Sprite can block only creatures with flying.</text>
             <name>Knight    </name>
             <set picURL="http://cdn.staticneo.com/w/mtg/c/c3/Knight5.jpg">PLC</set>
             <color>B</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Knight</type>
             <pt>2/2</pt>
             <tablerow>2</tablerow>
@@ -2402,24 +2402,24 @@ Cloud Sprite can block only creatures with flying.</text>
             <name>Knight Ally</name>
             <set picURL="http://media.wizards.com/2015/images/daily/okAysNztfA.png">BFZ</set>
             <color>W</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Knight Ally</type>
             <pt>2/2</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
-            <reverse-related>Allied Reinforcements</reverse-related>
+            <reverse-related count="2">Allied Reinforcements</reverse-related>
             <reverse-related>Gideon, Ally of Zendikar</reverse-related>
         </card>
         <card>
             <name>Kobolds of Kher Keep (token)</name>
             <set picURL="http://cdn.staticneo.com/w/mtg/c/ca/Kobolds_of_Kher_Keep.jpg">TSP</set>
             <color>R</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Kobold</type>
             <pt>0/1</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Kher Keep</reverse-related>
             <reverse-related>Prossh, Skyraider of Kher</reverse-related>
@@ -2428,14 +2428,14 @@ Cloud Sprite can block only creatures with flying.</text>
             <name>Kor Ally</name>
             <set picURL="http://media.wizards.com/2015/images/daily/My4kFweDNz.png">BFZ</set>
             <color>W</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Kor Ally</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Captain's Claws</reverse-related>
-            <reverse-related>Oath of Gideon</reverse-related>
+            <reverse-related count="2">Oath of Gideon</reverse-related>
             <reverse-related>Retreat to Emeria</reverse-related>
             <reverse-related>Unified Front</reverse-related>
         </card>
@@ -2444,13 +2444,13 @@ Cloud Sprite can block only creatures with flying.</text>
             <set picURL="http://magiccards.info/extras/token/commander-2014/kor-soldier.jpg">C14</set>
             <set picURL="http://magiccards.info/extras/token/zendikar/kor-soldier.jpg">ZEN</set>
             <color>W</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Kor Soldier</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
-            <reverse-related>Conqueror's Pledge</reverse-related>
+            <reverse-related count="6">Conqueror's Pledge</reverse-related>
             <reverse-related>Nahiri, the Lithomancer</reverse-related>
             <reverse-related>Nomads' Assembly</reverse-related>
         </card>
@@ -2459,18 +2459,18 @@ Cloud Sprite can block only creatures with flying.</text>
             <set picURL="http://magiccards.info/extras/token/commander-2014/kraken.jpg">C14</set>
             <set picURL="http://magiccards.info/extras/token/born-of-the-gods/kraken.jpg">BNG</set>
             <color>U</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Kraken</type>
             <pt>9/9</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Kiora, the Crashing Wave</reverse-related>
         </card>
         <card>
             <name>Land Mine</name>
             <set picURL="http://media.wizards.com/images/magic/daily/arcana/0012_MTGM15_TOK_EN%20copy.png">M15</set>
-            <manacost></manacost>
+            <manacost />
             <type>Token Artifact</type>
             <tablerow>1</tablerow>
             <text>{R}, Sacrifice this artifact: This artifact deals 2 damage to target attacking creature without flying.</text>
@@ -2481,7 +2481,7 @@ Cloud Sprite can block only creatures with flying.</text>
             <name>Lightning Rager</name>
             <set picURL="http://media.wizards.com/2015/c15_9dsm28ccakCDSk2/en_KrFJ6WHvCU.png">C15</set>
             <color>R</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Elemental</type>
             <pt>5/1</pt>
             <tablerow>2</tablerow>
@@ -2494,11 +2494,11 @@ At the beginning of the end step, sacrifice this creature.</text>
             <name>Lizard</name>
             <set picURL="http://magiccards.info/extras/token/alara-reborn/lizard.jpg">ARB</set>
             <color>G</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Lizard</type>
             <pt>2/2</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Predatory Advantage</reverse-related>
         </card>
@@ -2506,11 +2506,11 @@ At the beginning of the end step, sacrifice this creature.</text>
             <name>Lizard </name>
             <set picURL="http://media.wizards.com/2016/azetllnwjpxztp2b_CN2/en_VyVhztSkQq.png">CN2</set>
             <color>R</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Lizard</type>
             <pt>8/8</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Subterranean Tremors</reverse-related>
         </card>
@@ -2518,7 +2518,7 @@ At the beginning of the end step, sacrifice this creature.</text>
             <name>Llanowar Elves (token)</name>
             <set picURL="http://cdn.staticneo.com/w/mtg/7/71/Llanowar_Elves.jpg">FUT</set>
             <color>G</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Elf Druid</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
@@ -2529,7 +2529,7 @@ At the beginning of the end step, sacrifice this creature.</text>
         <card>
             <name>Manifest</name>
             <set picURL="http://magiccards.info/extras/token/fate-reforged/manifest.jpg">FRF</set>
-            <manacost></manacost>
+            <manacost />
             <type>Creature</type>
             <pt>2/2</pt>
             <tablerow>2</tablerow>
@@ -2541,7 +2541,7 @@ A manifested creature card can be turned face up any time for its mana cost. A f
             <name>Marit Lage</name>
             <set picURL="http://magiccards.info/extras/token/coldsnap/marit-lage.jpg">CSP</set>
             <color>B</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Legendary Creature — Avatar</type>
             <pt>20/20</pt>
             <tablerow>2</tablerow>
@@ -2553,11 +2553,11 @@ A manifested creature card can be turned face up any time for its mana cost. A f
             <name>Merfolk</name>
             <set picURL="http://magiccards.info/extras/token/zendikar/merfolk.jpg">ZEN</set>
             <color>U</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Merfolk</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Lullmage Mentor</reverse-related>
         </card>
@@ -2565,24 +2565,24 @@ A manifested creature card can be turned face up any time for its mana cost. A f
             <name>Merfolk Wizard</name>
             <set picURL="http://magiccards.info/extras/token/lorwyn/merfolk-wizard.jpg">LRW</set>
             <color>U</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Merfolk Wizard</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
-            <reverse-related>Benthicore</reverse-related>
+            <reverse-related count="2">Benthicore</reverse-related>
             <reverse-related>Stonybrook Schoolmaster</reverse-related>
-            <reverse-related>Summon the School</reverse-related>
+            <reverse-related count="2">Summon the School</reverse-related>
         </card>
         <card>
             <name>Metallic Sliver (token)</name>
             <set picURL="http://cdn.staticneo.com/w/mtg/b/bf/Metallic_Sliver.jpg">FUT</set>
-            <manacost></manacost>
+            <manacost />
             <type>Token Artifact Creature — Sliver</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Sliversmith</reverse-related>
         </card>
@@ -2590,11 +2590,11 @@ A manifested creature card can be turned face up any time for its mana cost. A f
             <name>Minion</name>
             <set picURL="http://magiccards.info/extras/token/duel-decks-phyrexia-vs-the-coalition/minion.jpg">DDE</set>
             <color>B</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Minion</type>
             <pt>*/*</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Phyrexian Processor</reverse-related>
         </card>
@@ -2602,11 +2602,11 @@ A manifested creature card can be turned face up any time for its mana cost. A f
             <name>Minion </name>
             <set picURL="http://img.photobucket.com/albums/v18/qtinator/Minion1.jpg">PCY</set>
             <color>B</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Minion</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Infernal Genesis</reverse-related>
         </card>
@@ -2615,11 +2615,11 @@ A manifested creature card can be turned face up any time for its mana cost. A f
             <set picURL="http://cdn.staticneo.com/w/mtg/c/c7/Minor_Demon.jpg">ME3</set>
             <color>B</color>
             <color>R</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Demon</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Boris Devilboon</reverse-related>
         </card>
@@ -2627,19 +2627,19 @@ A manifested creature card can be turned face up any time for its mana cost. A f
             <name>Minotaur</name>
             <set picURL="http://magiccards.info/extras/token/journey-into-nyx/minotaur.jpg">JOU</set>
             <color>R</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Minotaur</type>
             <pt>2/3</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
-            <reverse-related>Flurry of Horns</reverse-related>
+            <reverse-related count="2">Flurry of Horns</reverse-related>
         </card>
         <card>
             <name>Monk</name>
             <set picURL="http://magiccards.info/extras/token/fate-reforged/monk.jpg">FRF</set>
             <color>W</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Monk</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
@@ -2651,11 +2651,11 @@ A manifested creature card can be turned face up any time for its mana cost. A f
             <name>Monkey</name>
             <set picURL="http://cdn.staticneo.com/w/mtg/9/97/Ape1.jpg">MMQ</set>
             <color>G</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Monkey</type>
             <pt>2/2</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Monkey Cage</reverse-related>
         </card>
@@ -2663,7 +2663,7 @@ A manifested creature card can be turned face up any time for its mana cost. A f
             <name>Morph</name>
             <set picURL="http://magiccards.info/extras/token/dragons-of-tarkir/morph.jpg">DTK</set>
             <set picURL="http://magiccards.info/extras/token/khans-of-tarkir/morph.jpg">KTK</set>
-            <manacost></manacost>
+            <manacost />
             <type>Creature</type>
             <pt>2/2</pt>
             <tablerow>2</tablerow>
@@ -2680,15 +2680,15 @@ A card with morph can be turned face up any time for its morph cost.)</text>
             <set picURL="http://magiccards.info/extras/token/new-phyrexia/myr.jpg">NPH</set>
             <set picURL="http://magiccards.info/extras/token/scars-of-mirrodin/myr.jpg">SOM</set>
             <set picURL="http://magiccards.info/extras/token/player-rewards-2004/myr.jpg">MRD</set>
-            <manacost></manacost>
+            <manacost />
             <type>Token Artifact Creature — Myr</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Genesis Chamber</reverse-related>
-            <reverse-related>Master's Call</reverse-related>
-            <reverse-related>Myr Battlesphere</reverse-related>
+            <reverse-related count="2">Master's Call</reverse-related>
+            <reverse-related count="4">Myr Battlesphere</reverse-related>
             <reverse-related>Myr Incubator</reverse-related>
             <reverse-related>Myr Matrix</reverse-related>
             <reverse-related>Myr Sire</reverse-related>
@@ -2702,25 +2702,25 @@ A card with morph can be turned face up any time for its morph cost.)</text>
             <name>Octopus</name>
             <set picURL="http://media.wizards.com/2015/images/daily/V2qe0ALQPq.png">BFZ</set>
             <color>U</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Octopus</type>
             <pt>8/8</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Crush of Tentacles</reverse-related>
-            <reverse-related>Kiora, Master of the Depths</reverse-related>
+            <reverse-related count="3">Kiora, Master of the Depths</reverse-related>
         </card>
         <card>
             <name>Ogre</name>
             <set picURL="http://media.wizards.com/2016/bn8f9t2zc_C16/FJxOEvQb3P_EN.png">C16</set>
             <set picURL="http://magiccards.info/extras/token/worldwake/ogre.jpg">WWK</set>
             <color>R</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Ogre</type>
             <pt>3/3</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Kazuul, Tyrant of the Cliffs</reverse-related>
         </card>
@@ -2728,11 +2728,11 @@ A card with morph can be turned face up any time for its morph cost.)</text>
             <name>Ogre </name>
             <set picURL="http://magiccards.info/extras/token/conspiracy/ogre.jpg">CNS</set>
             <color>R</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Ogre</type>
             <pt>4/4</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Grenzo's Rebuttal</reverse-related>
         </card>
@@ -2742,11 +2742,11 @@ A card with morph can be turned face up any time for its morph cost.)</text>
             <set picURL="http://magiccards.info/extras/token/shards-of-alara/ooze.jpg">ALA</set>
             <set picURL="http://magiccards.info/extras/token/return-to-ravnica/ooze.jpg">RTR</set>
             <color>G</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Ooze</type>
             <pt>*/*</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Gelatinous Genesis</reverse-related>
             <reverse-related>Miming Slime</reverse-related>
@@ -2759,7 +2759,7 @@ A card with morph can be turned face up any time for its morph cost.)</text>
             <name>Ooze </name>
             <set picURL="http://magiccards.info/extras/token/innistrad/ooze.jpg">ISD</set>
             <color>G</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Ooze</type>
             <pt>*/*</pt>
             <tablerow>2</tablerow>
@@ -2771,7 +2771,7 @@ A card with morph can be turned face up any time for its morph cost.)</text>
             <name>Ooze  </name>
             <set picURL="http://magiccards.info/extras/token/magic-2011/ooze-1.jpg">M11</set>
             <color>G</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Ooze</type>
             <pt>2/2</pt>
             <tablerow>2</tablerow>
@@ -2784,22 +2784,22 @@ A card with morph can be turned face up any time for its morph cost.)</text>
             <name>Ooze   </name>
             <set picURL="http://magiccards.info/extras/token/magic-2011/ooze-2.jpg">M11</set>
             <color>G</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Ooze</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
         </card>
         <card>
             <name>Ooze    </name>
             <set picURL="http://media.wizards.com/2016/aksdjciawolkcc0_soi/en_RbPPm8e2Wb.png">SOI</set>
             <color>G</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Ooze</type>
             <pt>3/3</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Inexorable Blob</reverse-related>
         </card>
@@ -2807,7 +2807,7 @@ A card with morph can be turned face up any time for its morph cost.)</text>
             <name>Orb</name>
             <set picURL="http://cdn.staticneo.com/w/mtg/4/44/Orb.jpg">ALL</set>
             <color>U</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Orb</type>
             <pt>*/*</pt>
             <tablerow>2</tablerow>
@@ -2819,7 +2819,7 @@ A card with morph can be turned face up any time for its morph cost.)</text>
             <name>Pegasus</name>
             <set picURL="http://magiccards.info/extras/token/commander-2014/pegasus.jpg">C14</set>
             <color>W</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Pegasus</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
@@ -2835,7 +2835,7 @@ A card with morph can be turned face up any time for its morph cost.)</text>
             <set picURL="http://magiccards.info/extras/token/commander-2014/pentavite.jpg">C14</set>
             <set picURL="http://magiccards.info/extras/token/magic-2012/pentavite.jpg">M12</set>
             <set picURL="http://magiccards.info/extras/token/player-rewards-2004/pentavite.jpg">MRD</set>
-            <manacost></manacost>
+            <manacost />
             <type>Token Artifact Creature — Pentavite</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
@@ -2846,22 +2846,22 @@ A card with morph can be turned face up any time for its morph cost.)</text>
         <card>
             <name>Pest</name>
             <set picURL="http://i1013.photobucket.com/albums/af260/lovesoldier99/PESTTOKEN.jpg">MRD</set>
-            <manacost></manacost>
+            <manacost />
             <type>Token Artifact Creature — Pest</type>
             <pt>0/1</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Nuisance Engine</reverse-related>
         </card>
         <card>
             <name>Pincher</name>
             <set picURL="http://cdn.staticneo.com/w/mtg/8/88/Pincher.jpg">5DN</set>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Pincher</type>
             <pt>2/2</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Summoning Station</reverse-related>
         </card>
@@ -2870,14 +2870,14 @@ A card with morph can be turned face up any time for its morph cost.)</text>
             <set picURL="http://media.wizards.com/2015/ogw_239nCi30ks3/en_qcpll4yBTI.png">OGW</set>
             <set picURL="http://magiccards.info/extras/token/worldwake/plant.jpg">WWK</set>
             <color>G</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Plant</type>
             <pt>0/1</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Avenger of Zendikar</reverse-related>
-            <reverse-related>Evil Comes to Fruition</reverse-related>
+            <reverse-related count="7">Evil Comes to Fruition</reverse-related>
             <reverse-related>Khalni Garden</reverse-related>
             <reverse-related>Nature Shields Its Own</reverse-related>
             <reverse-related>Nissa, Voice of Zendikar</reverse-related>
@@ -2886,22 +2886,22 @@ A card with morph can be turned face up any time for its morph cost.)</text>
             <name>Plant </name>
             <set picURL="http://media.wizards.com/2015/images/daily/VIQOdH0X0n.png">BFZ</set>
             <color>G</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Plant</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Grovetender Druids</reverse-related>
         </card>
         <card>
             <name>Prism</name>
             <set picURL="http://cdn.staticneo.com/w/mtg/f/fb/Prism.jpg">VIS</set>
-            <manacost></manacost>
+            <manacost />
             <type>Token Artifact Creature — Prism</type>
             <pt>0/1</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Diamond Kaleidoscope</reverse-related>
         </card>
@@ -2909,11 +2909,11 @@ A card with morph can be turned face up any time for its morph cost.)</text>
             <name>Ragavan</name>
             <set picURL="http://media.wizards.com/2016/c1lRLirbrl_AER/en_rzqBW60kOg.png">AER</set>
             <color>R</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Legendary Creature — Monkey</type>
             <pt>2/1</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Kari Zev, Skyship Raider</reverse-related>
         </card>
@@ -2922,11 +2922,11 @@ A card with morph can be turned face up any time for its morph cost.)</text>
             <set picURL="http://magiccards.info/extras/token/shadowmoor/rat.jpg">SHM</set>
             <set picURL="http://magiccards.info/extras/token/gatecrash/rat.jpg">GTC</set>
             <color>B</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Rat</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Lab Rats</reverse-related>
             <reverse-related>Marrow-Gnawer</reverse-related>
@@ -2937,11 +2937,11 @@ A card with morph can be turned face up any time for its morph cost.)</text>
             <name>Reflection</name>
             <set picURL="http://cdn.staticneo.com/w/mtg/e/e2/Reflection1.jpg">INV</set>
             <color>W</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Reflection</type>
             <pt>*/*</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Pure Reflection</reverse-related>
         </card>
@@ -2949,11 +2949,11 @@ A card with morph can be turned face up any time for its morph cost.)</text>
             <name>Reflection </name>
             <set picURL="http://cdn.staticneo.com/w/mtg/2/27/Reflection2.jpg">TMP</set>
             <color>W</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Reflection</type>
             <pt>2/2</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Spirit Mirror</reverse-related>
         </card>
@@ -2961,7 +2961,7 @@ A card with morph can be turned face up any time for its morph cost.)</text>
             <name>Rhino</name>
             <set picURL="http://magiccards.info/extras/token/return-to-ravnica/rhino.jpg">RTR</set>
             <color>G</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Rhino</type>
             <pt>4/4</pt>
             <tablerow>2</tablerow>
@@ -2972,11 +2972,11 @@ A card with morph can be turned face up any time for its morph cost.)</text>
         <card>
             <name>Sand</name>
             <set picURL="http://cdn.staticneo.com/w/mtg/3/33/Sand1.jpg">GPT</set>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Sand</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Dune-Brood Nephilim</reverse-related>
         </card>
@@ -2986,11 +2986,11 @@ A card with morph can be turned face up any time for its morph cost.)</text>
             <color>R</color>
             <color>G</color>
             <color>W</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Sand Warrior</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Hazezon Tamar</reverse-related>
         </card>
@@ -3012,23 +3012,23 @@ A card with morph can be turned face up any time for its morph cost.)</text>
             <set picURL="http://magiccards.info/extras/token/return-to-ravnica/saproling.jpg">RTR</set>
             <set picURL="http://magiccards.info/extras/token/player-rewards-2001/saproling.jpg">INV</set>
             <color>G</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Saproling</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Aether Mutation</reverse-related>
             <reverse-related>Artifact Mutation</reverse-related>
             <reverse-related>Aura Mutation</reverse-related>
-            <reverse-related>Bramble Elemental</reverse-related>
+            <reverse-related count="2">Bramble Elemental</reverse-related>
             <reverse-related>Death Mutation</reverse-related>
             <reverse-related>Deathspore Thallid</reverse-related>
             <reverse-related>Dreampod Druid</reverse-related>
             <reverse-related>Druidic Satchel</reverse-related>
             <reverse-related>Elvish Farmer</reverse-related>
-            <reverse-related>Fertile Imagination</reverse-related>
-            <reverse-related>Fists of Ironwood</reverse-related>
+            <reverse-related count="2">Fertile Imagination</reverse-related>
+            <reverse-related count="2">Fists of Ironwood</reverse-related>
             <reverse-related>Flash Foliage</reverse-related>
             <reverse-related>Fungal Sprouting</reverse-related>
             <reverse-related>Ghave, Guru of Spores</reverse-related>
@@ -3048,15 +3048,15 @@ A card with morph can be turned face up any time for its morph cost.)</text>
             <reverse-related>Pallid Mycoderm</reverse-related>
             <reverse-related>Pollenbright Wings</reverse-related>
             <reverse-related>Psychotrope Thallid</reverse-related>
-            <reverse-related>Rith's Charm</reverse-related>
+            <reverse-related count="3">Rith's Charm</reverse-related>
             <reverse-related>Rith, the Awakener</reverse-related>
-            <reverse-related>Roots of All Evil</reverse-related>
+            <reverse-related count="5">Roots of All Evil</reverse-related>
             <reverse-related>Saproling Cluster</reverse-related>
             <reverse-related>Saproling Infestation</reverse-related>
             <reverse-related>Saproling Symbiosis</reverse-related>
             <reverse-related>Savage Thallid</reverse-related>
-            <reverse-related>Scatter the Seeds</reverse-related>
-            <reverse-related>Seed Spark</reverse-related>
+            <reverse-related count="3">Scatter the Seeds</reverse-related>
+            <reverse-related count="2">Seed Spark</reverse-related>
             <reverse-related>Selesnya Evangel</reverse-related>
             <reverse-related>Selesnya Guildmage</reverse-related>
             <reverse-related>Spontaneous Generation</reverse-related>
@@ -3067,14 +3067,14 @@ A card with morph can be turned face up any time for its morph cost.)</text>
             <reverse-related>Sporoloth Ancient</reverse-related>
             <reverse-related>Sprout</reverse-related>
             <reverse-related>Sprout Swarm</reverse-related>
-            <reverse-related>Sprouting Thrinax</reverse-related>
+            <reverse-related count="3">Sprouting Thrinax</reverse-related>
             <reverse-related>Supply // Demand</reverse-related>
             <reverse-related>Tana, the Bloodsower</reverse-related>
             <reverse-related>Thallid</reverse-related>
             <reverse-related>Thallid Devourer</reverse-related>
             <reverse-related>Thallid Germinator</reverse-related>
             <reverse-related>Thallid Shell-Dweller</reverse-related>
-            <reverse-related>Thelonite Hermit</reverse-related>
+            <reverse-related count="4">Thelonite Hermit</reverse-related>
             <reverse-related>Tukatongue Thallid</reverse-related>
             <reverse-related>Ulasht, the Hate Seed</reverse-related>
             <reverse-related>Utopia Mycon</reverse-related>
@@ -3088,7 +3088,7 @@ A card with morph can be turned face up any time for its morph cost.)</text>
             <name>Saproling </name>
             <set picURL="http://cdn.staticneo.com/w/mtg/7/76/Saproling3.jpg">NMS</set>
             <color>G</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Saproling</type>
             <pt>*/*</pt>
             <tablerow>2</tablerow>
@@ -3101,57 +3101,57 @@ A card with morph can be turned face up any time for its morph cost.)</text>
             <set picURL="http://magiccards.info/extras/token/theros/satyr.jpg">THS</set>
             <color>R</color>
             <color>G</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Satyr</type>
             <pt>2/2</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
-            <reverse-related>Revel of the Fallen God</reverse-related>
+            <reverse-related count="4">Revel of the Fallen God</reverse-related>
             <reverse-related>Xenagos, the Reveler</reverse-related>
         </card>
         <card>
             <name>Serf</name>
             <set picURL="http://media.wizards.com/2016/adhfianalodifdj2_EMA/en_UwZdI8LJ0u.png">EMA</set>
             <color>B</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Serf</type>
             <pt>0/1</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
-            <reverse-related>Sengir Autocrat</reverse-related>
+            <reverse-related count="3">Sengir Autocrat</reverse-related>
         </card>
         <card>
             <name>Servo</name>
             <set picURL="http://media.wizards.com/2016/bVvMNuiu2i_KLD/en_xzZQc5a68Z.png">KLD</set>
             <set picURL="http://media.wizards.com/2016/bVvMNuiu2i_KLD/en_oKAeTK3DKA.png">KLD</set>
             <set picURL="http://media.wizards.com/2016/bVvMNuiu2i_KLD/en_b786LD89UN.png">KLD</set>
-            <manacost></manacost>
+            <manacost />
             <type>Token Artifact Creature — Servo</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Accomplished Automaton</reverse-related>
             <reverse-related>Ambitious Aetherborn</reverse-related>
-            <reverse-related>Angel of Invention</reverse-related>
+            <reverse-related count="2">Angel of Invention</reverse-related>
             <reverse-related>Animation Module</reverse-related>
             <reverse-related>Cogworker's Puzzleknot</reverse-related>
-            <reverse-related>Cultivator of Blades</reverse-related>
-            <reverse-related>Elegant Edgecrafters</reverse-related>
+            <reverse-related count="2">Cultivator of Blades</reverse-related>
+            <reverse-related count="2">Elegant Edgecrafters</reverse-related>
             <reverse-related>Glint-Sleeve Artisan</reverse-related>
             <reverse-related>Highspire Artisan</reverse-related>
             <reverse-related>Iron League Steed</reverse-related>
-            <reverse-related>Marionette Master</reverse-related>
+            <reverse-related count="3">Marionette Master</reverse-related>
             <reverse-related>Master Trinketeer</reverse-related>
             <reverse-related>Maulfist Squad</reverse-related>
             <reverse-related>Oviya Pashiri, Sage Lifecrafter</reverse-related>
             <reverse-related>Peema Outrider</reverse-related>
             <reverse-related>Propeller Pioneer</reverse-related>
-            <reverse-related>Servo Exhibition</reverse-related>
-            <reverse-related>Visionary Augmenter</reverse-related>
-            <reverse-related>Weaponcraft Enthusiast</reverse-related>
+            <reverse-related count="2">Servo Exhibition</reverse-related>
+            <reverse-related count="2">Visionary Augmenter</reverse-related>
+            <reverse-related count="2">Weaponcraft Enthusiast</reverse-related>
             <reverse-related>Aether Chaser</reverse-related>
             <reverse-related>Aether Herder</reverse-related>
             <reverse-related>Aether Inspector</reverse-related>
@@ -3162,13 +3162,13 @@ A card with morph can be turned face up any time for its morph cost.)</text>
             <reverse-related>Renegade's Getaway</reverse-related>
             <reverse-related>Servo Schematic</reverse-related>
             <reverse-related>Sly Requisitioner</reverse-related>
-            <reverse-related>Sram's Expertise</reverse-related>
+            <reverse-related count="3">Sram's Expertise</reverse-related>
         </card>
         <card>
             <name>Shapeshifter </name>
             <set picURL="http://media.wizards.com/2015/c15_9dsm28ccakCDSk2/en_v2CKUzXPj8.png">C15</set>
             <set picURL="http://magiccards.info/extras/token/lorwyn/shapeshifter.jpg">LRW</set>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Shapeshifter</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
@@ -3180,11 +3180,11 @@ A card with morph can be turned face up any time for its morph cost.)</text>
             <name>Sheep</name>
             <set picURL="http://cdn.staticneo.com/w/mtg/5/57/Sheep1.jpg">TSB</set>
             <color>G</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Sheep</type>
             <pt>0/1</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Ovinomancer</reverse-related>
         </card>
@@ -3192,7 +3192,7 @@ A card with morph can be turned face up any time for its morph cost.)</text>
             <name>Skeleton</name>
             <set picURL="http://magiccards.info/extras/token/shards-of-alara/skeleton.jpg">ALA</set>
             <color>B</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Skeleton</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
@@ -3206,14 +3206,14 @@ A card with morph can be turned face up any time for its morph cost.)</text>
             <set picURL="http://media.wizards.com/images/magic/daily/arcana/0001_MTGM15_TOK_EN%20copy.png">M15</set>
             <set picURL="http://magiccards.info/extras/token/player-rewards-2003/sliver.jpg">LGN</set>
             <set picURL="http://magiccards.info/extras/token/magic-2014/sliver.jpg">M14</set>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Sliver</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Brood Sliver</reverse-related>
-            <reverse-related>Hive Stirrings</reverse-related>
+            <reverse-related count="2">Hive Stirrings</reverse-related>
             <reverse-related>Sliver Hive</reverse-related>
             <reverse-related>Sliver Queen</reverse-related>
         </card>
@@ -3224,14 +3224,14 @@ A card with morph can be turned face up any time for its morph cost.)</text>
             <set picURL="http://magiccards.info/extras/token/khans-of-tarkir/snake.jpg">KTK</set>
             <set picURL="http://magiccards.info/extras/token/zendikar/snake.jpg">ZEN</set>
             <color>G</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Snake</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Bestial Menace</reverse-related>
-            <reverse-related>Cobra Trap</reverse-related>
+            <reverse-related count="4">Cobra Trap</reverse-related>
             <reverse-related>Endless Swarm</reverse-related>
             <reverse-related>Hooded Hydra</reverse-related>
             <reverse-related>Orochi Eggwatcher</reverse-related>
@@ -3240,12 +3240,12 @@ A card with morph can be turned face up any time for its morph cost.)</text>
             <reverse-related>Seed the Land</reverse-related>
             <reverse-related>Snake Basket</reverse-related>
             <reverse-related>Snake Pit</reverse-related>
-            <reverse-related>Sosuke's Summons</reverse-related>
+            <reverse-related count="2">Sosuke's Summons</reverse-related>
         </card>
         <card>
             <name>Snake </name>
             <set picURL="http://cdn.staticneo.com/w/mtg/0/01/Snake3.jpg">MED</set>
-            <manacost></manacost>
+            <manacost />
             <type>Token Artifact Creature — Snake</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
@@ -3258,11 +3258,11 @@ A card with morph can be turned face up any time for its morph cost.)</text>
             <set picURL="http://media.wizards.com/2015/c15_9dsm28ccakCDSk2/en_JIyE6GkvUc.png">C15</set>
             <color>G</color>
             <color>U</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Snake</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Patagia Viper</reverse-related>
         </card>
@@ -3271,7 +3271,7 @@ A card with morph can be turned face up any time for its morph cost.)</text>
             <set picURL="http://magiccards.info/extras/token/journey-into-nyx/snake.jpg">JOU</set>
             <color>B</color>
             <color>G</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Enchantment Creature — Snake</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
@@ -3283,7 +3283,7 @@ A card with morph can be turned face up any time for its morph cost.)</text>
             <name>Snake    </name>
             <set picURL="http://media-dominaria.cursecdn.com/attachments/113/426/635201279747658553.jpg">C13</set>
             <color>B</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Snake</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
@@ -3314,50 +3314,50 @@ A card with morph can be turned face up any time for its morph cost.)</text>
             <set picURL="http://magiccards.info/extras/token/tenth-edition/soldier.jpg">10E</set>
             <set picURL="http://magiccards.info/extras/token/player-rewards-2002/soldier.jpg">ONS</set>
             <color>W</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Soldier</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Akroan Horse</reverse-related>
             <reverse-related>Alliance of Arms</reverse-related>
             <reverse-related>Attended Knight</reverse-related>
             <reverse-related>Bant Sojourners</reverse-related>
             <reverse-related>Benalish Commander</reverse-related>
-            <reverse-related>Captain of the Watch</reverse-related>
-            <reverse-related>Captain's Call</reverse-related>
+            <reverse-related count="3">Captain of the Watch</reverse-related>
+            <reverse-related count="3">Captain's Call</reverse-related>
             <reverse-related>Darien, King of Kjeldor</reverse-related>
             <reverse-related>Decree of Justice</reverse-related>
             <reverse-related>Deploy to the Front</reverse-related>
-            <reverse-related>Elspeth Tirel</reverse-related>
+            <reverse-related count="3">Elspeth Tirel</reverse-related>
             <reverse-related>Elspeth, Knight-Errant</reverse-related>
-            <reverse-related>Elspeth, Sun's Champion</reverse-related>
+            <reverse-related count="3">Elspeth, Sun's Champion</reverse-related>
             <reverse-related>Entrapment Maneuver</reverse-related>
             <reverse-related>Evangel of Heliod</reverse-related>
-            <reverse-related>Even the Odds</reverse-related>
+            <reverse-related count="3">Even the Odds</reverse-related>
             <reverse-related>First Response</reverse-related>
-            <reverse-related>Hero of Bladehold</reverse-related>
+            <reverse-related count="2">Hero of Bladehold</reverse-related>
             <reverse-related>Kjeldoran Outpost</reverse-related>
-            <reverse-related>Knight-Captain of Eos</reverse-related>
+            <reverse-related count="2">Knight-Captain of Eos</reverse-related>
             <reverse-related>Launch the Fleet</reverse-related>
             <reverse-related>Lieutenants of the Guard</reverse-related>
             <reverse-related>Martial Coup</reverse-related>
             <reverse-related>Mobilization</reverse-related>
             <reverse-related>Murder Investigation</reverse-related>
             <reverse-related>Precinct Captain</reverse-related>
-            <reverse-related>Raise the Alarm</reverse-related>
+            <reverse-related count="2">Raise the Alarm</reverse-related>
             <reverse-related>Security Detail</reverse-related>
             <reverse-related>Stormfront Riders</reverse-related>
-            <reverse-related>Throne of Empires</reverse-related>
-            <reverse-related>Timely Reinforcements</reverse-related>
+            <reverse-related count="5">Throne of Empires</reverse-related>
+            <reverse-related count="3">Timely Reinforcements</reverse-related>
         </card>
         <card>
             <name>Soldier </name>
             <set picURL="http://magiccards.info/extras/token/gatecrash/soldier.jpg">GTC</set>
             <color>R</color>
             <color>W</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Soldier</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
@@ -3371,7 +3371,7 @@ A card with morph can be turned face up any time for its morph cost.)</text>
             <name>Soldier  </name>
             <set picURL="http://media.wizards.com/2016/azetllnwjpxztp2b_CN2/en_Uod6lKrGvi.png">CN2</set>
             <color>W</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Soldier</type>
             <pt>1/2</pt>
             <tablerow>2</tablerow>
@@ -3383,11 +3383,11 @@ A card with morph can be turned face up any time for its morph cost.)</text>
             <name>Soldier    </name>
             <set picURL="http://magiccards.info/extras/token/theros/soldier-3.jpg">THS</set>
             <color>R</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Soldier</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Akroan Crusader</reverse-related>
         </card>
@@ -3395,11 +3395,11 @@ A card with morph can be turned face up any time for its morph cost.)</text>
             <name>Soldier     </name>
             <set picURL="http://magiccards.info/extras/token/born-of-the-gods/soldier.jpg">BNG</set>
             <color>W</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Enchantment Creature — Soldier</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>God-Favored General</reverse-related>
         </card>
@@ -3407,19 +3407,19 @@ A card with morph can be turned face up any time for its morph cost.)</text>
             <name>Soldier Ally</name>
             <set picURL="http://magiccards.info/extras/token/worldwake/soldier-ally.jpg">WWK</set>
             <color>W</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Soldier Ally</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
-            <reverse-related>Join the Ranks</reverse-related>
+            <reverse-related count="2">Join the Ranks</reverse-related>
         </card>
         <card>
             <name>Spark Elemental (token)</name>
             <set picURL="http://cdn.staticneo.com/w/mtg/a/ae/Spark_Elemental.jpg">FUT</set>
             <color>R</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Elemental</type>
             <pt>3/1</pt>
             <tablerow>2</tablerow>
@@ -3431,11 +3431,11 @@ At the beginning of the end step, sacrifice Spark Elemental.</text>
         <card>
             <name>Spawn</name>
             <set picURL="http://cdn.staticneo.com/w/mtg/d/d3/Spawn.jpg">DST</set>
-            <manacost></manacost>
+            <manacost />
             <type>Token Artifact Creature — Spawn</type>
             <pt>2/2</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Spawning Pit</reverse-related>
         </card>
@@ -3443,7 +3443,7 @@ At the beginning of the end step, sacrifice Spark Elemental.</text>
             <name>Sphinx</name>
             <set picURL="http://magiccards.info/extras/token/journey-into-nyx/sphinx.jpg">JOU</set>
             <color>U</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Sphinx</type>
             <pt>4/4</pt>
             <tablerow>2</tablerow>
@@ -3458,7 +3458,7 @@ At the beginning of the end step, sacrifice Spark Elemental.</text>
             <set picURL="http://magiccards.info/extras/token/innistrad/spider.jpg">ISD</set>
             <set picURL="http://magiccards.info/extras/token/shadowmoor/spider.jpg">SHM</set>
             <color>G</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Spider</type>
             <pt>1/2</pt>
             <tablerow>2</tablerow>
@@ -3466,14 +3466,14 @@ At the beginning of the end step, sacrifice Spark Elemental.</text>
             <token>1</token>
             <reverse-related>Arachnogenesis</reverse-related>
             <reverse-related>Gloomwidow's Feast</reverse-related>
-            <reverse-related>Ishkanah, Grafwidow</reverse-related>
+            <reverse-related count="3">Ishkanah, Grafwidow</reverse-related>
             <reverse-related>Spider Spawning</reverse-related>
         </card>
         <card>
             <name>Spider </name>
             <set picURL="http://magiccards.info/extras/token/modern-masters/spider.jpg">MMA</set>
             <color>B</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Spider</type>
             <pt>2/4</pt>
             <tablerow>2</tablerow>
@@ -3485,7 +3485,7 @@ At the beginning of the end step, sacrifice Spark Elemental.</text>
             <name>Spider  </name>
             <set picURL="http://magiccards.info/extras/token/journey-into-nyx/spider.jpg">JOU</set>
             <color>G</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Enchantment Creature — Spider</type>
             <pt>1/3</pt>
             <tablerow>2</tablerow>
@@ -3497,11 +3497,11 @@ At the beginning of the end step, sacrifice Spark Elemental.</text>
             <name>Spike</name>
             <set picURL="http://cdn.staticneo.com/w/mtg/7/7c/Spike.jpg">STH</set>
             <color>G</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Spike</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Spike Breeder</reverse-related>
         </card>
@@ -3525,7 +3525,7 @@ At the beginning of the end step, sacrifice Spark Elemental.</text>
             <set picURL="http://magiccards.info/extras/token/duel-decks-sorin-vs-tibalt/spirit.jpg">DDK</set>
             <set picURL="http://magiccards.info/extras/token/player-rewards-2001/spirit.jpg">PLS</set>
             <color>W</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Spirit</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
@@ -3534,7 +3534,7 @@ At the beginning of the end step, sacrifice Spark Elemental.</text>
             <reverse-related>Abzan Ascendancy</reverse-related>
             <reverse-related>Afterlife</reverse-related>
             <reverse-related>Avacyn's Collar</reverse-related>
-            <reverse-related>Benevolent Offering</reverse-related>
+            <reverse-related count="3">Benevolent Offering</reverse-related>
             <reverse-related>Custodi Soulbinders</reverse-related>
             <reverse-related>Dauntless Cathar</reverse-related>
             <reverse-related>Doomed Traveler</reverse-related>
@@ -3544,17 +3544,17 @@ At the beginning of the end step, sacrifice Spark Elemental.</text>
             <reverse-related>Field of Souls</reverse-related>
             <reverse-related>Funeral Pyre</reverse-related>
             <reverse-related>Gallows at Willow Hill</reverse-related>
-            <reverse-related>Geist-Honored Monk</reverse-related>
+            <reverse-related count="2">Geist-Honored Monk</reverse-related>
             <reverse-related>Hallowed Spiritkeeper</reverse-related>
             <reverse-related>Haunted Dead</reverse-related>
-            <reverse-related>Kirtar's Wrath</reverse-related>
-            <reverse-related>Lingering Souls</reverse-related>
+            <reverse-related count="2">Kirtar's Wrath</reverse-related>
+            <reverse-related count="2">Lingering Souls</reverse-related>
             <reverse-related>Luminous Angel</reverse-related>
             <reverse-related>March of Souls</reverse-related>
-            <reverse-related>Mausoleum Guard</reverse-related>
-            <reverse-related>Midnight Haunting</reverse-related>
+            <reverse-related count="2">Mausoleum Guard</reverse-related>
+            <reverse-related count="2">Midnight Haunting</reverse-related>
             <reverse-related>Moorland Haunt</reverse-related>
-            <reverse-related>Nearheath Chaplain</reverse-related>
+            <reverse-related count="2">Nearheath Chaplain</reverse-related>
             <reverse-related>Not Forgotten</reverse-related>
             <reverse-related>Requiem Angel</reverse-related>
             <reverse-related>Rousing of Souls</reverse-related>
@@ -3562,21 +3562,21 @@ At the beginning of the end step, sacrifice Spark Elemental.</text>
             <reverse-related>Sandsteppe Outcast</reverse-related>
             <reverse-related>Seize the Soul</reverse-related>
             <reverse-related>Slayer's Plate</reverse-related>
-            <reverse-related>Spectral Procession</reverse-related>
-            <reverse-related>Spectral Reserves</reverse-related>
+            <reverse-related count="3">Spectral Procession</reverse-related>
+            <reverse-related count="2">Spectral Reserves</reverse-related>
             <reverse-related>Spirit Bonds</reverse-related>
             <reverse-related>Spirit Cairn</reverse-related>
             <reverse-related>Teysa, Orzhov Scion</reverse-related>
             <reverse-related>Transluminant</reverse-related>
-            <reverse-related>Triplicate Spirits</reverse-related>
-            <reverse-related>Twilight Drover</reverse-related>
-            <reverse-related>Vessel of Ephemera</reverse-related>
+            <reverse-related count="3">Triplicate Spirits</reverse-related>
+            <reverse-related count="2">Twilight Drover</reverse-related>
+            <reverse-related count="2">Vessel of Ephemera</reverse-related>
         </card>
         <card>
             <name>Spirit </name>
             <set picURL="http://magiccards.info/extras/token/avacyn-restored/spirit-2.jpg">AVR</set>
             <color>U</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Spirit</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
@@ -3591,7 +3591,7 @@ At the beginning of the end step, sacrifice Spark Elemental.</text>
             <set picURL="http://magiccards.info/extras/token/eventide/spirit.jpg">EVE</set>
             <color>W</color>
             <color>B</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Spirit</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
@@ -3605,11 +3605,11 @@ At the beginning of the end step, sacrifice Spark Elemental.</text>
             <set picURL="http://media.wizards.com/2016/bn8f9t2zc_C16/bQqBAcQB03_EN.png">C16</set>
             <set picURL="http://media.wizards.com/2016/adhfianalodifdj2_EMA/en_qQaHPqyjyC.png">EMA</set>
             <set picURL="http://magiccards.info/extras/token/player-rewards-2004/spirit.jpg">CHK</set>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Spirit</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Baku Altar</reverse-related>
             <reverse-related>Dripping-Tongue Zubera</reverse-related>
@@ -3624,11 +3624,11 @@ At the beginning of the end step, sacrifice Spark Elemental.</text>
             <name>Spirit    </name>
             <set picURL="http://s8.postimg.org/qxkmzlwid/SPIRIT.jpg">ME2</set>
             <color>B</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Spirit</type>
             <pt>*/*</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Broken Visage</reverse-related>
         </card>
@@ -3636,7 +3636,7 @@ At the beginning of the end step, sacrifice Spark Elemental.</text>
             <name>Spirit     </name>
             <set picURL="http://cdn.staticneo.com/w/mtg/6/6a/Spirit3.jpg">BOK</set>
             <color>W</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Spirit</type>
             <pt>3/3</pt>
             <tablerow>2</tablerow>
@@ -3649,7 +3649,7 @@ At the beginning of the end step, sacrifice Spark Elemental.</text>
             <set picURL="http://media.wizards.com/2015/c15_9dsm28ccakCDSk2/en_YIG8kZUUvK.png">C15</set>
             <color>W</color>
             <color>B</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Enchantment Creature — Spirit</type>
             <pt>*/*</pt>
             <tablerow>2</tablerow>
@@ -3662,11 +3662,11 @@ At the beginning of the end step, sacrifice Spark Elemental.</text>
             <set picURL="http://magiccards.info/extras/token/khans-of-tarkir/spirit-warrior.jpg">KTK</set>
             <color>B</color>
             <color>G</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Spirit Warrior</type>
             <pt>*/*</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Kin-Tree Invocation</reverse-related>
         </card>
@@ -3674,7 +3674,7 @@ At the beginning of the end step, sacrifice Spark Elemental.</text>
             <name>Splinter </name>
             <set picURL="http://cdn.staticneo.com/w/mtg/f/f6/Splinter.jpg">ALL</set>
             <color>G</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Splinter</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
@@ -3688,7 +3688,7 @@ Cumulative upkeep {G}</text>
             <set picURL="http://media.wizards.com/2016/bn8f9t2zc_C16/I59skxnJe9_EN.png">C16</set>
             <set picURL="http://media.wizards.com/images/magic/daily/arcana/0004_MTGM15_TOK_EN%20copy.png">M15</set>
             <color>U</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Squid</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
@@ -3702,33 +3702,33 @@ Cumulative upkeep {G}</text>
             <set picURL="http://magiccards.info/extras/token/conspiracy/squirrel.jpg">CNS</set>
             <set picURL="http://magiccards.info/extras/token/player-rewards-2002/squirrel.jpg">ODY</set>
             <color>G</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Squirrel</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Acorn Catapult</reverse-related>
-            <reverse-related>Acorn Harvest</reverse-related>
+            <reverse-related count="2">Acorn Harvest</reverse-related>
             <reverse-related>Chatter of the Squirrel</reverse-related>
-            <reverse-related>Deranged Hermit</reverse-related>
+            <reverse-related count="4">Deranged Hermit</reverse-related>
             <reverse-related>Druid's Call</reverse-related>
             <reverse-related>Liege of the Hollows</reverse-related>
             <reverse-related>Nantuko Shrine</reverse-related>
             <reverse-related>Nut Collector</reverse-related>
             <reverse-related>Squirrel Nest</reverse-related>
-            <reverse-related>Squirrel Wrangler</reverse-related>
+            <reverse-related count="2">Squirrel Wrangler</reverse-related>
         </card>
         <card>
             <name>Stangg Twin</name>
             <set picURL="http://cdn.staticneo.com/w/mtg/0/04/Stangg_Twin.jpg">ME3</set>
             <color>R</color>
             <color>G</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Legendary Creature — Human Warrior</type>
             <pt>3/4</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Stangg</reverse-related>
         </card>
@@ -3736,18 +3736,18 @@ Cumulative upkeep {G}</text>
             <name>Starfish</name>
             <set picURL="http://i1013.photobucket.com/albums/af260/lovesoldier99/STARFISHTOKEN.jpg">ME3</set>
             <color>U</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Starfish</type>
             <pt>0/1</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Spiny Starfish</reverse-related>
         </card>
         <card>
             <name>Stoneforged Blade</name>
             <set picURL="http://magiccards.info/extras/token/commander-2014/stoneforged-blade.jpg">C14</set>
-            <manacost></manacost>
+            <manacost />
             <type>Token Artifact — Equipment</type>
             <tablerow>2</tablerow>
             <text>Indestructible
@@ -3760,18 +3760,18 @@ Equip {0}</text>
             <name>Survivor</name>
             <set picURL="http://cdn.staticneo.com/w/mtg/1/14/Survivor.jpg">MED</set>
             <color>R</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Survivor</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Varchild's War-Riders</reverse-related>
         </card>
         <card>
             <name>Tetravite</name>
             <set picURL="http://cdn.staticneo.com/w/mtg/e/e6/Tetravite.jpg">ATQ</set>
-            <manacost></manacost>
+            <manacost />
             <type>Token Artifact Creature — Tetravite</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
@@ -3788,36 +3788,36 @@ This creature can't be enchanted.</text>
             <set picURL="http://media.wizards.com/2015/images/daily/en_9ju9ab3gkt.png">ORI</set>
             <set picURL="http://media.wizards.com/2015/images/daily/en_rntjyw1s1o.png">ORI</set>
             <set picURL="http://magiccards.info/extras/token/mirrodin-besieged/thopter.jpg">MBS</set>
-            <manacost></manacost>
+            <manacost />
             <type>Token Artifact Creature — Thopter</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
             <text>Flying</text>
             <token>1</token>
             <reverse-related>Aspiring Aeronaut</reverse-related>
-            <reverse-related>Experimental Aviator</reverse-related>
-            <reverse-related>Foundry of the Consuls</reverse-related>
+            <reverse-related count="2">Experimental Aviator</reverse-related>
+            <reverse-related count="2">Foundry of the Consuls</reverse-related>
             <reverse-related>Ghirapur Gearcrafter</reverse-related>
             <reverse-related>Hangarback Walker</reverse-related>
             <reverse-related>Pia Nalaar</reverse-related>
-            <reverse-related>Pia and Kiran Nalaar</reverse-related>
-            <reverse-related>Thopter Assembly</reverse-related>
+            <reverse-related count="2">Pia and Kiran Nalaar</reverse-related>
+            <reverse-related count="5">Thopter Assembly</reverse-related>
             <reverse-related>Thopter Engineer</reverse-related>
             <reverse-related>Thopter Spy Network</reverse-related>
             <reverse-related>Thopter Squadron</reverse-related>
-            <reverse-related>Whirler Rogue</reverse-related>
+            <reverse-related count="2">Whirler Rogue</reverse-related>
             <reverse-related>Whirler Virtuoso</reverse-related>
             <reverse-related>Whirlermaker</reverse-related>
             <reverse-related>Efficient Construction</reverse-related>
             <reverse-related>Filigree Crawler</reverse-related>
-            <reverse-related>Maverick Thopterist</reverse-related>
+            <reverse-related count="2">Maverick Thopterist</reverse-related>
         </card>
         <card>
             <name>Thopter </name>
             <set picURL="http://media.wizards.com/2016/bn8f9t2zc_C16/PK9s0eoiqm_EN.png">C16</set>
             <set picURL="http://magiccards.info/extras/token/shards-of-alara/thopter.jpg">ALA</set>
             <color>U</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Artifact Creature — Thopter</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
@@ -3831,11 +3831,11 @@ This creature can't be enchanted.</text>
             <name>Thrull</name>
             <set picURL="http://magiccards.info/extras/token/duel-decks-divine-vs-demonic/thrull.jpg">DDC</set>
             <color>B</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Thrull</type>
             <pt>0/1</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Breeding Pit</reverse-related>
         </card>
@@ -3843,11 +3843,11 @@ This creature can't be enchanted.</text>
             <name>Thrull </name>
             <set picURL="http://media.wizards.com/2015/mm2_9vgauji43t9a/en_lDMIi3XONu.png">MM2</set>
             <color>B</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Thrull</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Endrek Sahr, Master Breeder</reverse-related>
         </card>
@@ -3855,7 +3855,7 @@ This creature can't be enchanted.</text>
             <name>Tombspawn</name>
             <set picURL="http://cdn.staticneo.com/w/mtg/5/5c/Tombspawn.jpg">MIR</set>
             <color>B</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Zombie</type>
             <pt>2/2</pt>
             <tablerow>2</tablerow>
@@ -3867,11 +3867,11 @@ This creature can't be enchanted.</text>
             <name>Treefolk</name>
             <set picURL="http://magiccards.info/extras/token/commander-2014/treefolk.jpg">C14</set>
             <color>G</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Treefolk</type>
             <pt>*/*</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Sylvan Offering</reverse-related>
         </card>
@@ -3880,11 +3880,11 @@ This creature can't be enchanted.</text>
             <set picURL="http://magiccards.info/extras/token/modern-masters/treefolk-shaman.jpg">MMA</set>
             <set picURL="http://magiccards.info/extras/token/morningtide/treefolk-shaman.jpg">MOR</set>
             <color>G</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Treefolk Shaman</type>
             <pt>2/5</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Reach of Branches</reverse-related>
         </card>
@@ -3892,7 +3892,7 @@ This creature can't be enchanted.</text>
             <name>Treefolk Warrior</name>
             <set picURL="http://media.wizards.com/images/magic/daily/arcana/0011_MTGM15_TOK_EN%20copy.png">M15</set>
             <color>G</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Treefolk Warrior</type>
             <pt>*/*</pt>
             <tablerow>2</tablerow>
@@ -3903,7 +3903,7 @@ This creature can't be enchanted.</text>
         <card>
             <name>Triskelavite</name>
             <set picURL="http://cdn.staticneo.com/w/mtg/a/a7/Triskelavite.jpg">TSP</set>
-            <manacost></manacost>
+            <manacost />
             <type>Token Artifact Creature — Triskelavite</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
@@ -3916,22 +3916,22 @@ Sacrifice this creature: This creature deals 1 damage to target creature or play
             <name>Tuktuk The Returned</name>
             <set picURL="http://magiccards.info/extras/token/commander-2014/tuktuk-the-returned.jpg">C14</set>
             <set picURL="http://magiccards.info/extras/token/rise-of-the-eldrazi/tuktuk-the-returned.jpg">ROE</set>
-            <manacost></manacost>
+            <manacost />
             <type>Token Legendary Artifact Creature — Goblin Golem</type>
             <pt>5/5</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Tuktuk the Explorer</reverse-related>
         </card>
         <card>
             <name>Twin</name>
             <set picURL="http://cdn.staticneo.com/w/mtg/7/78/Twin.jpg">DST</set>
-            <manacost></manacost>
+            <manacost />
             <type>Token Artifact Creature — Construct</type>
             <pt>*/*</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Gemini Engine</reverse-related>
         </card>
@@ -3939,7 +3939,7 @@ Sacrifice this creature: This creature deals 1 damage to target creature or play
             <name>Urami</name>
             <set picURL="http://cdn.staticneo.com/w/mtg/f/f1/Urami.jpg">SOK</set>
             <color>B</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Legendary Creature — Demon Spirit</type>
             <pt>5/5</pt>
             <tablerow>2</tablerow>
@@ -3952,7 +3952,7 @@ Sacrifice this creature: This creature deals 1 damage to target creature or play
             <set picURL="http://magiccards.info/extras/token/khans-of-tarkir/vampire.jpg">KTK</set>
             <set picURL="http://magiccards.info/extras/token/innistrad/vampire.jpg">ISD</set>
             <color>B</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Vampire</type>
             <pt>2/2</pt>
             <tablerow>2</tablerow>
@@ -3966,7 +3966,7 @@ Sacrifice this creature: This creature deals 1 damage to target creature or play
             <name>Vampire </name>
             <set picURL="http://magiccards.info/extras/token/dark-ascension/vampire.jpg">DKA</set>
             <color>B</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Vampire</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
@@ -3978,18 +3978,18 @@ Sacrifice this creature: This creature deals 1 damage to target creature or play
             <name>Vampire  </name>
             <set picURL="http://magiccards.info/extras/token/zendikar/vampire.jpg">ZEN</set>
             <color>B</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Vampire</type>
             <pt>*/*</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Kalitas, Bloodchief of Ghet</reverse-related>
         </card>
         <card>
             <name>Vampire Knight</name>
             <set picURL="http://media.wizards.com/2016/aksdjciawolkcc0_soi/en_Lz7fjwmpzN.png">SOI</set>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Vampire Knight</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
@@ -4003,18 +4003,18 @@ Sacrifice this creature: This creature deals 1 damage to target creature or play
             <set picURL="http://cdn.staticneo.com/w/mtg/9/91/Voja.jpg">RAV</set>
             <color>G</color>
             <color>W</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Legendary Creature — Wolf</type>
             <pt>2/2</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Tolsimir Wolfblood</reverse-related>
         </card>
         <card>
             <name>Wall</name>
             <set picURL="http://cdn.staticneo.com/w/mtg/3/36/Wall2.jpg">MIR</set>
-            <manacost></manacost>
+            <manacost />
             <type>Token Artifact Creature — Wall</type>
             <pt>0/2</pt>
             <tablerow>2</tablerow>
@@ -4026,7 +4026,7 @@ Sacrifice this creature: This creature deals 1 damage to target creature or play
             <name>Wall </name>
             <set picURL="http://media.wizards.com/2016/adhfianalodifdj2_EMA/en_biVLwMvOWF.png">EMA</set>
             <color>U</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Wall</type>
             <pt>5/5</pt>
             <tablerow>2</tablerow>
@@ -4037,7 +4037,7 @@ Sacrifice this creature: This creature deals 1 damage to target creature or play
         <card>
             <name>Wasp</name>
             <set picURL="http://magiccards.info/extras/token/tenth-edition/wasp.jpg">10E</set>
-            <manacost></manacost>
+            <manacost />
             <type>Token Artifact Creature — Insect</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
@@ -4049,11 +4049,11 @@ Sacrifice this creature: This creature deals 1 damage to target creature or play
             <name>Warrior</name>
             <set picURL="http://cdn.staticneo.com/w/mtg/9/95/Warrior.jpg">SOK</set>
             <color>R</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Warrior</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Rally the Horde</reverse-related>
         </card>
@@ -4063,11 +4063,11 @@ Sacrifice this creature: This creature deals 1 damage to target creature or play
             <set picURL="http://magiccards.info/extras/token/khans-of-tarkir/warrior-1.jpg">KTK</set>
             <set picURL="http://magiccards.info/extras/token/khans-of-tarkir/warrior-2.jpg">KTK</set>
             <color>W</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Warrior</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Herald of Anafenza</reverse-related>
             <reverse-related>Mardu Charm</reverse-related>
@@ -4079,11 +4079,11 @@ Sacrifice this creature: This creature deals 1 damage to target creature or play
             <name>Warrior  </name>
             <set picURL="http://magiccards.info/extras/token/fate-reforged/warrior.jpg">FRF</set>
             <color>B</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Warrior</type>
             <pt>2/1</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Mardu Strike Leader</reverse-related>
         </card>
@@ -4091,7 +4091,7 @@ Sacrifice this creature: This creature deals 1 damage to target creature or play
             <name>Weird</name>
             <set picURL="http://cdn.staticneo.com/w/mtg/a/ae/Weird.jpg">GPT</set>
             <color>U</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Weird</type>
             <pt>3/3</pt>
             <tablerow>2</tablerow>
@@ -4103,7 +4103,7 @@ Sacrifice this creature: This creature deals 1 damage to target creature or play
             <name>Whale</name>
             <set picURL="http://magiccards.info/extras/token/commander-2014/whale.jpg">C14</set>
             <color>U</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Whale</type>
             <pt>6/6</pt>
             <tablerow>2</tablerow>
@@ -4114,7 +4114,7 @@ Sacrifice this creature: This creature deals 1 damage to target creature or play
         <card>
             <name>Wirefly</name>
             <set picURL="http://cdn.staticneo.com/w/mtg/f/f5/Wirefly.jpg">DST</set>
-            <manacost></manacost>
+            <manacost />
             <type>Token Artifact Creature — Insect</type>
             <pt>2/2</pt>
             <tablerow>2</tablerow>
@@ -4139,11 +4139,11 @@ Sacrifice this creature: This creature deals 1 damage to target creature or play
             <set picURL="http://magiccards.info/extras/token/shadowmoor/wolf.jpg">SHM</set>
             <set picURL="http://magiccards.info/extras/token/lorwyn/wolf.jpg">LRW</set>
             <color>G</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Wolf</type>
             <pt>2/2</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Arlinn Kord</reverse-related>
             <reverse-related>Bestial Menace</reverse-related>
@@ -4157,8 +4157,8 @@ Sacrifice this creature: This creature deals 1 damage to target creature or play
             <reverse-related>Kessig Cagebreakers</reverse-related>
             <reverse-related>Master of the Wild Hunt</reverse-related>
             <reverse-related>Pack Guardian</reverse-related>
-            <reverse-related>Predator's Howl</reverse-related>
-            <reverse-related>Raised by Wolves</reverse-related>
+            <reverse-related count="3">Predator's Howl</reverse-related>
+            <reverse-related count="2">Raised by Wolves</reverse-related>
             <reverse-related>Silverfur Partisan</reverse-related>
             <reverse-related>Sword of Body and Mind</reverse-related>
             <reverse-related>Turntimber Ranger</reverse-related>
@@ -4172,7 +4172,7 @@ Sacrifice this creature: This creature deals 1 damage to target creature or play
             <name>Wolf </name>
             <set picURL="http://magiccards.info/extras/token/innistrad/wolf-1.jpg">ISD</set>
             <color>B</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Wolf</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
@@ -4184,7 +4184,7 @@ Sacrifice this creature: This creature deals 1 damage to target creature or play
             <name>Wolf  </name>
             <set picURL="http://i167.photobucket.com/albums/u148/Ruja/Magic%20Tokens/Coldsnap/4.jpg">CSP</set>
             <color>G</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Wolf</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
@@ -4196,7 +4196,7 @@ Sacrifice this creature: This creature deals 1 damage to target creature or play
             <name>Wolves of the Hunt</name>
             <set picURL="http://s8.postimg.org/f8l8pduxh/WOLVES_OF_THE_HUNT.jpg">M10</set>
             <color>G</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Wolf</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
@@ -4208,7 +4208,7 @@ Sacrifice this creature: This creature deals 1 damage to target creature or play
             <name>Wood</name>
             <set picURL="http://oi43.tinypic.com/2z6s4ly.jpg">MIR</set>
             <color>G</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Wall</type>
             <pt>0/1</pt>
             <tablerow>2</tablerow>
@@ -4224,11 +4224,11 @@ Sacrifice this creature: This creature deals 1 damage to target creature or play
             <set picURL="http://magiccards.info/extras/token/eventide/worm.jpg">EVE</set>
             <color>B</color>
             <color>G</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Worm</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Creakwood Liege</reverse-related>
             <reverse-related>Worm Harvest</reverse-related>
@@ -4240,13 +4240,13 @@ Sacrifice this creature: This creature deals 1 damage to target creature or play
             <set picURL="http://magiccards.info/extras/token/magic-2012/wurm.jpg">M12</set>
             <set picURL="http://magiccards.info/extras/token/player-rewards-2002/wurm.jpg">ODY</set>
             <color>G</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Wurm</type>
             <pt>6/6</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
-            <reverse-related>Crush of Wurms</reverse-related>
+            <reverse-related count="3">Crush of Wurms</reverse-related>
             <reverse-related>Garruk, Primal Hunter</reverse-related>
             <reverse-related>Roar of the Wurm</reverse-related>
             <reverse-related>Wurmweaver Coil</reverse-related>
@@ -4255,7 +4255,7 @@ Sacrifice this creature: This creature deals 1 damage to target creature or play
             <name>Wurm </name>
             <set picURL="http://magiccards.info/extras/token/commander-2014/wurm-2.jpg">C14</set>
             <set picURL="http://magiccards.info/extras/token/scars-of-mirrodin/wurm-2.jpg">SOM</set>
-            <manacost></manacost>
+            <manacost />
             <type>Token Artifact Creature — Wurm</type>
             <pt>3/3</pt>
             <tablerow>2</tablerow>
@@ -4267,7 +4267,7 @@ Sacrifice this creature: This creature deals 1 damage to target creature or play
             <name>Wurm  </name>
             <set picURL="http://magiccards.info/extras/token/commander-2014/wurm-1.jpg">C14</set>
             <set picURL="http://magiccards.info/extras/token/scars-of-mirrodin/wurm-1.jpg">SOM</set>
-            <manacost></manacost>
+            <manacost />
             <type>Token Artifact Creature — Wurm</type>
             <pt>3/3</pt>
             <tablerow>2</tablerow>
@@ -4279,7 +4279,7 @@ Sacrifice this creature: This creature deals 1 damage to target creature or play
             <name>Wurm   </name>
             <set picURL="http://cdn.staticneo.com/w/mtg/d/d9/Wurm3.jpg">APC</set>
             <color>B</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Wurm</type>
             <pt>6/6</pt>
             <tablerow>2</tablerow>
@@ -4291,7 +4291,7 @@ Sacrifice this creature: This creature deals 1 damage to target creature or play
             <name>Wurm    </name>
             <set picURL="http://magiccards.info/extras/token/return-to-ravnica/wurm.jpg">RTR</set>
             <color>G</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Wurm</type>
             <pt>5/5</pt>
             <tablerow>2</tablerow>
@@ -4305,11 +4305,11 @@ Sacrifice this creature: This creature deals 1 damage to target creature or play
             <name>Wurm     </name>
             <set picURL="http://cdn.staticneo.com/w/mtg/7/7e/Wurm2.jpg">FUT</set>
             <color>G</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Wurm</type>
             <pt>*/*</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Baru, Fist of Krosa</reverse-related>
             <reverse-related>Wurmcalling</reverse-related>
@@ -4345,14 +4345,14 @@ Sacrifice this creature: This creature deals 1 damage to target creature or play
             <set picURL="http://magiccards.info/extras/token/tenth-edition/zombie.jpg">10E</set>
             <set picURL="http://magiccards.info/extras/token/player-rewards-2002/zombie.jpg">ODY</set>
             <color>B</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Zombie</type>
             <pt>2/2</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Archdemon of Unx</reverse-related>
-            <reverse-related>Army of the Damned</reverse-related>
+            <reverse-related count="13">Army of the Damned</reverse-related>
             <reverse-related>Assemble the Rank and Vile</reverse-related>
             <reverse-related>Bridge from Below</reverse-related>
             <reverse-related>Cellar Door</reverse-related>
@@ -4370,9 +4370,9 @@ Sacrifice this creature: This creature deals 1 damage to target creature or play
             <reverse-related>From Under the Floorboards</reverse-related>
             <reverse-related>Ghoulcaller Gisa</reverse-related>
             <reverse-related>Ghoulcaller's Accomplice</reverse-related>
-            <reverse-related>Gisa's Bidding</reverse-related>
+            <reverse-related count="2">Gisa's Bidding</reverse-related>
             <reverse-related>Graf Harvest</reverse-related>
-            <reverse-related>Grave Titan</reverse-related>
+            <reverse-related count="2">Grave Titan</reverse-related>
             <reverse-related>Grixis Slavedriver</reverse-related>
             <reverse-related>Havengul Runebinder</reverse-related>
             <reverse-related>Kalitas, Traitor of Ghet</reverse-related>
@@ -4380,9 +4380,9 @@ Sacrifice this creature: This creature deals 1 damage to target creature or play
             <reverse-related>Liliana's Reaver</reverse-related>
             <reverse-related>Liliana, Heretical Healer</reverse-related>
             <reverse-related>Liliana, the Last Hope</reverse-related>
-            <reverse-related>Maalfeld Twins</reverse-related>
+            <reverse-related count="2">Maalfeld Twins</reverse-related>
             <reverse-related>Midnight Ritual</reverse-related>
-            <reverse-related>Moan of the Unhallowed</reverse-related>
+            <reverse-related count="2">Moan of the Unhallowed</reverse-related>
             <reverse-related>Necromancer's Covenant</reverse-related>
             <reverse-related>Necromancer's Stockpile</reverse-related>
             <reverse-related>Necromaster Dragon</reverse-related>
@@ -4391,7 +4391,7 @@ Sacrifice this creature: This creature deals 1 damage to target creature or play
             <reverse-related>Null Caller</reverse-related>
             <reverse-related>Oath of Liliana</reverse-related>
             <reverse-related>Overseer of the Damned</reverse-related>
-            <reverse-related>Rakshasa Gravecaller</reverse-related>
+            <reverse-related count="2">Rakshasa Gravecaller</reverse-related>
             <reverse-related>Reap the Seagraf</reverse-related>
             <reverse-related>Rise from the Tides</reverse-related>
             <reverse-related>Rotlung Reanimator</reverse-related>
@@ -4414,11 +4414,11 @@ Sacrifice this creature: This creature deals 1 damage to target creature or play
             <name>Zombie </name>
             <set picURL="http://magiccards.info/extras/token/born-of-the-gods/zombie.jpg">BNG</set>
             <color>B</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Enchantment Creature — Zombie</type>
             <pt>2/2</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Forlorn Pseudamma</reverse-related>
         </card>
@@ -4426,11 +4426,11 @@ Sacrifice this creature: This creature deals 1 damage to target creature or play
             <name>Zombie  </name>
             <set picURL="http://magiccards.info/extras/token/journey-into-nyx/zombie.jpg">JOU</set>
             <color>B</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Zombie</type>
             <pt>*/*</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Ritual of the Returned</reverse-related>
             <reverse-related>Soul Separator</reverse-related>
@@ -4439,11 +4439,11 @@ Sacrifice this creature: This creature deals 1 damage to target creature or play
             <name>Zombie   </name>
             <set picURL="http://magiccards.info/extras/token/commander-2014/zombie-1.jpg">C14</set>
             <color>U</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Zombie</type>
             <pt>*/*</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Stitcher Geralf</reverse-related>
         </card>
@@ -4451,11 +4451,11 @@ Sacrifice this creature: This creature deals 1 damage to target creature or play
             <name>Zombie Giant</name>
             <set picURL="http://magiccards.info/extras/token/zendikar/zombie-giant.jpg">ZEN</set>
             <color>B</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Zombie Giant</type>
             <pt>5/5</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Quest for the Gravelord</reverse-related>
         </card>
@@ -4463,11 +4463,11 @@ Sacrifice this creature: This creature deals 1 damage to target creature or play
             <name>Zombie Horror</name>
             <set picURL="http://magiccards.info/extras/token/dragons-of-tarkir/zombie-horror.jpg">DTK</set>
             <color>B</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Zombie Horror</type>
             <pt>*/*</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Corpseweft</reverse-related>
         </card>
@@ -4476,18 +4476,18 @@ Sacrifice this creature: This creature deals 1 damage to target creature or play
             <set picURL="http://magiccards.info/extras/token/alara-reborn/zombie-wizard.jpg">ARB</set>
             <color>U</color>
             <color>B</color>
-            <manacost></manacost>
+            <manacost />
             <type>Token Creature — Zombie Wizard</type>
             <pt>1/1</pt>
             <tablerow>2</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Lich Lord of Unx</reverse-related>
         </card>
         <card>
             <name>Ajani Steadfast (emblem)</name>
             <set picURL="http://media.wizards.com/images/magic/daily/arcana/0013_MTGM15_TOK_EN%20copy.png">M15</set>
-            <manacost></manacost>
+            <manacost />
             <type>Emblem — Ajani</type>
             <tablerow>1</tablerow>
             <text>If a source would deal damage to you or a planeswalker you control, prevent all but 1 of that damage.</text>
@@ -4497,7 +4497,7 @@ Sacrifice this creature: This creature deals 1 damage to target creature or play
         <card>
             <name>Arlinn Kord (emblem)</name>
             <set picURL="http://media.wizards.com/2016/aksdjciawolkcc0_soi/en_JJ0x2nMAKz.png">SOI</set>
-            <manacost></manacost>
+            <manacost />
             <type>Emblem — Arlinn</type>
             <tablerow>1</tablerow>
             <text>Creatures you control have haste and "{T}: This creature deals damage equal to its power to target creature or player."</text>
@@ -4508,7 +4508,7 @@ Sacrifice this creature: This creature deals 1 damage to target creature or play
         <card>
             <name>Chandra, Roaring Flame (emblem)</name>
             <set picURL="http://media.wizards.com/2015/images/daily/en_gjqxspbw14.png">ORI</set>
-            <manacost></manacost>
+            <manacost />
             <type>Emblem — Chandra</type>
             <tablerow>1</tablerow>
             <text>At the beginning of your upkeep, this emblem deals 3 damage to you.</text>
@@ -4518,7 +4518,7 @@ Sacrifice this creature: This creature deals 1 damage to target creature or play
         <card>
             <name>Chandra, Torch of Defiance (emblem)</name>
             <set picURL="http://media.wizards.com/2016/bVvMNuiu2i_KLD/en_hPjChGGcMo.png">KLD</set>
-            <manacost></manacost>
+            <manacost />
             <type>Emblem — Chandra</type>
             <tablerow>1</tablerow>
             <text>Whenever you cast a spell, this emblem deals 5 damage to target creature or player.</text>
@@ -4529,7 +4529,7 @@ Sacrifice this creature: This creature deals 1 damage to target creature or play
             <name>Dack Fayden (emblem)</name>
             <set picURL="http://media.wizards.com/2016/adhfianalodifdj2_EMA/en_KZQONbOfjg.png">EMA</set>
             <set picURL="http://magiccards.info/extras/token/conspiracy/emblem-dack-fayden.jpg">CNS</set>
-            <manacost></manacost>
+            <manacost />
             <type>Emblem — Dack</type>
             <tablerow>1</tablerow>
             <text>Whenever you cast a spell that targets one or more permanents, gain control of those permanents.</text>
@@ -4540,7 +4540,7 @@ Sacrifice this creature: This creature deals 1 damage to target creature or play
             <name>Daretti, Scrap Savant (emblem)</name>
             <set picURL="http://media.wizards.com/2016/bn8f9t2zc_C16/no0YB9HlIT_EN.png">C16</set>
             <set picURL="http://magiccards.info/extras/token/commander-2014/emblem-daretti.jpg">C14</set>
-            <manacost></manacost>
+            <manacost />
             <type>Emblem — Daretti</type>
             <tablerow>1</tablerow>
             <text>Whenever an artifact is put into your graveyard from the battlefield, return that card to the battlefield at the beginning of the next end step.</text>
@@ -4550,7 +4550,7 @@ Sacrifice this creature: This creature deals 1 damage to target creature or play
         <card>
             <name>Domri Rade (emblem)</name>
             <set picURL="http://magiccards.info/extras/token/gatecrash/emblem-domri-rade.jpg">GTC</set>
-            <manacost></manacost>
+            <manacost />
             <type>Emblem — Domri</type>
             <tablerow>1</tablerow>
             <text>Creatures you control have double strike, trample, hexproof, and haste.</text>
@@ -4560,7 +4560,7 @@ Sacrifice this creature: This creature deals 1 damage to target creature or play
         <card>
             <name>Dovin Baan (emblem)</name>
             <set picURL="http://media.wizards.com/2016/bVvMNuiu2i_KLD/en_TndzDeN0rh.png">KLD</set>
-            <manacost></manacost>
+            <manacost />
             <type>Emblem — Dovin</type>
             <tablerow>1</tablerow>
             <text>Your opponents can't untap more than two permanents during their untap steps.</text>
@@ -4571,7 +4571,7 @@ Sacrifice this creature: This creature deals 1 damage to target creature or play
             <name>Elspeth, Knight-Errant (emblem)</name>
             <set picURL="http://magiccards.info/extras/token/modern-event-deck/emblem-elspeth-knight-errant.jpg">MD1</set>
             <set picURL="http://magiccards.info/extras/token/modern-masters/emblem-elspeth-knight-errant.jpg">MMA</set>
-            <manacost></manacost>
+            <manacost />
             <type>Emblem — Elspeth</type>
             <tablerow>1</tablerow>
             <text>Artifacts, creatures, enchantments, and lands you control have indestructible.</text>
@@ -4581,7 +4581,7 @@ Sacrifice this creature: This creature deals 1 damage to target creature or play
         <card>
             <name>Elspeth, Sun's Champion (emblem)</name>
             <set picURL="http://magiccards.info/extras/token/theros/elspeth-suns-champion-emblem.jpg">THS</set>
-            <manacost></manacost>
+            <manacost />
             <type>Emblem — Elspeth</type>
             <tablerow>1</tablerow>
             <text>Creatures you control get +2/+2 and have flying.</text>
@@ -4591,7 +4591,7 @@ Sacrifice this creature: This creature deals 1 damage to target creature or play
         <card>
             <name>Garruk, Caller of Beasts (emblem)</name>
             <set picURL="http://magiccards.info/extras/token/magic-2014/emblem-garruk-caller-of-beasts.jpg">M14</set>
-            <manacost></manacost>
+            <manacost />
             <type>Emblem — Garruk</type>
             <tablerow>1</tablerow>
             <text>Whenever you cast a creature spell, you may search your library for a creature card, put it onto the battlefield, then shuffle your library.</text>
@@ -4601,7 +4601,7 @@ Sacrifice this creature: This creature deals 1 damage to target creature or play
         <card>
             <name>Garruk, Apex Predator (emblem)</name>
             <set picURL="http://media.wizards.com/images/magic/daily/arcana/0014_MTGM15_TOK_EN%20copy.png">M15</set>
-            <manacost></manacost>
+            <manacost />
             <type>Emblem — Garruk</type>
             <tablerow>1</tablerow>
             <text>Whenever a creature attacks you, it gets +5/+5 and gains trample until end of turn.</text>
@@ -4611,7 +4611,7 @@ Sacrifice this creature: This creature deals 1 damage to target creature or play
         <card>
             <name>Gideon, Ally of Zendikar (emblem)</name>
             <set picURL="http://media.wizards.com/2015/images/daily/jvSkttHcrm.png">BFZ</set>
-            <manacost></manacost>
+            <manacost />
             <type>Emblem — Gideon</type>
             <tablerow>1</tablerow>
             <text>Creatures you control get +1/+1.</text>
@@ -4621,7 +4621,7 @@ Sacrifice this creature: This creature deals 1 damage to target creature or play
         <card>
             <name>Jace, Telepath Unbound (emblem)</name>
             <set picURL="http://media.wizards.com/2015/images/daily/en_rri1iwnt1o.png">ORI</set>
-            <manacost></manacost>
+            <manacost />
             <type>Emblem — Jace</type>
             <tablerow>1</tablerow>
             <text>Whenever you cast a spell, target opponent puts the top five cards of his or her library into his or her graveyard.</text>
@@ -4631,7 +4631,7 @@ Sacrifice this creature: This creature deals 1 damage to target creature or play
         <card>
             <name>Jace, Unraveler of Secrets (emblem)</name>
             <set picURL="http://media.wizards.com/2016/aksdjciawolkcc0_soi/en_us6FYXzyW4.png">SOI</set>
-            <manacost></manacost>
+            <manacost />
             <type>Emblem — Jace</type>
             <tablerow>1</tablerow>
             <text>Whenever an opponent casts his or her first spell each turn, counter that spell.</text>
@@ -4641,7 +4641,7 @@ Sacrifice this creature: This creature deals 1 damage to target creature or play
         <card>
             <name>Kiora, the Crashing Wave (emblem)</name>
             <set picURL="http://magiccards.info/extras/token/born-of-the-gods/emblem-kiora-the-crashing-wave.jpg">BNG</set>
-            <manacost></manacost>
+            <manacost />
             <type>Emblem — Kiora</type>
             <tablerow>1</tablerow>
             <text>At the beginning of your end step, create a 9/9 blue Kraken creature token.</text>
@@ -4652,7 +4652,7 @@ Sacrifice this creature: This creature deals 1 damage to target creature or play
         <card>
             <name>Kiora, Master of the Depths (emblem)</name>
             <set picURL="http://media.wizards.com/2015/images/daily/BdrcxTuuOn.png">BFZ</set>
-            <manacost></manacost>
+            <manacost />
             <type>Emblem — Kiora</type>
             <tablerow>1</tablerow>
             <text>Whenever a creature enters the battlefield under your control, you may have it fight target creature.</text>
@@ -4662,7 +4662,7 @@ Sacrifice this creature: This creature deals 1 damage to target creature or play
         <card>
             <name>Koth of the Hammer (emblem)</name>
             <set picURL="http://magiccards.info/extras/token/duel-decks-venser-vs-koth/emblem-koth-of-the-hammer.jpg">DDI</set>
-            <manacost></manacost>
+            <manacost />
             <type>Emblem — Koth</type>
             <tablerow>1</tablerow>
             <text>Mountains you control have ‘Tap: This land deals 1 damage to target creature or player.'</text>
@@ -4673,7 +4673,7 @@ Sacrifice this creature: This creature deals 1 damage to target creature or play
             <name>Liliana of the Dark Realms (emblem)</name>
             <set picURL="http://magiccards.info/extras/token/magic-2014/emblem-liliana-of-the-dark-realms.jpg">M14</set>
             <set picURL="http://magiccards.info/extras/token/magic-2013/liliana-of-the-dark-realms-emblem.jpg">M13</set>
-            <manacost></manacost>
+            <manacost />
             <type>Emblem — Liliana</type>
             <tablerow>1</tablerow>
             <text>Swamps you control have ‘Tap: Add {B}{B}{B}{B} to your mana pool.'</text>
@@ -4683,7 +4683,7 @@ Sacrifice this creature: This creature deals 1 damage to target creature or play
         <card>
             <name>Liliana, Defiant Necromancer (emblem)</name>
             <set picURL="http://media.wizards.com/2015/images/daily/en_1j3ypa60bu.png">ORI</set>
-            <manacost></manacost>
+            <manacost />
             <type>Emblem — Liliana</type>
             <tablerow>1</tablerow>
             <text>Whenever a creature dies, return it to the battlefield under your control at the beginning of the next end step.</text>
@@ -4693,7 +4693,7 @@ Sacrifice this creature: This creature deals 1 damage to target creature or play
         <card>
             <name>Liliana, the Last Hope (emblem)</name>
             <set picURL="http://media.wizards.com/2016/ouhtebrpjwxcnw5_EMN/en_3uiqIat9XN.png">EMN</set>
-            <manacost></manacost>
+            <manacost />
             <type>Emblem — Liliana</type>
             <tablerow>1</tablerow>
             <text>At the beginning of your end step, create X 2/2 black Zombie creature tokens, where X is two plus the number of Zombies you control.</text>
@@ -4704,7 +4704,7 @@ Sacrifice this creature: This creature deals 1 damage to target creature or play
         <card>
             <name>Narset Transcendent (emblem)</name>
             <set picURL="http://magiccards.info/extras/token/dragons-of-tarkir/emblem-narset.jpg">DTK</set>
-            <manacost></manacost>
+            <manacost />
             <type>Emblem — Narset</type>
             <tablerow>1</tablerow>
             <text>Your opponents can't cast noncreature spells.</text>
@@ -4714,7 +4714,7 @@ Sacrifice this creature: This creature deals 1 damage to target creature or play
         <card>
             <name>Nissa, Vital Force (emblem)</name>
             <set picURL="http://media.wizards.com/2016/bVvMNuiu2i_KLD/en_L3HvZKtjG2.png">KLD</set>
-            <manacost></manacost>
+            <manacost />
             <type>Emblem — Nissa</type>
             <tablerow>1</tablerow>
             <text>Whenever a land enters the battlefield under your control, you may draw a card.</text>
@@ -4724,7 +4724,7 @@ Sacrifice this creature: This creature deals 1 damage to target creature or play
         <card>
             <name>Ob Nixilis of the Black Oath (emblem)</name>
             <set picURL="http://magiccards.info/extras/token/commander-2014/emblem-nixilis.jpg">C14</set>
-            <manacost></manacost>
+            <manacost />
             <type>Emblem — Nixilis</type>
             <tablerow>1</tablerow>
             <text>{1}{B}, Sacrifice a creature: You gain X life and draw X cards, where X is the sacrificed creature's power.</text>
@@ -4734,7 +4734,7 @@ Sacrifice this creature: This creature deals 1 damage to target creature or play
         <card>
             <name>Ob Nixilis Reignited (emblem)</name>
             <set picURL="http://media.wizards.com/2015/images/daily/ECytCRIuXD.png">BFZ</set>
-            <manacost></manacost>
+            <manacost />
             <type>Emblem — Nixilis</type>
             <tablerow>1</tablerow>
             <text>Whenever a player draws a card, you lose 2 life.</text>
@@ -4744,7 +4744,7 @@ Sacrifice this creature: This creature deals 1 damage to target creature or play
         <card>
             <name>Sarkhan, the Dragonspeaker (emblem)</name>
             <set picURL="http://magiccards.info/extras/token/khans-of-tarkir/emblem-sarkhan.jpg">KTK</set>
-            <manacost></manacost>
+            <manacost />
             <type>Emblem — Sarkhan</type>
             <tablerow>1</tablerow>
             <text>At the beginning of your draw step, draw two additional cards.
@@ -4755,7 +4755,7 @@ At the beginning of your end step, discard your hand.</text>
         <card>
             <name>Sorin, Lord of Innistrad (emblem)</name>
             <set picURL="http://magiccards.info/extras/token/dark-ascension/emblem.jpg">DKA</set>
-            <manacost></manacost>
+            <manacost />
             <type>Emblem — Sorin</type>
             <tablerow>1</tablerow>
             <text>Creatures you control get +1/+0.</text>
@@ -4765,7 +4765,7 @@ At the beginning of your end step, discard your hand.</text>
         <card>
             <name>Sorin, Solemn Visitor (emblem)</name>
             <set picURL="http://magiccards.info/extras/token/khans-of-tarkir/emblem-sorin.jpg">KTK</set>
-            <manacost></manacost>
+            <manacost />
             <type>Emblem — Sorin</type>
             <tablerow>1</tablerow>
             <text>At the beginning of each opponent's upkeep, that player sacrifices a creature.</text>
@@ -4775,7 +4775,7 @@ At the beginning of your end step, discard your hand.</text>
         <card>
             <name>Tamiyo, Field Researcher (emblem)</name>
             <set picURL="http://media.wizards.com/2016/ouhtebrpjwxcnw5_EMN/en_c30wTaXc7C.png">EMN</set>
-            <manacost></manacost>
+            <manacost />
             <type>Emblem — Tamiyo</type>
             <tablerow>1</tablerow>
             <text>You may cast nonland cards from your hand without paying their mana costs.</text>
@@ -4785,7 +4785,7 @@ At the beginning of your end step, discard your hand.</text>
         <card>
             <name>Tamiyo, the Moon Sage (emblem)</name>
             <set picURL="http://magiccards.info/extras/token/avacyn-restored/emblem-tamiyo-the-moon-sage.jpg">AVR</set>
-            <manacost></manacost>
+            <manacost />
             <type>Emblem — Tamiyo</type>
             <tablerow>1</tablerow>
             <text>You have no maximum hand size.
@@ -4796,7 +4796,7 @@ Whenever a card is put into your graveyard from anywhere, you may return it to y
         <card>
             <name>Teferi, Temporal Archmage (emblem)</name>
             <set picURL="http://magiccards.info/extras/token/commander-2014/emblem-teferi.jpg">C14</set>
-            <manacost></manacost>
+            <manacost />
             <type>Emblem — Teferi</type>
             <tablerow>1</tablerow>
             <text>You may activate loyalty abilities of planeswalkers you control on any player's turn any time you could cast an instant.</text>
@@ -4806,7 +4806,7 @@ Whenever a card is put into your graveyard from anywhere, you may return it to y
         <card>
             <name>Tezzeret the Schemer (emblem)</name>
             <set picURL="http://media.wizards.com/2016/c1lRLirbrl_AER/en_kbLsVYA78b.png">AER</set>
-            <manacost></manacost>
+            <manacost />
             <type>Emblem — Tezzeret</type>
             <tablerow>1</tablerow>
             <text>At the beginning of combat on your turn, target artifact you control becomes an artifact creature with base power and toughness 5/5.</text>
@@ -4816,7 +4816,7 @@ Whenever a card is put into your graveyard from anywhere, you may return it to y
         <card>
             <name>Venser, the Sojourner (emblem)</name>
             <set picURL="http://magiccards.info/extras/token/duel-decks-venser-vs-koth/emblem-venser-the-sojourner.jpg">DDI</set>
-            <manacost></manacost>
+            <manacost />
             <type>Emblem — Venser</type>
             <tablerow>1</tablerow>
             <text>Whenever you cast a spell, exile target permanent.</text>
@@ -4826,10 +4826,10 @@ Whenever a card is put into your graveyard from anywhere, you may return it to y
         <card>
             <name>Energy Reserve</name>
             <set picURL="http://i.imgur.com/D4xLMxC.png">KLD</set>
-            <manacost></manacost>
+            <manacost />
             <type>Counter</type>
             <tablerow>1</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Aether Hub</reverse-related>
             <reverse-related>Aether Meltdown</reverse-related>
@@ -4905,10 +4905,10 @@ Whenever a card is put into your graveyard from anywhere, you may return it to y
         <card>
             <name>Experience Counter</name>
             <set picURL="http://i.imgur.com/GgQ6lhZ.jpg">C15</set>
-            <manacost></manacost>
+            <manacost />
             <type>Counter</type>
             <tablerow>1</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Daxos the Returned</reverse-related>
             <reverse-related>Ezuri, Claw of Progress</reverse-related>
@@ -4919,10 +4919,10 @@ Whenever a card is put into your graveyard from anywhere, you may return it to y
         <card>
             <name>Poison Counter</name>
             <set picURL="http://magiccards.info/extras/token/new-phyrexia/poison-counter.jpg">NPH</set>
-            <manacost></manacost>
+            <manacost />
             <type>Counter</type>
             <tablerow>1</tablerow>
-            <text></text>
+            <text />
             <token>1</token>
             <reverse-related>Blackcleave Goblin</reverse-related>
             <reverse-related>Blight Mamba</reverse-related>
@@ -4999,7 +4999,7 @@ Whenever a card is put into your graveyard from anywhere, you may return it to y
         <card>
             <name>The Monarch</name>
             <set picURL="http://media.wizards.com/2016/azetllnwjpxztp2b_CN2/en_OFPgMTjwcu.png">CN2</set>
-            <manacost></manacost>
+            <manacost />
             <type>State</type>
             <tablerow>1</tablerow>
             <text>At the beginning of your end step, draw a card.


### PR DESCRIPTION
Cards that create multiple of a single type of token should be designated as such for future functionality.

ex: `Lingering Souls` creates 2 spirit tokens.  It now is stored as: `<reverse-related count="2">Lingering Souls</reverse-related>`