### PR TITLE
README: add dynamic version badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Magic-Token
+Magic-Token [![](https://img.shields.io/badge/dynamic/xml.svg?label=version&url=https%3A%2F%2Fraw.githubusercontent.com%2FCockatrice%2FMagic-Token%2Fmaster%2Ftokens.xml&query=%2F%2FsourceVersion)](https://github.com/Cockatrice/Magic-Token/blob/master/tokens.xml)
 =================
 
 This repo contains tokens information in [Cockatrice](https://github.com/cockatrice/cockatrice)'s XML card database format for Magic: The Gathering


### PR DESCRIPTION
README now always shows the current version number

Preview: https://github.com/cockatrice/magic-token/tree/tooomm-patch-1#magic-token-


<br>

I'm still a fan of using a standard version number in semver style with its advantages ([and you use them for releases already...](https://github.com/cockatrice/magic-token/releases)). The date belongs to the currently empty `createdAt` key imo. In case that changes, I would display the date next to the version badge as well.