### PR TITLE
Make Ajani's Pridemade token unique

### DIFF
--- a/tokens.xml
+++ b/tokens.xml
@@ -38,7 +38,7 @@
             <tablerow>2</tablerow>
         </card>
         <card>
-            <name>Ajani's Pridemate</name>
+            <name>Ajani's Pridemate </name>
             <text>Whenever you gain life, put a +1/+1 counter on Ajani's Pridemate.</text>
             <prop>
                 <colors>W</colors>


### PR DESCRIPTION
fix https://github.com/Cockatrice/Magic-Token/issues/66

Problem was that the actual card with the same name wasn't displayed anymore.
Used the same workaround we have for several instances of different Soldier tokens for example by appending space characters to the name.