### PR TITLE
fix conflict with Unquenchable Fury from NEO

### DIFF
--- a/challenge_tokens.xml
+++ b/challenge_tokens.xml
@@ -134,7 +134,7 @@ Hero's Reward — When Refreshing Elixir is put into a graveyard from anywhere, 
             <text>Each player may sacrifice an artifact or enchantment. Impulsive Destruction deals 3 damage to each player who didn't sacrifice a permanent this way.</text>
         </card>
         <card>
-            <name>Unquenchable Fury</name>
+            <name>Unquenchable Fury </name>
             <set picURL="http://deckmaster.info/images/cards/BNG/-66710-hr.jpg">CTH</set>
             <color></color>
             <manacost></manacost>


### PR DESCRIPTION
challenge token names are not reserved, so we have to keep an eye out for similar issues in future
https://markrosewater.tumblr.com/post/675628467162873856/is-there-a-reason-why-you-printed-unquenchable