### PR TITLE
change set of the serpent generator token to legends

### DIFF
--- a/tokens.xml
+++ b/tokens.xml
@@ -6885,7 +6885,7 @@ Equip {1}</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://cdn.staticneo.com/w/mtg/0/01/Snake3.jpg">MED</set>
+            <set picURL="https://cdn.staticneo.com/w/mtg/0/01/Snake3.jpg">LEG</set>
             <reverse-related>Serpent Generator</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>


### PR DESCRIPTION
for some reason this used to be med which probably wasn't even an existing set code when we added the token?