### PR TITLE
fix xsd link

### DIFF
--- a/tokens.xml
+++ b/tokens.xml
@@ -4,7 +4,7 @@
     We have made a new user-editable file for token modifications.
     Currently this file is "TK.xml" and can be found in your customsets directory.
 -->
-<cockatrice_carddatabase version="4" xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/Cockatrice/Cockatrice/master/doc/cards.xsd">
+<cockatrice_carddatabase version="4" xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/Cockatrice/Cockatrice/master/doc/carddatabase_v4/cards.xsd">
     <cards>
         <!--
         <card>


### PR DESCRIPTION
Now that xsd files for v3 and v4 of Cockatrice card databases are available, the link changed in the upstream repo.