### PR TITLE
Cleanup erroneous relationships

### DIFF
--- a/tokens.xml
+++ b/tokens.xml
@@ -1052,7 +1052,7 @@ Creature tokens you control have flying and vigilance.</text>
             <set picURL="https://media.wizards.com/2020/iko/en_kfvZCnHFzR.png">IKO</set>
             <set picURL="https://img.scryfall.com/cards/large/front/b/3/b31f1580-5bba-4cef-b0c8-f2837a597b7d.jpg">M19</set>
             <set picURL="https://img.scryfall.com/cards/large/front/a/f/af0086cd-56b5-450e-818c-e54f45d1a104.jpg">AKH</set>
-            <reverse-related count="3" exclude="exclude">Ajani, Adversary of Tyrants</reverse-related>
+            <reverse-related count="3">Ajani, Adversary of Tyrants (Emblem)</reverse-related>
             <reverse-related count="2">Cubwarden</reverse-related>
             <reverse-related count="2">Leonin Warleader</reverse-related>
             <reverse-related count="2">Pride Sovereign</reverse-related>
@@ -8460,7 +8460,7 @@ Sacrifice this creature: This creature deals 1 damage to target creature or play
             <reverse-related>Liliana, Death's Majesty</reverse-related>
             <reverse-related>Liliana, Dreadhorde General</reverse-related>
             <reverse-related>Liliana, Heretical Healer</reverse-related>
-            <reverse-related count="x">Liliana, the Last Hope</reverse-related>
+            <reverse-related count="x">Liliana, the Last Hope (Emblem)</reverse-related>
             <reverse-related count="2">Maalfeld Twins</reverse-related>
             <reverse-related>Magus of the Bridge</reverse-related>
             <reverse-related count="x">Midnight Ritual</reverse-related>
@@ -9234,7 +9234,7 @@ Cradle of the Death God — Create The Atropal, a legendary 4/4 black God Horror
                 <maintype>Emblem</maintype>
             </prop>
             <set picURL="https://media.wizards.com/2016/ouhtebrpjwxcnw5_EMN/en_3uiqIat9XN.png">EMN</set>
-            <related>Zombie</related>
+            <related count="x">Zombie</related>
             <reverse-related exclude="exclude">Liliana, the Last Hope</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>

--- a/tokens.xml
+++ b/tokens.xml
@@ -679,7 +679,6 @@ Creature tokens you control have flying and vigilance.</text>
                 <pt>4/4</pt>
             </prop>
             <set picURL="https://media.wizards.com/2018/rna/en_gcngyJXapg.png">RNA</set>
-            <reverse-related>Domri, Chaos Bringer</reverse-related>
             <reverse-related>Domri, Chaos Bringer (Emblem)</reverse-related>
             <reverse-related>Thrash // Threat</reverse-related>
             <token>1</token>

--- a/tokens.xml
+++ b/tokens.xml
@@ -8865,7 +8865,6 @@ Cradle of the Death God — Create The Atropal, a legendary 4/4 black God Horror
                 <maintype>Emblem</maintype>
             </prop>
             <set picURL="https://img.scryfall.com/cards/large/front/1/c/1c97e5b2-a024-4aa7-a9b8-45f441aad138.jpg">M19</set>
-            <related count="3">Cat   </related>
             <reverse-related>Ajani, Adversary of Tyrants</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -9234,7 +9233,6 @@ Cradle of the Death God — Create The Atropal, a legendary 4/4 black God Horror
                 <maintype>Emblem</maintype>
             </prop>
             <set picURL="https://media.wizards.com/2016/ouhtebrpjwxcnw5_EMN/en_3uiqIat9XN.png">EMN</set>
-            <related count="x">Zombie</related>
             <reverse-related exclude="exclude">Liliana, the Last Hope</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>

--- a/tokens.xml
+++ b/tokens.xml
@@ -8459,7 +8459,7 @@ Sacrifice this creature: This creature deals 1 damage to target creature or play
             <reverse-related>Liliana, Death's Majesty</reverse-related>
             <reverse-related>Liliana, Dreadhorde General</reverse-related>
             <reverse-related>Liliana, Heretical Healer</reverse-related>
-            <reverse-related count="x">Liliana, the Last Hope (Emblem)</reverse-related>
+            <reverse-related count="x=2">Liliana, the Last Hope (Emblem)</reverse-related>
             <reverse-related count="2">Maalfeld Twins</reverse-related>
             <reverse-related>Magus of the Bridge</reverse-related>
             <reverse-related count="x">Midnight Ritual</reverse-related>


### PR DESCRIPTION
It was not just Kiora that needed a fix. ~~There are probably still more.~~

This also removes double linkings from both directions for some tokens via `related` and `reverse-related`.

<br>

Linking https://github.com/Cockatrice/Magic-Token/commit/0aa71e3d538ce355fe1b1d7ca9539a3510d08e7e