### PR TITLE
CI: Adjust + document version bump workflow

### DIFF
--- a/.github/workflows/updateversion.yml
+++ b/.github/workflows/updateversion.yml
@@ -1,11 +1,11 @@
-name: Update version on pr approval
+name: Update version on PR approval
 
 # Usage of this automated version bump workflow
 #
 # If there is a new PR with valid changes and additions, there are two ways to let the CI run before merging:
-#  a) Approve the changes via the PR review feature.
-#     In case you want to approve the PR, but need to skip the version update, let the bot know. ("@github-actions :x:")
-#  b) Since PR creators can not approve their own changes, they need to add a review comment requesting the bot. ("@github-actions :ship:")
+#  a) Approve the changes via the 'PR review' feature.
+#     In case you want to approve the PR without updating the version, let the bot know. ("@github-actions :x:")
+#  b) Since PR creators can not approve their own changes, they need to add a 'review comment' requesting the bot. ("@github-actions :ship:")
 #
 # Note: Only repo members can trigger this.
 
@@ -21,18 +21,23 @@ jobs:
         ( github.event.review.author_association == 'OWNER' ||
           github.event.review.author_association == 'MEMBER'
         ) &&
-        ! contains( github.event.review.body, '@github-actions :x:' )
+        ( ! contains( github.event.review.body, '@github-actions :x:' ) ||
+          ! contains( github.event.review.body, '@github-actions ❌' )
+        )
       ) ||
       ( github.event_name == 'pull_request_review' &&
         ( github.event.review.author_association == 'OWNER' ||
           github.event.review.author_association == 'MEMBER'
         ) &&
-        contains( github.event.review.body, '@github-actions :ship:' )
+        ( contains( github.event.review.body, '@github-actions :ship:' ) ||
+          contains( github.event.review.body, '@github-actions 🚢' )
+        )
       )
     runs-on: ubuntu-latest
     steps:
-      - name: Get proper pr info
+      - name: Get proper PR info
         id: configure
+        shell: bash
         env:
           EVENT: ${{github.event_name}}
           NUMBER: ${{github.event.issue.number}}

--- a/.github/workflows/updateversion.yml
+++ b/.github/workflows/updateversion.yml
@@ -12,8 +12,6 @@ name: Update version on pr approval
 on:
   pull_request_review:
     types: [submitted]
-  pull_request_review_comment:
-    types: [created]
 
 jobs:
   update_version:
@@ -25,7 +23,7 @@ jobs:
         ) &&
         ! contains( github.event.review.body, '@github-actions :x:' )
       ) ||
-      ( github.event_name == 'pull_request_review_comment' &&
+      ( github.event_name == 'pull_request_review' &&
         ( github.event.review.author_association == 'OWNER' ||
           github.event.review.author_association == 'MEMBER'
         ) &&

--- a/.github/workflows/updateversion.yml
+++ b/.github/workflows/updateversion.yml
@@ -12,6 +12,8 @@ name: Update version on pr approval
 on:
   pull_request_review:
     types: [submitted]
+  pull_request_review_comment:
+    types: [created]
 
 jobs:
   update_version:
@@ -23,7 +25,7 @@ jobs:
         ) &&
         ! contains( github.event.review.body, '@github-actions :x:' )
       ) ||
-      ( github.event_name == 'pull_request_review' &&
+      ( github.event_name == 'pull_request_review_comment' &&
         ( github.event.review.author_association == 'OWNER' ||
           github.event.review.author_association == 'MEMBER'
         ) &&

--- a/.github/workflows/updateversion.yml
+++ b/.github/workflows/updateversion.yml
@@ -1,10 +1,17 @@
 name: Update version on pr approval
 
+# Usage of this automated version bump workflow
+#
+# If there is a new PR with valid changes and additions, there are two ways to let the CI run before merging:
+#  a) Approve the changes via the PR review feature.
+#     In case you want to approve the PR, but need to skip the version update, let the bot know. ("@github-actions :x:")
+#  b) Since PR creators can not approve their own changes, they need to add a review comment requesting the bot. ("@github-actions :ship:")
+#
+# Note: Only repo members can trigger this.
+
 on:
   pull_request_review:
     types: [submitted]
-  issue_comment:
-    types: [created]
 
 jobs:
   update_version:
@@ -14,14 +21,13 @@ jobs:
         ( github.event.review.author_association == 'OWNER' ||
           github.event.review.author_association == 'MEMBER'
         ) &&
-        ! contains( github.event.review.body, '@github-actions noop' )
+        ! contains( github.event.review.body, '@github-actions :x:' )
       ) ||
-      ( github.event_name == 'issue_comment' &&
-        github.event.issue.pull_request &&
-        ( github.event.comment.author_association == 'OWNER' ||
-          github.event.comment.author_association == 'MEMBER'
+      ( github.event_name == 'pull_request_review' &&
+        ( github.event.review.author_association == 'OWNER' ||
+          github.event.review.author_association == 'MEMBER'
         ) &&
-        endsWith( github.event.comment.body, '@github-actions update version' )
+        contains( github.event.review.body, '@github-actions :ship:' )
       )
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Changes:
- Little doc about how this works.
- Do not trigger on every comment written in all repo, but only on *submitted reviews*.
    - In case the PR creator themselves need to trigger the workflow, they can submit a *review comment* on their own PR.
- Changed keywords to ❌ and 🚢

<br>

TODO
- [ ] Update https://github.com/Cockatrice/Magic-Token/wiki/Token-updating-process-flow