### PR TITLE
Update Token Links to Use API calls

### DIFF
--- a/tokens.xml
+++ b/tokens.xml
@@ -40,7 +40,7 @@
                 <cmc>0</cmc>
                 <pt>4/4</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/7/1/71dc8556-a658-40e1-8a93-6a62af208a28.jpg">HOU</set>
+            <set picURL="https://api.scryfall.com/cards/71dc8556-a658-40e1-8a93-6a62af208a28?format=image">HOU</set>
             <reverse-related>Adorned Pouncer</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -55,7 +55,7 @@
                 <maintype>Creature</maintype>
                 <pt>2/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/b/0/b0819e8e-fb7e-43c7-a7cf-d768f43193ac.jpg?1592515934">M20</set>
+            <set picURL="https://api.scryfall.com/cards/b0819e8e-fb7e-43c7-a7cf-d768f43193ac?format=image">M20</set>
             <reverse-related>Ajani, Strength of the Pride</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -71,8 +71,8 @@ When Angel of Sanctions enters the battlefield, you may exile target nonland per
                 <cmc>0</cmc>
                 <pt>3/4</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/8/a80e1cab-ff67-459f-ab64-2c340a8e36ac.jpg?1572370656">C19</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/1/a1786cb3-6f38-4f10-b5f1-8feb20e3baaf.jpg">AKH</set>
+            <set picURL="https://api.scryfall.com/cards/a80e1cab-ff67-459f-ab64-2c340a8e36ac?format=image">C19</set>
+            <set picURL="https://api.scryfall.com/cards/a1786cb3-6f38-4f10-b5f1-8feb20e3baaf?format=image">AKH</set>
             <reverse-related>Angel of Sanctions</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -87,27 +87,27 @@ When Angel of Sanctions enters the battlefield, you may exile target nonland per
                 <cmc>0</cmc>
                 <pt>4/4</pt>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/9/e/9efb5dbc-673b-4ea0-89b3-2c9bb8047816.jpg?1675905854">ONC</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/e/6/e6dd9a8a-3b80-4c1c-9d44-7f998164dbcc.jpg?1641599832">VOC</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/f/7/f7c65b6a-9c63-4604-b7db-d75772799616.jpg?1608908406">CMR</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/f/f/ff0335da-631f-46b8-bfa1-b2f210c91f5f.jpg?1598311447">2XM</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/9/e/9e12d954-3ec2-46e3-b01f-1fd63159e8a4.jpg?1594733473">M21</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/2/9/29d42a00-299d-47d3-ba03-e63812d57931.jpg?1591319106">C20</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/6/a/6ac609aa-49d1-4330-b718-a90b0560da52.jpg?1592709988">C18</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/6/1671013a-2c15-44f0-b4bc-057eb5f727db.jpg?1562701916">A25</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/back/e/2/e2235007-b02e-463b-95e1-a8bea74a0f9d.jpg?1571508092">UST</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/6/2/6277af10-b10b-450b-9d42-54c978337931.jpg?1562841180">MM3</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/b/d/bdb975fe-ac30-4249-bb55-7efb64645e4d.jpg?1562086880">SOI</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/8/a/8adb32a4-6a42-41e9-a1ce-9502e391620a.jpg?1562857270">C15</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/1/a1ce74d5-ec65-44e8-b6c2-3f70b9fc3dbb.jpg">ORI</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/9/c/9c8fe0d7-5c40-45fe-b3d8-47852380845e.jpg">C14</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/8/2/826320b7-4ccf-4ace-8c2c-15052b6bad73.jpg">M14</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/7/1/71766a5a-ce00-4e48-b4f6-0d1a7f5b2691.jpg">GTC</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/6/8/68dd1682-a5d5-4323-b876-66a86c311c43.jpg">AVR</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/0/a0d7d857-2a54-4d0e-a97c-11400053194c.jpg">ISD</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/f/1fc37484-b58b-4a42-9281-b4272dc7c872.jpg">ZEN</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/9/d902520e-b4ed-4805-9f64-096acf7c5f31.jpg">CON</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/7/c7f3264a-7b4a-4fef-af73-d4241742a4e8.jpg">P04</set>
+            <set picURL="https://api.scryfall.com/cards/9efb5dbc-673b-4ea0-89b3-2c9bb8047816?format=image">ONC</set>
+            <set picURL="https://api.scryfall.com/cards/e6dd9a8a-3b80-4c1c-9d44-7f998164dbcc?format=image">VOC</set>
+            <set picURL="https://api.scryfall.com/cards/f7c65b6a-9c63-4604-b7db-d75772799616?format=image">CMR</set>
+            <set picURL="https://api.scryfall.com/cards/ff0335da-631f-46b8-bfa1-b2f210c91f5f?format=image">2XM</set>
+            <set picURL="https://api.scryfall.com/cards/9e12d954-3ec2-46e3-b01f-1fd63159e8a4?format=image">M21</set>
+            <set picURL="https://api.scryfall.com/cards/29d42a00-299d-47d3-ba03-e63812d57931?format=image">C20</set>
+            <set picURL="https://api.scryfall.com/cards/6ac609aa-49d1-4330-b718-a90b0560da52?format=image">C18</set>
+            <set picURL="https://api.scryfall.com/cards/1671013a-2c15-44f0-b4bc-057eb5f727db?format=image">A25</set>
+            <set picURL="https://api.scryfall.com/cards/e2235007-b02e-463b-95e1-a8bea74a0f9d?format=image&amp;face=back">UST</set>
+            <set picURL="https://api.scryfall.com/cards/6277af10-b10b-450b-9d42-54c978337931?format=image">MM3</set>
+            <set picURL="https://api.scryfall.com/cards/bdb975fe-ac30-4249-bb55-7efb64645e4d?format=image">SOI</set>
+            <set picURL="https://api.scryfall.com/cards/8adb32a4-6a42-41e9-a1ce-9502e391620a?format=image">C15</set>
+            <set picURL="https://api.scryfall.com/cards/a1ce74d5-ec65-44e8-b6c2-3f70b9fc3dbb?format=image">ORI</set>
+            <set picURL="https://api.scryfall.com/cards/9c8fe0d7-5c40-45fe-b3d8-47852380845e?format=image">C14</set>
+            <set picURL="https://api.scryfall.com/cards/826320b7-4ccf-4ace-8c2c-15052b6bad73?format=image">M14</set>
+            <set picURL="https://api.scryfall.com/cards/71766a5a-ce00-4e48-b4f6-0d1a7f5b2691?format=image">GTC</set>
+            <set picURL="https://api.scryfall.com/cards/68dd1682-a5d5-4323-b876-66a86c311c43?format=image">AVR</set>
+            <set picURL="https://api.scryfall.com/cards/a0d7d857-2a54-4d0e-a97c-11400053194c?format=image">ISD</set>
+            <set picURL="https://api.scryfall.com/cards/1fc37484-b58b-4a42-9281-b4272dc7c872?format=image">ZEN</set>
+            <set picURL="https://api.scryfall.com/cards/d902520e-b4ed-4805-9f64-096acf7c5f31?format=image">CON</set>
+            <set picURL="https://api.scryfall.com/cards/c7f3264a-7b4a-4fef-af73-d4241742a4e8?format=image">P04</set>
             <reverse-related>Angelic Accord</reverse-related>
             <reverse-related>Angelic Ascension</reverse-related>
             <reverse-related>Angelic Favor</reverse-related>
@@ -153,9 +153,9 @@ When Angel of Sanctions enters the battlefield, you may exile target nonland per
                 <cmc>0</cmc>
                 <pt>3/3</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/3/9/39bae778-0dee-47d5-a7cd-f2be11b5e79b.jpg?1650819867">SNC</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/3/2/323dd323-2ca2-4c85-9ef6-34341cd40d96.jpg?1626138901">AFR</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/9/6/96f407ef-2b08-45e9-a45e-128cf0a63839.jpg">OGW</set>
+            <set picURL="https://api.scryfall.com/cards/39bae778-0dee-47d5-a7cd-f2be11b5e79b?format=image">SNC</set>
+            <set picURL="https://api.scryfall.com/cards/323dd323-2ca2-4c85-9ef6-34341cd40d96?format=image">AFR</set>
+            <set picURL="https://api.scryfall.com/cards/96f407ef-2b08-45e9-a45e-128cf0a63839?format=image">OGW</set>
             <reverse-related count="5">Elspeth Resplendent</reverse-related>
             <reverse-related>Linvala, the Preserver</reverse-related>
             <reverse-related count="x=3">Soul of Emancipation</reverse-related>
@@ -173,13 +173,13 @@ When Angel of Sanctions enters the battlefield, you may exile target nonland per
                 <cmc>0</cmc>
                 <pt>4/4</pt>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/0/d/0dd269c7-1333-470d-b8ef-e54add09b350.jpg?1675905855">ONC</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/f/8/f8ed0c17-c5e4-4d78-8eee-34c57dd7ce55.jpg?1662835074">DMU</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/f/f/ff898688-0a49-4411-85f4-dddaa40788b5.jpg?1644543270">NEC</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/9/1/91808554-23ab-44f9-92a1-87ee7d58cd9a.jpg?1563073000">MH1</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/b/1/b16b81e0-5525-4be3-96db-807146fdc5b3.jpg?1557575869">WAR</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/c/acb271a8-68bb-45e6-9f99-568479e92ea0.jpg?1572892475">GRN</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/c/dc31e017-81e6-43bf-bf8e-ea0faca5d9b7.jpg">M19</set>
+            <set picURL="https://api.scryfall.com/cards/0dd269c7-1333-470d-b8ef-e54add09b350?format=image">ONC</set>
+            <set picURL="https://api.scryfall.com/cards/f8ed0c17-c5e4-4d78-8eee-34c57dd7ce55?format=image">DMU</set>
+            <set picURL="https://api.scryfall.com/cards/ff898688-0a49-4411-85f4-dddaa40788b5?format=image">NEC</set>
+            <set picURL="https://api.scryfall.com/cards/91808554-23ab-44f9-92a1-87ee7d58cd9a?format=image">MH1</set>
+            <set picURL="https://api.scryfall.com/cards/b16b81e0-5525-4be3-96db-807146fdc5b3?format=image">WAR</set>
+            <set picURL="https://api.scryfall.com/cards/acb271a8-68bb-45e6-9f99-568479e92ea0?format=image">GRN</set>
+            <set picURL="https://api.scryfall.com/cards/dc31e017-81e6-43bf-bf8e-ea0faca5d9b7?format=image">M19</set>
             <reverse-related count="x">Divine Visitation</reverse-related>
             <reverse-related count="x" exclude="exclude">Finale of Glory</reverse-related>
             <reverse-related>Historian's Boon</reverse-related>
@@ -203,8 +203,8 @@ When Angel of Sanctions enters the battlefield, you may exile target nonland per
                 <cmc>0</cmc>
                 <pt>4/4</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/2/a2db6fe1-b6ec-43ca-933f-dbab4cd08064.jpg?1654172678">CLB</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/9/1/91098481-46c2-49bf-8123-e9cab2f22b84.jpg?1604194613">ZNR</set>
+            <set picURL="https://api.scryfall.com/cards/a2db6fe1-b6ec-43ca-933f-dbab4cd08064?format=image">CLB</set>
+            <set picURL="https://api.scryfall.com/cards/91098481-46c2-49bf-8123-e9cab2f22b84?format=image">ZNR</set>
             <reverse-related count="2">Emeria's Call</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -219,7 +219,7 @@ When Angel of Sanctions enters the battlefield, you may exile target nonland per
                 <cmc>0</cmc>
                 <pt>4/4</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/3/b/3bd871a3-3802-4bdc-8033-3ecfd01c0449.jpg?1615686143">KHM</set>
+            <set picURL="https://api.scryfall.com/cards/3bd871a3-3802-4bdc-8033-3ecfd01c0449?format=image">KHM</set>
             <reverse-related>Firja's Retribution</reverse-related>
             <reverse-related>Great Hall of Starnheim</reverse-related>
             <reverse-related count="x=1">Starnheim Unleashed</reverse-related>
@@ -237,7 +237,7 @@ When Angel of Sanctions enters the battlefield, you may exile target nonland per
                 <cmc>0</cmc>
                 <pt>1/3</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/9/8/98956e73-04e4-4d7f-bda5-cfa78eb71350.jpg">AKH</set>
+            <set picURL="https://api.scryfall.com/cards/98956e73-04e4-4d7f-bda5-cfa78eb71350?format=image">AKH</set>
             <reverse-related>Anointer Priest</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -251,9 +251,9 @@ When Angel of Sanctions enters the battlefield, you may exile target nonland per
                 <cmc>0</cmc>
                 <pt>3/3</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/7/17e0924c-e4b7-482d-9076-1d3b8ff09e9b.jpg?1641306040">TSR</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/e/e/ee2d434d-5d9b-4475-b421-6d004c988997.jpg?1598311661">2XM</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/8/3/8343e00c-5fc6-46a0-a238-3759338dced4.jpg">C14</set>
+            <set picURL="https://api.scryfall.com/cards/17e0924c-e4b7-482d-9076-1d3b8ff09e9b?format=image">TSR</set>
+            <set picURL="https://api.scryfall.com/cards/ee2d434d-5d9b-4475-b421-6d004c988997?format=image">2XM</set>
+            <set picURL="https://api.scryfall.com/cards/8343e00c-5fc6-46a0-a238-3759338dced4?format=image">C14</set>
             <reverse-related>Pongify</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -269,7 +269,7 @@ Pay 3 life: Arco-Flagellant gains indestructible until end of turn.</text>
                 <cmc>0</cmc>
                 <pt>3/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/c/acb3325d-0b43-471b-9311-1c5ba14b06cf.jpg?1663566358">40K</set>
+            <set picURL="https://api.scryfall.com/cards/acb3325d-0b43-471b-9311-1c5ba14b06cf?format=image">40K</set>
             <reverse-related count="x">Arco-Flagellant</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -283,7 +283,7 @@ Pay 3 life: Arco-Flagellant gains indestructible until end of turn.</text>
                 <cmc>0</cmc>
                 <pt>4/4</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/a/0affd414-f774-48d1-af9e-bff74e58e1ca.jpg">ORI</set>
+            <set picURL="https://api.scryfall.com/cards/0affd414-f774-48d1-af9e-bff74e58e1ca?format=image">ORI</set>
             <reverse-related>Nissa, Sage Animist</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -298,9 +298,9 @@ Pay 3 life: Arco-Flagellant gains indestructible until end of turn.</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/4/4/4401437c-23ea-44ac-a8e7-eb033e1d61eb.jpg?1572370679">C19</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/3/a3960d63-168d-4d08-a10b-3331194fdc36.jpg">DDM</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/8/9/89eb9f92-d189-4438-b6fe-cb253055d63e.jpg">RTR</set>
+            <set picURL="https://api.scryfall.com/cards/4401437c-23ea-44ac-a8e7-eb033e1d61eb?format=image">C19</set>
+            <set picURL="https://api.scryfall.com/cards/a3960d63-168d-4d08-a10b-3331194fdc36?format=image">DDM</set>
+            <set picURL="https://api.scryfall.com/cards/89eb9f92-d189-4438-b6fe-cb253055d63e?format=image">RTR</set>
             <reverse-related count="3">Vraska the Unseen</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -315,7 +315,7 @@ Pay 3 life: Arco-Flagellant gains indestructible until end of turn.</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/f/5/f577d422-59d7-43ab-a822-2d73d47e61dd.jpg?1561897509">CN2</set>
+            <set picURL="https://api.scryfall.com/cards/f577d422-59d7-43ab-a822-2d73d47e61dd?format=image">CN2</set>
             <reverse-related>Queen Marchesa</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -331,7 +331,7 @@ Whenever this creature deals damage to a planeswalker, destroy that planeswalker
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/b/7/b7e997ac-5a4a-4555-9b37-06c25a5db356.jpg?1557575904">WAR</set>
+            <set picURL="https://api.scryfall.com/cards/b7e997ac-5a4a-4555-9b37-06c25a5db356?format=image">WAR</set>
             <reverse-related>Vraska, Swarm's Eminence</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -344,7 +344,7 @@ Whenever this creature deals damage to a planeswalker, destroy that planeswalker
                 <cmc>0</cmc>
                 <pt>2/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/e/7/e72daa68-0680-431c-a616-b3693fd58813.jpg?1641306045">TSR</set>
+            <set picURL="https://api.scryfall.com/cards/e72daa68-0680-431c-a616-b3693fd58813?format=image">TSR</set>
             <reverse-related>Urza's Factory</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -359,7 +359,7 @@ Whenever this creature deals damage to a planeswalker, destroy that planeswalker
                 <cmc>0</cmc>
                 <pt>2/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/9/3/93bc9e79-88c8-436b-94f7-17b349baf306.jpg?1663529926">40K</set>
+            <set picURL="https://api.scryfall.com/cards/93bc9e79-88c8-436b-94f7-17b349baf306?format=image">40K</set>
             <reverse-related count="x">Mortarion, Daemon Primarch</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -374,7 +374,7 @@ Whenever this creature deals damage to a planeswalker, destroy that planeswalker
                 <cmc>0</cmc>
                 <pt>2/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/9/d9662108-7a01-48d4-bb5d-edcbf1ed5a0d.jpg?1663569741">40K</set>
+            <set picURL="https://api.scryfall.com/cards/d9662108-7a01-48d4-bb5d-edcbf1ed5a0d?format=image">40K</set>
             <reverse-related>Belisarius Cawl</reverse-related>
             <reverse-related count="x">Birth of the Imperium</reverse-related>
             <reverse-related count="x">Defenders of Humanity</reverse-related>
@@ -394,9 +394,9 @@ Whenever this creature deals damage to a planeswalker, destroy that planeswalker
                 <cmc>0</cmc>
                 <pt>*/*</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/8/6/863768b5-3cf9-415c-b4fd-371dc5afee18.jpg">M11</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/6/160c268c-db2f-4105-8f40-0237b59ed333.jpg">M10</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/f/6/f669cb99-be79-413b-8266-1dfd6a15cb41.jpg">LRW</set>
+            <set picURL="https://api.scryfall.com/cards/863768b5-3cf9-415c-b4fd-371dc5afee18?format=image">M11</set>
+            <set picURL="https://api.scryfall.com/cards/160c268c-db2f-4105-8f40-0237b59ed333?format=image">M10</set>
+            <set picURL="https://api.scryfall.com/cards/f669cb99-be79-413b-8266-1dfd6a15cb41?format=image">LRW</set>
             <reverse-related>Ajani Goldmane</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -411,7 +411,7 @@ Whenever this creature deals damage to a planeswalker, destroy that planeswalker
                 <cmc>0</cmc>
                 <pt>4/4</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/f/5f3f8f97-0c27-49d6-ae9a-a0fe2a7ce38b.jpg">M19</set>
+            <set picURL="https://api.scryfall.com/cards/5f3f8f97-0c27-49d6-ae9a-a0fe2a7ce38b?format=image">M19</set>
             <reverse-related>Ajani's Last Stand</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -427,7 +427,7 @@ Whenever this creature attacks, it deals 3 damage to each opponent.</text>
                 <cmc>0</cmc>
                 <pt>3/6</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/9/4/94a50acd-ac2d-47bf-b331-0bcf5edd9c75.jpg?1641306148">STX</set>
+            <set picURL="https://api.scryfall.com/cards/94a50acd-ac2d-47bf-b331-0bcf5edd9c75?format=image">STX</set>
             <reverse-related>Awaken the Blood Avatar</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -442,7 +442,7 @@ Whenever this creature attacks, it deals 3 damage to each opponent.</text>
                 <cmc>0</cmc>
                 <pt>3/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/a/1a3814e3-7ad2-4c87-8630-ab56e13b6ee9.jpg">AKH</set>
+            <set picURL="https://api.scryfall.com/cards/1a3814e3-7ad2-4c87-8630-ab56e13b6ee9?format=image">AKH</set>
             <reverse-related>Aven Initiate</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -458,7 +458,7 @@ Creature tokens you control have flying and vigilance.</text>
                 <cmc>0</cmc>
                 <pt>2/3</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/8/a8f339c6-2c0d-4631-849b-44d4360b5131.jpg">AKH</set>
+            <set picURL="https://api.scryfall.com/cards/a8f339c6-2c0d-4631-849b-44d4360b5131?format=image">AKH</set>
             <reverse-related>Aven Wind Guide</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -472,7 +472,7 @@ Creature tokens you control have flying and vigilance.</text>
                 <cmc>0</cmc>
                 <pt>3/3</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/4/e/4e42cb2e-578f-4fec-a9a4-33b95b78229c.jpg?1662835091">DMU</set>
+            <set picURL="https://api.scryfall.com/cards/4e42cb2e-578f-4fec-a9a4-33b95b78229c?format=image">DMU</set>
             <reverse-related>Greensleeves, Maro-Sorcerer</reverse-related>
             <reverse-related count="x" exclude="exclude">Greensleeves, Maro-Sorcerer</reverse-related>
             <token>1</token>
@@ -488,7 +488,7 @@ Creature tokens you control have flying and vigilance.</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/4/c/4c8f2c0f-7ed8-4d72-8f94-33ad615bf21d.jpg?1664344123">UNF</set>
+            <set picURL="https://api.scryfall.com/cards/4c8f2c0f-7ed8-4d72-8f94-33ad615bf21d?format=image">UNF</set>
             <reverse-related>Balloon Stand</reverse-related>
             <reverse-related>Gift Shop</reverse-related>
             <reverse-related count="3">Memory Test</reverse-related>
@@ -506,12 +506,12 @@ Creature tokens you control have flying and vigilance.</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/5/55368a15-e45b-4407-9c03-1b17bf84607a.jpg?1641599893">VOC</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/e/5/e5c0f400-41be-488b-be84-b07289b1ef62.jpg?1641305858">MID</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/9/e/9e2b5361-ff9a-485c-8ae2-52bf376fd9ad.jpg?1552078403">GK2</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/f/1/f1349fcb-db31-4b1d-8063-e5c28b4472cc.jpg">M19</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/2/020c88d9-d058-4290-b0d7-b91754f91a22.jpg">C17</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/8/9/89d7ed94-564b-415c-b590-d89c972384a1.jpg">MMA</set>
+            <set picURL="https://api.scryfall.com/cards/55368a15-e45b-4407-9c03-1b17bf84607a?format=image">VOC</set>
+            <set picURL="https://api.scryfall.com/cards/e5c0f400-41be-488b-be84-b07289b1ef62?format=image">MID</set>
+            <set picURL="https://api.scryfall.com/cards/9e2b5361-ff9a-485c-8ae2-52bf376fd9ad?format=image">GK2</set>
+            <set picURL="https://api.scryfall.com/cards/f1349fcb-db31-4b1d-8063-e5c28b4472cc?format=image">M19</set>
+            <set picURL="https://api.scryfall.com/cards/020c88d9-d058-4290-b0d7-b91754f91a22?format=image">C17</set>
+            <set picURL="https://api.scryfall.com/cards/89d7ed94-564b-415c-b590-d89c972384a1?format=image">MMA</set>
             <reverse-related>Bat Whisperer</reverse-related>
             <reverse-related count="2">Belfry Spirit</reverse-related>
             <reverse-related>Desecrated Tomb</reverse-related>
@@ -533,7 +533,7 @@ Creature tokens you control have flying and vigilance.</text>
                 <cmc>0</cmc>
                 <pt>1/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/4/c/4c532e0f-8934-4ad3-bb1a-640abe946e10.jpg?1641306027">TSR</set>
+            <set picURL="https://api.scryfall.com/cards/4c532e0f-8934-4ad3-bb1a-640abe946e10?format=image">TSR</set>
             <reverse-related>Sengir Nosferatu</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -547,14 +547,14 @@ Creature tokens you control have flying and vigilance.</text>
                 <cmc>0</cmc>
                 <pt>2/2</pt>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/7/7/772dac39-269b-4a35-aad3-320279af833f.jpg?1667886810">BRO</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/9/d/9d8ab1dd-f8a5-4a93-8aa0-f0701a4c3ff2.jpg?1662663425">DMC</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/e/c/ec53abaa-b316-496d-9351-318a9dd9de4d.jpg?1615686653">KHM</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/b/0/b0f09f9e-e0f9-4ed8-bfc0-5f1a3046106e.jpg?1572489163">ELD</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/6/c6610846-00d8-4cc2-a90a-4dc043ba7fa6.jpg?1563073126">MH1</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/8/c879d4a6-cef5-48f1-8c08-f5b59ec850de.jpg?1562857282">C15</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/6/e/6e1fc8db-f4a3-4f9c-bfab-64d5a3968435.jpg">ONS</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/a/0a21bc37-6f21-4dda-a313-a0d75696f7fc.jpg">ODY</set>
+            <set picURL="https://api.scryfall.com/cards/772dac39-269b-4a35-aad3-320279af833f?format=image">BRO</set>
+            <set picURL="https://api.scryfall.com/cards/9d8ab1dd-f8a5-4a93-8aa0-f0701a4c3ff2?format=image">DMC</set>
+            <set picURL="https://api.scryfall.com/cards/ec53abaa-b316-496d-9351-318a9dd9de4d?format=image">KHM</set>
+            <set picURL="https://api.scryfall.com/cards/b0f09f9e-e0f9-4ed8-bfc0-5f1a3046106e?format=image">ELD</set>
+            <set picURL="https://api.scryfall.com/cards/c6610846-00d8-4cc2-a90a-4dc043ba7fa6?format=image">MH1</set>
+            <set picURL="https://api.scryfall.com/cards/c879d4a6-cef5-48f1-8c08-f5b59ec850de?format=image">C15</set>
+            <set picURL="https://api.scryfall.com/cards/6e1fc8db-f4a3-4f9c-bfab-64d5a3968435?format=image">ONS</set>
+            <set picURL="https://api.scryfall.com/cards/0a21bc37-6f21-4dda-a313-a0d75696f7fc?format=image">ODY</set>
             <reverse-related>Argoth, Sanctum of Nature</reverse-related>
             <reverse-related>Ayula's Influence</reverse-related>
             <reverse-related count="x" exclude="exclude">Ayula's Influence</reverse-related>
@@ -581,7 +581,7 @@ Creature tokens you control have flying and vigilance.</text>
                 <cmc>0</cmc>
                 <pt>4/4</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/a/ca3dae7d-3880-4c0a-acfb-8fd227cf9fab.jpg">KTK</set>
+            <set picURL="https://api.scryfall.com/cards/ca3dae7d-3880-4c0a-acfb-8fd227cf9fab?format=image">KTK</set>
             <reverse-related>Bear's Companion</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -595,35 +595,35 @@ Creature tokens you control have flying and vigilance.</text>
                 <cmc>0</cmc>
                 <pt>3/3</pt>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/4/7/47239704-652c-49a7-9011-30f1f7d0078f.jpg?1675905872">ONC</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/9/591cb5b2-6394-4c1a-b227-5c32e633b493.jpg?1661549611">DMU</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/1/01e095bd-091c-442f-aa21-0826c40acb6c.jpg?1654172039">CLB</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/2/a/2aa672bb-60f3-4601-8c14-f486a54f615b.jpg?1644543471">NEC</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/4/4/44a4ef4a-a026-424e-88ff-e2bb77aaf05d.jpg?1641306086">C21</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/6/06d59ee8-446e-427f-ac88-53f5fa378384.jpg?1623022216">CMR</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/2/d270aeed-b15f-46f9-97ba-ccce562caefa.jpg?1598311679">2XM</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/8/8/882247ba-99d2-46db-8314-f800f3366b7f.jpg?1594733622">M21</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/f/1f2c9241-9cba-4c99-85cc-7e74286d1dc1.jpg?1591225601">IKO</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/6/564ed3be-ef91-42eb-90ff-452bc23463b5.jpg?1572370727">C19</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/8/3/832691a5-c638-481b-a413-3fdfc604a132.jpg">M19</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/5/d51a6408-0311-4daa-bfb2-b2f6f8fcbc3e.jpg?1561758147">BBD</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/back/6/1/610def80-1303-488e-bfd9-4a27f031d20e.jpg?1571508307">UST</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/5/c5ca0ca5-421c-41d9-a797-3c8443d253ae.jpg">E01</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/b/4/b4333372-80ea-42df-bf8a-d1f12bcb348e.jpg?1562841188">MM3</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/b/0/b067ff1d-32c5-4bd9-ba7c-749a5ad7acdc.jpg?1562930488">C16</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/c/ac453b05-4eb3-42f2-99e7-40e29558c50a.jpg?1561897506">CN2</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/4/4/445e2667-3b00-4e01-ac4b-20f4af267387.jpg">C14</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/d/dd81e49b-bd38-4c0c-b9fe-ce33c15621d6.jpg?1562640083">M15</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/6/b/6b28a5db-d095-4214-ba0c-14b1aeddb1eb.jpg">DDL</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/8/a8fc2dc9-40df-46d8-98c0-ca4919bd5524.jpg">M14</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/9/c94010f1-cd4b-4f65-8a0e-2df6eec058ec.jpg">M13</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/3/b/3bb48d4f-e39f-4d51-9bb1-efca7dbfdc83.jpg">M12</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/6/6/664bd13a-80fd-4ffe-bc65-f02a7a087427.jpg">M11</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/9/d98c546e-2933-4833-b47b-084db56fb5d6.jpg">DDD</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/4/b/4b935437-e097-466b-a9d5-6dc0dc6a10f3.jpg">M10</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/3/f/3fc3a29a-280d-4f2c-9a01-8cfead75f583.jpg">EVE</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/3/c3cbd01b-dbf5-424a-855d-f9a9d7e7e414.jpg">LRW</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/0/d02d5670-fff3-4011-8e45-e6843e4e8988.jpg">DST</set>
+            <set picURL="https://api.scryfall.com/cards/47239704-652c-49a7-9011-30f1f7d0078f?format=image">ONC</set>
+            <set picURL="https://api.scryfall.com/cards/591cb5b2-6394-4c1a-b227-5c32e633b493?format=image">DMU</set>
+            <set picURL="https://api.scryfall.com/cards/01e095bd-091c-442f-aa21-0826c40acb6c?format=image">CLB</set>
+            <set picURL="https://api.scryfall.com/cards/2aa672bb-60f3-4601-8c14-f486a54f615b?format=image">NEC</set>
+            <set picURL="https://api.scryfall.com/cards/44a4ef4a-a026-424e-88ff-e2bb77aaf05d?format=image">C21</set>
+            <set picURL="https://api.scryfall.com/cards/06d59ee8-446e-427f-ac88-53f5fa378384?format=image">CMR</set>
+            <set picURL="https://api.scryfall.com/cards/d270aeed-b15f-46f9-97ba-ccce562caefa?format=image">2XM</set>
+            <set picURL="https://api.scryfall.com/cards/882247ba-99d2-46db-8314-f800f3366b7f?format=image">M21</set>
+            <set picURL="https://api.scryfall.com/cards/1f2c9241-9cba-4c99-85cc-7e74286d1dc1?format=image">IKO</set>
+            <set picURL="https://api.scryfall.com/cards/564ed3be-ef91-42eb-90ff-452bc23463b5?format=image">C19</set>
+            <set picURL="https://api.scryfall.com/cards/832691a5-c638-481b-a413-3fdfc604a132?format=image">M19</set>
+            <set picURL="https://api.scryfall.com/cards/d51a6408-0311-4daa-bfb2-b2f6f8fcbc3e?format=image">BBD</set>
+            <set picURL="https://api.scryfall.com/cards/610def80-1303-488e-bfd9-4a27f031d20e?format=image&amp;face=back">UST</set>
+            <set picURL="https://api.scryfall.com/cards/c5ca0ca5-421c-41d9-a797-3c8443d253ae?format=image">E01</set>
+            <set picURL="https://api.scryfall.com/cards/b4333372-80ea-42df-bf8a-d1f12bcb348e?format=image">MM3</set>
+            <set picURL="https://api.scryfall.com/cards/b067ff1d-32c5-4bd9-ba7c-749a5ad7acdc?format=image">C16</set>
+            <set picURL="https://api.scryfall.com/cards/ac453b05-4eb3-42f2-99e7-40e29558c50a?format=image">CN2</set>
+            <set picURL="https://api.scryfall.com/cards/445e2667-3b00-4e01-ac4b-20f4af267387?format=image">C14</set>
+            <set picURL="https://api.scryfall.com/cards/dd81e49b-bd38-4c0c-b9fe-ce33c15621d6?format=image">M15</set>
+            <set picURL="https://api.scryfall.com/cards/6b28a5db-d095-4214-ba0c-14b1aeddb1eb?format=image">DDL</set>
+            <set picURL="https://api.scryfall.com/cards/a8fc2dc9-40df-46d8-98c0-ca4919bd5524?format=image">M14</set>
+            <set picURL="https://api.scryfall.com/cards/c94010f1-cd4b-4f65-8a0e-2df6eec058ec?format=image">M13</set>
+            <set picURL="https://api.scryfall.com/cards/3bb48d4f-e39f-4d51-9bb1-efca7dbfdc83?format=image">M12</set>
+            <set picURL="https://api.scryfall.com/cards/664bd13a-80fd-4ffe-bc65-f02a7a087427?format=image">M11</set>
+            <set picURL="https://api.scryfall.com/cards/d98c546e-2933-4833-b47b-084db56fb5d6?format=image">DDD</set>
+            <set picURL="https://api.scryfall.com/cards/4b935437-e097-466b-a9d5-6dc0dc6a10f3?format=image">M10</set>
+            <set picURL="https://api.scryfall.com/cards/3fc3a29a-280d-4f2c-9a01-8cfead75f583?format=image">EVE</set>
+            <set picURL="https://api.scryfall.com/cards/c3cbd01b-dbf5-424a-855d-f9a9d7e7e414?format=image">LRW</set>
+            <set picURL="https://api.scryfall.com/cards/d02d5670-fff3-4011-8e45-e6843e4e8988?format=image">DST</set>
             <reverse-related>Beast Within</reverse-related>
             <reverse-related>Bringer of the Green Dawn</reverse-related>
             <reverse-related count="x">Curious Herd</reverse-related>
@@ -658,19 +658,19 @@ Creature tokens you control have flying and vigilance.</text>
                 <cmc>0</cmc>
                 <pt>4/4</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/f/5/f55c70b8-0fa5-4d08-9061-f53d6f949908.jpg?1653273209">MID</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/1/a1eff7f8-b645-41cb-bcd9-3dc1ab10200e.jpg?1641306190">MH2</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/0/50d90039-6e75-4c76-893d-cd1686a36be9.jpg?1620573811">CMR</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/e/9/e952eed6-0243-4f32-b6a5-64c2d3ab0ef8.jpg?1591319203">C20</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/9/9/99f37b65-06ec-47dc-a299-6e65d1254995.jpg?1572370715">C19</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/3/8/381854e2-7369-473e-a604-4dd7c010fc89.jpg?1592710061">C18</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/4/a4210312-e617-4e72-bf80-2c8d42b7777d.jpg">E01</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/f/5ff64dab-233b-42b0-88bb-d3e4f7eb4e93.jpg?1562841178">MM3</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/9/2/920f4eca-4e0c-4cbc-9a9b-a5b4b447d49d.jpg?1562857276">C15</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/3/c30a67ba-df39-4a70-a725-6853e3fcba0b.jpg">C14</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/6/f/6fd6877b-b4f1-4953-b9a4-c97d0ae7d673.jpg">DDD</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/7/6/76b5e455-053d-4a86-93b2-2436b554b638.jpg">ZEN</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/e/ce45e037-5efb-4735-afee-12d7dc3127d1.jpg">ODY</set>
+            <set picURL="https://api.scryfall.com/cards/f55c70b8-0fa5-4d08-9061-f53d6f949908?format=image">MID</set>
+            <set picURL="https://api.scryfall.com/cards/a1eff7f8-b645-41cb-bcd9-3dc1ab10200e?format=image">MH2</set>
+            <set picURL="https://api.scryfall.com/cards/50d90039-6e75-4c76-893d-cd1686a36be9?format=image">CMR</set>
+            <set picURL="https://api.scryfall.com/cards/e952eed6-0243-4f32-b6a5-64c2d3ab0ef8?format=image">C20</set>
+            <set picURL="https://api.scryfall.com/cards/99f37b65-06ec-47dc-a299-6e65d1254995?format=image">C19</set>
+            <set picURL="https://api.scryfall.com/cards/381854e2-7369-473e-a604-4dd7c010fc89?format=image">C18</set>
+            <set picURL="https://api.scryfall.com/cards/a4210312-e617-4e72-bf80-2c8d42b7777d?format=image">E01</set>
+            <set picURL="https://api.scryfall.com/cards/5ff64dab-233b-42b0-88bb-d3e4f7eb4e93?format=image">MM3</set>
+            <set picURL="https://api.scryfall.com/cards/920f4eca-4e0c-4cbc-9a9b-a5b4b447d49d?format=image">C15</set>
+            <set picURL="https://api.scryfall.com/cards/c30a67ba-df39-4a70-a725-6853e3fcba0b?format=image">C14</set>
+            <set picURL="https://api.scryfall.com/cards/6fd6877b-b4f1-4953-b9a4-c97d0ae7d673?format=image">DDD</set>
+            <set picURL="https://api.scryfall.com/cards/76b5e455-053d-4a86-93b2-2436b554b638?format=image">ZEN</set>
+            <set picURL="https://api.scryfall.com/cards/ce45e037-5efb-4735-afee-12d7dc3127d1?format=image">ODY</set>
             <reverse-related>Baloth Cage Trap</reverse-related>
             <reverse-related>Beast Attack</reverse-related>
             <reverse-related>Combine Chrysalis</reverse-related>
@@ -691,7 +691,7 @@ Creature tokens you control have flying and vigilance.</text>
                 <cmc>0</cmc>
                 <pt>8/8</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/7/a7382e4b-43dc-4b35-8a9e-ab886ea0a981.jpg">ALA</set>
+            <set picURL="https://api.scryfall.com/cards/a7382e4b-43dc-4b35-8a9e-ab886ea0a981?format=image">ALA</set>
             <reverse-related>Godsire</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -734,7 +734,7 @@ Creature tokens you control have flying and vigilance.</text>
                 <cmc>0</cmc>
                 <pt>5/5</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/4/4/44675b6a-ea5a-44f1-9f2c-3725cdfcc814.jpg?1592710068">C18</set>
+            <set picURL="https://api.scryfall.com/cards/44675b6a-ea5a-44f1-9f2c-3725cdfcc814?format=image">C18</set>
             <reverse-related>Spawning Grounds</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -749,7 +749,7 @@ Creature tokens you control have flying and vigilance.</text>
                 <cmc>0</cmc>
                 <pt>3/3</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/f/c/fc48bf5f-5fe1-41ef-a63d-85daacd941f7.jpg?1562640149">M15</set>
+            <set picURL="https://api.scryfall.com/cards/fc48bf5f-5fe1-41ef-a63d-85daacd941f7?format=image">M15</set>
             <reverse-related>Garruk, Apex Predator</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -762,7 +762,7 @@ Creature tokens you control have flying and vigilance.</text>
                 <cmc>0</cmc>
                 <pt>6/6</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/4/d/4de1d095-459f-42fd-9d9f-8f71d002a5b2.jpg?1562639796">KLD</set>
+            <set picURL="https://api.scryfall.com/cards/4de1d095-459f-42fd-9d9f-8f71d002a5b2?format=image">KLD</set>
             <reverse-related>Architect of the Untamed</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -776,7 +776,7 @@ Creature tokens you control have flying and vigilance.</text>
                 <cmc>0</cmc>
                 <pt>4/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/2/9/29b7ecd1-c70e-467c-a9ea-99c2668c3405.jpg">AKH</set>
+            <set picURL="https://api.scryfall.com/cards/29b7ecd1-c70e-467c-a9ea-99c2668c3405?format=image">AKH</set>
             <reverse-related>Trial of Strength</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -791,7 +791,7 @@ Creature tokens you control have flying and vigilance.</text>
                 <cmc>0</cmc>
                 <pt>4/4</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/8/7/87ec9ade-1e06-43c9-97df-55465cabdf32.jpg?1572892529">RNA</set>
+            <set picURL="https://api.scryfall.com/cards/87ec9ade-1e06-43c9-97df-55465cabdf32?format=image">RNA</set>
             <reverse-related>Thrash // Threat</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -804,7 +804,7 @@ Creature tokens you control have flying and vigilance.</text>
                 <maintype>Creature</maintype>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/9/b/9bbfa4d4-106b-4fec-86ac-b81b71a8f432.jpg?1584741596">UND</set>
+            <set picURL="https://api.scryfall.com/cards/9bbfa4d4-106b-4fec-86ac-b81b71a8f432?format=image">UND</set>
             <reverse-related>B.O.B. (Bevy of Beebles)</reverse-related>
             <reverse-related count="4" exclude="exclude">B.O.B. (Bevy of Beebles)</reverse-related>
             <token>1</token>
@@ -820,8 +820,8 @@ Creature tokens you control have flying and vigilance.</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/f/0fd60456-70aa-49ae-a0a7-2c50cb085223.jpg?1591319166">C20</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/3/03c3dc23-d6f2-4209-82e1-a0b936c94231.jpg?1572892490">GRN</set>
+            <set picURL="https://api.scryfall.com/cards/0fd60456-70aa-49ae-a0a7-2c50cb085223?format=image">C20</set>
+            <set picURL="https://api.scryfall.com/cards/03c3dc23-d6f2-4209-82e1-a0b936c94231?format=image">GRN</set>
             <reverse-related>Murmuring Mystic</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -836,7 +836,7 @@ Creature tokens you control have flying and vigilance.</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/b/7/b7b55dcf-ae63-4b84-8d39-80b5a6de3c1a.jpg">ARB</set>
+            <set picURL="https://api.scryfall.com/cards/b7b55dcf-ae63-4b84-8d39-80b5a6de3c1a?format=image">ARB</set>
             <reverse-related count="x">Flurry of Wings</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -851,7 +851,7 @@ Creature tokens you control have flying and vigilance.</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/8/a813c741-d0d4-48cd-9bbf-8a04a544ce8e.jpg?1552078404">GK2</set>
+            <set picURL="https://api.scryfall.com/cards/a813c741-d0d4-48cd-9bbf-8a04a544ce8e?format=image">GK2</set>
             <reverse-related count="x">Dovescape</reverse-related>
             <reverse-related>Pride of the Clouds</reverse-related>
             <token>1</token>
@@ -867,18 +867,18 @@ Creature tokens you control have flying and vigilance.</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/2/e/2e5db619-2ccc-4e5b-bf74-0f8ed77afad9.jpg?1675905857">ONC</set>
-            <set picURL="https://cards.scryfall.io/large/front/d/3/d3fdde92-dc2c-4ed0-b092-926ef9c091ad.jpg?1674397376">DMR</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/f/5f3034f6-145f-4e60-9e55-c4054fd8e70f.jpg?1661539599">DMU</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/f/e/fe8e40dd-f435-4abc-a3e8-fd3d3a94e910.jpg?1641306173">MH2</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/2/2/22e33dff-23d5-4f31-8dd6-270657e150d8.jpg?1594733474">M21</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/7/4/74bc5a99-095d-437e-8aa9-30845196dd1b.jpg?1591319115">C20</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/4/3/43c72f53-db47-48d1-85f0-626440b0c88c.jpg?1563073015">MH1</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/2/f/2fd5abfa-ec18-49a4-9531-826d47c6301b.jpg?1562840740">MM3</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/6/c6e6d6a1-4a05-4b6f-9a80-81a0ac6f2b34.jpg?1562934890">C16</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/8/c862470b-f273-4e01-945b-bf3697cd1359.jpg">BNG</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/5/05b4dbe1-12ac-404f-a1fe-96e0b620533e.jpg">RTR</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/b/abbb3c16-a7ef-4b83-b1a9-637a905229d7.jpg">ZEN</set>
+            <set picURL="https://api.scryfall.com/cards/2e5db619-2ccc-4e5b-bf74-0f8ed77afad9?format=image">ONC</set>
+            <set picURL="https://api.scryfall.com/cards/d3fdde92-dc2c-4ed0-b092-926ef9c091ad?format=image">DMR</set>
+            <set picURL="https://api.scryfall.com/cards/5f3034f6-145f-4e60-9e55-c4054fd8e70f?format=image">DMU</set>
+            <set picURL="https://api.scryfall.com/cards/fe8e40dd-f435-4abc-a3e8-fd3d3a94e910?format=image">MH2</set>
+            <set picURL="https://api.scryfall.com/cards/22e33dff-23d5-4f31-8dd6-270657e150d8?format=image">M21</set>
+            <set picURL="https://api.scryfall.com/cards/74bc5a99-095d-437e-8aa9-30845196dd1b?format=image">C20</set>
+            <set picURL="https://api.scryfall.com/cards/43c72f53-db47-48d1-85f0-626440b0c88c?format=image">MH1</set>
+            <set picURL="https://api.scryfall.com/cards/2fd5abfa-ec18-49a4-9531-826d47c6301b?format=image">MM3</set>
+            <set picURL="https://api.scryfall.com/cards/c6e6d6a1-4a05-4b6f-9a80-81a0ac6f2b34?format=image">C16</set>
+            <set picURL="https://api.scryfall.com/cards/c862470b-f273-4e01-945b-bf3697cd1359?format=image">BNG</set>
+            <set picURL="https://api.scryfall.com/cards/05b4dbe1-12ac-404f-a1fe-96e0b620533e?format=image">RTR</set>
+            <set picURL="https://api.scryfall.com/cards/abbb3c16-a7ef-4b83-b1a9-637a905229d7?format=image">ZEN</set>
             <reverse-related>Aether Channeler</reverse-related>
             <reverse-related>Akim, the Soaring Wind</reverse-related>
             <reverse-related count="2">Battle Screech</reverse-related>
@@ -909,9 +909,9 @@ Creature tokens you control have flying and vigilance.</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/a/1a0cb299-057d-4c39-9d73-3a3512526e4a.jpg?1615686221">KHM</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/4/d453ee89-6122-4d51-989c-e78b046a9de3.jpg">EVE</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/2/6/26e0e196-36e6-4d7a-a76b-1c2a18270267.jpg">INV</set>
+            <set picURL="https://api.scryfall.com/cards/1a0cb299-057d-4c39-9d73-3a3512526e4a?format=image">KHM</set>
+            <set picURL="https://api.scryfall.com/cards/d453ee89-6122-4d51-989c-e78b046a9de3?format=image">EVE</set>
+            <set picURL="https://api.scryfall.com/cards/26e0e196-36e6-4d7a-a76b-1c2a18270267?format=image">INV</set>
             <reverse-related count="2">Alrund's Epiphany</reverse-related>
             <reverse-related>Fable of Wolf and Owl</reverse-related>
             <reverse-related count="x">Ordered Migration</reverse-related>
@@ -930,9 +930,9 @@ Creature tokens you control have flying and vigilance.</text>
                 <cmc>0</cmc>
                 <pt>3/3</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/9/5988dc9e-724f-4645-8769-b94c5ef631b9.jpg?1568003326">C19</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/b/6/b6311cc7-8431-43a3-83ec-b2a5f07acf56.jpg">M12</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/a/5a84671e-cbe8-467e-9a8a-bbecba6158fa.jpg">M11</set>
+            <set picURL="https://api.scryfall.com/cards/5988dc9e-724f-4645-8769-b94c5ef631b9?format=image">C19</set>
+            <set picURL="https://api.scryfall.com/cards/b6311cc7-8431-43a3-83ec-b2a5f07acf56?format=image">M12</set>
+            <set picURL="https://api.scryfall.com/cards/5a84671e-cbe8-467e-9a8a-bbecba6158fa?format=image">M11</set>
             <reverse-related>Roc Egg</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -947,8 +947,8 @@ Creature tokens you control have flying and vigilance.</text>
                 <cmc>0</cmc>
                 <pt>2/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/9/09ae926d-80be-42c5-8c36-658cd38d2597.jpg?1562896902">C16</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/a/ca72703f-d45b-4c80-98a8-55fad1fcf431.jpg">THS</set>
+            <set picURL="https://api.scryfall.com/cards/09ae926d-80be-42c5-8c36-658cd38d2597?format=image">C16</set>
+            <set picURL="https://api.scryfall.com/cards/ca72703f-d45b-4c80-98a8-55fad1fcf431?format=image">THS</set>
             <reverse-related>Swan Song</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -963,7 +963,7 @@ Creature tokens you control have flying and vigilance.</text>
                 <cmc>0</cmc>
                 <pt>2/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/a/ca6ce21f-2a29-480e-91f9-b089232863ff.jpg">BNG</set>
+            <set picURL="https://api.scryfall.com/cards/ca6ce21f-2a29-480e-91f9-b089232863ff?format=image">BNG</set>
             <reverse-related>Aerie Worshippers</reverse-related>
             <reverse-related count="2">Rise of Eagles</reverse-related>
             <token>1</token>
@@ -979,7 +979,7 @@ Creature tokens you control have flying and vigilance.</text>
                 <cmc>0</cmc>
                 <pt>4/4</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/b/5/b5489e26-6aec-4706-9c3e-8454878fa6c3.jpg">8ED</set>
+            <set picURL="https://api.scryfall.com/cards/b5489e26-6aec-4706-9c3e-8454878fa6c3?format=image">8ED</set>
             <reverse-related>Rukh Egg</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -994,8 +994,8 @@ Creature tokens you control have flying and vigilance.</text>
                 <cmc>0</cmc>
                 <pt>3/4</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/4/a/4ac57a34-23ad-4780-a464-e2472d277a27.jpg?1568003319">C19</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/a/aa788dea-2968-45e8-9e08-c89e3e227d88.jpg">KTK</set>
+            <set picURL="https://api.scryfall.com/cards/4ac57a34-23ad-4780-a464-e2472d277a27?format=image">C19</set>
+            <set picURL="https://api.scryfall.com/cards/aa788dea-2968-45e8-9e08-c89e3e227d88?format=image">KTK</set>
             <reverse-related>Wingmate Roc</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -1011,7 +1011,7 @@ This creature can block only creatures with flying.</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/0/a0f7b2f0-16d3-4db0-a737-c7b8dcb9d5de.jpg?1641305856">MID</set>
+            <set picURL="https://api.scryfall.com/cards/a0f7b2f0-16d3-4db0-a737-c7b8dcb9d5de?format=image">MID</set>
             <reverse-related>Ominous Roost</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -1027,7 +1027,7 @@ This creature can't block.</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/8/d/8dce95d5-2ae7-4bd9-92f4-1cb3bed5f733.jpg?1661539757">DMU</set>
+            <set picURL="https://api.scryfall.com/cards/8dce95d5-2ae7-4bd9-92f4-1cb3bed5f733?format=image">DMU</set>
             <reverse-related>The Raven Man</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -1040,7 +1040,7 @@ This creature can't block.</text>
                 <maintype>Artifact</maintype>
                 <cmc>0</cmc>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/6/a6f374bc-cd29-469f-808a-6a6c004ee8aa.jpg?1636041263">VOW</set>
+            <set picURL="https://api.scryfall.com/cards/a6f374bc-cd29-469f-808a-6a6c004ee8aa?format=image">VOW</set>
             <reverse-related>Anje, Maid of Dishonor</reverse-related>
             <reverse-related>Arterial Alchemy</reverse-related>
             <reverse-related>Belligerent Guest</reverse-related>
@@ -1090,7 +1090,7 @@ This creature can't block.</text>
                 <cmc>0</cmc>
                 <pt>2/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/4/a/4a3d2013-e10c-49aa-adf6-4a3a141e48ce.jpg?1663530044">40K</set>
+            <set picURL="https://api.scryfall.com/cards/4a3d2013-e10c-49aa-adf6-4a3a141e48ce?format=image">40K</set>
             <reverse-related count="2">Pink Horror</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -1104,7 +1104,7 @@ This creature can't block.</text>
                 <cmc>0</cmc>
                 <pt>3/3</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/8/3/83dcacd3-8707-4354-a1a5-9863d677d67f.jpg">PCA</set>
+            <set picURL="https://api.scryfall.com/cards/83dcacd3-8707-4354-a1a5-9863d677d67f?format=image">PCA</set>
             <reverse-related>Brindle Shoat</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -1118,9 +1118,9 @@ This creature can't block.</text>
                 <cmc>0</cmc>
                 <pt>2/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/f/afb796a0-4eb0-4fc5-bf84-92a71bec4466.jpg?1654171558">CLB</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/a/1a7f9534-ccbc-4304-afad-d2896be60b8e.jpg?1641306090">C21</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/2/f/2f40613b-1bde-4939-86ad-6bd40f9db0d6.jpg">THS</set>
+            <set picURL="https://api.scryfall.com/cards/afb796a0-4eb0-4fc5-bf84-92a71bec4466?format=image">CLB</set>
+            <set picURL="https://api.scryfall.com/cards/1a7f9534-ccbc-4304-afad-d2896be60b8e?format=image">C21</set>
+            <set picURL="https://api.scryfall.com/cards/2f40613b-1bde-4939-86ad-6bd40f9db0d6?format=image">THS</set>
             <reverse-related>Carefree Swinemaster</reverse-related>
             <reverse-related>Contraband Livestock</reverse-related>
             <reverse-related count="x">Curse of the Swine</reverse-related>
@@ -1137,7 +1137,7 @@ This creature can't block.</text>
                 <maintype>Creature</maintype>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/3/6/365b2234-c29d-42db-a8e0-80685a4b6434.jpg?1572489170">ELD</set>
+            <set picURL="https://api.scryfall.com/cards/365b2234-c29d-42db-a8e0-80685a4b6434?format=image">ELD</set>
             <related>Food Token</related>
             <reverse-related count="3">Wolf's Quarry</reverse-related>
             <token>1</token>
@@ -1152,7 +1152,7 @@ This creature can't block.</text>
                 <maintype>Creature</maintype>
                 <pt>3/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/9/7/975c4329-418a-4ada-82fa-9286fb61d61a.jpg?1636630123">VOW</set>
+            <set picURL="https://api.scryfall.com/cards/975c4329-418a-4ada-82fa-9286fb61d61a?format=image">VOW</set>
             <reverse-related>Rural Recruit</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -1167,8 +1167,8 @@ This creature can't block.</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/d/0d0475e9-68ae-4553-a5ef-650091e04967.jpg?1654171472">CLB</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/4/c49e8e79-8673-41c2-a1ad-273c37e27aca.jpg?1625767076">AFR</set>
+            <set picURL="https://api.scryfall.com/cards/0d0475e9-68ae-4553-a5ef-650091e04967?format=image">CLB</set>
+            <set picURL="https://api.scryfall.com/cards/c49e8e79-8673-41c2-a1ad-273c37e27aca?format=image">AFR</set>
             <reverse-related>Minsc &amp; Boo, Timeless Heroes</reverse-related>
             <reverse-related>Minsc, Beloved Ranger</reverse-related>
             <token>1</token>
@@ -1182,7 +1182,7 @@ This creature can't block.</text>
                 <maintype>Creature</maintype>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/f/af1a8115-127d-4268-a4d0-95360862e5fb.jpg?1562927573">UST</set>
+            <set picURL="https://api.scryfall.com/cards/af1a8115-127d-4268-a4d0-95360862e5fb?format=image">UST</set>
             <reverse-related count="x">The Big Idea</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -1239,7 +1239,7 @@ This creature can't block.</text>
                 <cmc>0</cmc>
                 <pt>3/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/8/4/8437b125-6057-4d17-9f2c-28ea56553f84.jpg?1562702178">EMA</set>
+            <set picURL="https://api.scryfall.com/cards/8437b125-6057-4d17-9f2c-28ea56553f84?format=image">EMA</set>
             <reverse-related>Tooth and Claw</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -1253,7 +1253,7 @@ This creature can't block.</text>
                 <cmc>0</cmc>
                 <pt>2/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/e/2/e2c91781-acf9-4cff-be1a-85148ad2a683.jpg?1604194683">ZNR</set>
+            <set picURL="https://api.scryfall.com/cards/e2c91781-acf9-4cff-be1a-85148ad2a683?format=image">ZNR</set>
             <reverse-related>Felidar Retreat</reverse-related>
             <reverse-related count="x=1" exclude="exclude">Felidar Retreat</reverse-related>
             <token>1</token>
@@ -1269,7 +1269,7 @@ This creature can't block.</text>
                 <maintype>Creature</maintype>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/8/1/816da759-e224-4960-b2b6-453cadc2faf1.jpg?1591225557">IKO</set>
+            <set picURL="https://api.scryfall.com/cards/816da759-e224-4960-b2b6-453cadc2faf1?format=image">IKO</set>
             <reverse-related count="x=1">Skycat Sovereign</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -1284,7 +1284,7 @@ This creature can't block.</text>
                 <cmc>0</cmc>
                 <pt>3/3</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/7/4/748d267d-9c81-4dc0-92b7-eafb7691c6cc.jpg">C17</set>
+            <set picURL="https://api.scryfall.com/cards/748d267d-9c81-4dc0-92b7-eafb7691c6cc?format=image">C17</set>
             <reverse-related>Wasitora, Nekoru Queen</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -1299,7 +1299,7 @@ This creature can't block.</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/9/2/921d6192-6b6d-4aa1-be80-bc0b9f503e33.jpg">BNG</set>
+            <set picURL="https://api.scryfall.com/cards/921d6192-6b6d-4aa1-be80-bc0b9f503e33?format=image">BNG</set>
             <reverse-related>Brimaz, King of Oreskos</reverse-related>
             <reverse-related>Vanguard of Brimaz</reverse-related>
             <token>1</token>
@@ -1314,16 +1314,16 @@ This creature can't block.</text>
                 <cmc>0</cmc>
                 <pt>2/2</pt>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/1/1/11011596-4aa1-48a7-90d8-36cb7b27c711.jpg?1675095303">ONE</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/b/db1b2c60-c995-441a-a3d6-20220d6cb7f1.jpg?1620573744">CMR</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/f/8/f859b55c-0b49-4190-b1fa-94f97a59b57c.jpg?1598312335">2XM</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/8/58a18a05-4fa1-467e-9310-e5c6dc797fcf.jpg?1592710004">C18</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/3/d3f2fd62-5430-449b-ac1b-14867d2bb326.jpg">C17</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/9/4/9494ce65-5f2d-421c-a112-5de18e36f48b.jpg?1562857278">C15</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/0/5038c1a3-882d-4640-b8ad-c2c60b0f1973.jpg">C14</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/b/db41ce71-52df-4bc1-884d-b09419d8dd13.jpg">M14</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/f/9/f97868f6-a9ce-4ce9-bc3f-b535f3202602.jpg">M13</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/2/5252ab51-43e8-4b24-9830-de0ad9b9d3dc.jpg">SOM</set>
+            <set picURL="https://api.scryfall.com/cards/11011596-4aa1-48a7-90d8-36cb7b27c711?format=image">ONE</set>
+            <set picURL="https://api.scryfall.com/cards/db1b2c60-c995-441a-a3d6-20220d6cb7f1?format=image">CMR</set>
+            <set picURL="https://api.scryfall.com/cards/f859b55c-0b49-4190-b1fa-94f97a59b57c?format=image">2XM</set>
+            <set picURL="https://api.scryfall.com/cards/58a18a05-4fa1-467e-9310-e5c6dc797fcf?format=image">C18</set>
+            <set picURL="https://api.scryfall.com/cards/d3f2fd62-5430-449b-ac1b-14867d2bb326?format=image">C17</set>
+            <set picURL="https://api.scryfall.com/cards/9494ce65-5f2d-421c-a112-5de18e36f48b?format=image">C15</set>
+            <set picURL="https://api.scryfall.com/cards/5038c1a3-882d-4640-b8ad-c2c60b0f1973?format=image">C14</set>
+            <set picURL="https://api.scryfall.com/cards/db41ce71-52df-4bc1-884d-b09419d8dd13?format=image">M14</set>
+            <set picURL="https://api.scryfall.com/cards/f97868f6-a9ce-4ce9-bc3f-b535f3202602?format=image">M13</set>
+            <set picURL="https://api.scryfall.com/cards/5252ab51-43e8-4b24-9830-de0ad9b9d3dc?format=image">SOM</set>
             <reverse-related>Ajani's Chosen</reverse-related>
             <reverse-related count="x">Ajani, Caller of the Pride</reverse-related>
             <reverse-related>Kemba, Kha Enduring</reverse-related>
@@ -1341,7 +1341,7 @@ This creature can't block.</text>
                 <cmc>0</cmc>
                 <pt>2/1</pt>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/0/5/05a61555-ddb9-4d55-b637-a219d772033d.jpg?1674397379">DMR</set>
+            <set picURL="https://api.scryfall.com/cards/05a61555-ddb9-4d55-b637-a219d772033d?format=image">DMR</set>
             <set picURL="https://cdn.staticneo.com/w/mtg/0/08/Cat2.jpg">APC</set>
             <reverse-related>Penumbra Bobcat</reverse-related>
             <token>1</token>
@@ -1356,7 +1356,7 @@ This creature can't block.</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/f/b/fbdf8dc1-1b10-4fce-97b9-1f5600500cc1.jpg?1595212480">M21</set>
+            <set picURL="https://api.scryfall.com/cards/fbdf8dc1-1b10-4fce-97b9-1f5600500cc1?format=image">M21</set>
             <reverse-related>Rin and Seri, Inseparable</reverse-related>
             <reverse-related count="x">Waiting in the Weeds</reverse-related>
             <token>1</token>
@@ -1372,9 +1372,9 @@ This creature can't block.</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/7/d754e09c-efc0-4536-9f2a-6bd7e2f860ab.jpg?1591225552">IKO</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/b/3/b31f1580-5bba-4cef-b0c8-f2837a597b7d.jpg">M19</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/f/af0086cd-56b5-450e-818c-e54f45d1a104.jpg">AKH</set>
+            <set picURL="https://api.scryfall.com/cards/d754e09c-efc0-4536-9f2a-6bd7e2f860ab?format=image">IKO</set>
+            <set picURL="https://api.scryfall.com/cards/b31f1580-5bba-4cef-b0c8-f2837a597b7d?format=image">M19</set>
+            <set picURL="https://api.scryfall.com/cards/af0086cd-56b5-450e-818c-e54f45d1a104?format=image">AKH</set>
             <reverse-related count="2">Cubwarden</reverse-related>
             <reverse-related count="2">Leonin Warleader</reverse-related>
             <reverse-related count="2">Pride Sovereign</reverse-related>
@@ -1391,9 +1391,9 @@ This creature can't block.</text>
                 <cmc>0</cmc>
                 <pt>2/2</pt>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/0/7/07b58d5f-8a9f-4fd6-83d6-efe3a92e89b2.jpg?1674397383">DMR</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/2/e/2e07758f-0d1c-47d9-ba5a-43bc2a7423cd.jpg?1615686706">KHM</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/f/6/f6541414-c506-449d-b3a8-79f47be531a9.jpg?1594733633">M21</set>
+            <set picURL="https://api.scryfall.com/cards/07b58d5f-8a9f-4fd6-83d6-efe3a92e89b2?format=image">DMR</set>
+            <set picURL="https://api.scryfall.com/cards/2e07758f-0d1c-47d9-ba5a-43bc2a7423cd?format=image">KHM</set>
+            <set picURL="https://api.scryfall.com/cards/f6541414-c506-449d-b3a8-79f47be531a9?format=image">M21</set>
             <reverse-related count="2">Esika's Chariot</reverse-related>
             <reverse-related>Jolrael, Mwonvuli Recluse</reverse-related>
             <token>1</token>
@@ -1408,7 +1408,7 @@ This creature can't block.</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/f/5f458f39-27b6-4121-bda9-1a0d1b42f5fb.jpg?1604194657">ZNR</set>
+            <set picURL="https://api.scryfall.com/cards/5f458f39-27b6-4121-bda9-1a0d1b42f5fb?format=image">ZNR</set>
             <reverse-related>Attended Healer</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -1423,7 +1423,7 @@ This creature can't block.</text>
                 <cmc>0</cmc>
                 <pt>2/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/7/57bd0b29-0860-4ee3-832a-f62ba7bf4aac.jpg?1650819953">SNC</set>
+            <set picURL="https://api.scryfall.com/cards/57bd0b29-0860-4ee3-832a-f62ba7bf4aac?format=image">SNC</set>
             <reverse-related count="x">Jinnie Fay, Jetmir's Second</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -1438,7 +1438,7 @@ This creature can't block.</text>
                 <cmc>0</cmc>
                 <pt>2/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/1/a16b4228-ed85-4d31-8760-88539b9a3cf9.jpg?1664343995">UNF</set>
+            <set picURL="https://api.scryfall.com/cards/a16b4228-ed85-4d31-8760-88539b9a3cf9?format=image">UNF</set>
             <reverse-related>Katerina of Myra's Marvels</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -1453,9 +1453,9 @@ This creature can't block.</text>
                 <cmc>0</cmc>
                 <pt>2/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/8/d886263e-9f46-4389-a543-947d6e51cb1a.jpg?1662835172">DMU</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/7/0742ca95-9455-4f56-b26c-2994d12af602.jpg?1592710075">C18</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/2/9/29c4e4f2-0040-4490-b357-660d729ad9cc.jpg">C17</set>
+            <set picURL="https://api.scryfall.com/cards/d886263e-9f46-4389-a543-947d6e51cb1a?format=image">DMU</set>
+            <set picURL="https://api.scryfall.com/cards/0742ca95-9455-4f56-b26c-2994d12af602?format=image">C18</set>
+            <set picURL="https://api.scryfall.com/cards/29c4e4f2-0040-4490-b357-660d729ad9cc?format=image">C17</set>
             <reverse-related>Jedit Ojanen of Efrava</reverse-related>
             <reverse-related>Jedit Ojanen, Mercenary</reverse-related>
             <reverse-related count="x" exclude="exclude">Jedit Ojanen, Mercenary</reverse-related>
@@ -1472,11 +1472,11 @@ This creature can't block.</text>
                 <cmc>0</cmc>
                 <pt>3/3</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/9/1/91a182ce-11e6-4a7e-a306-15e3670fc433.jpg?1572370720">C19</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/f/5fc993a7-a1ce-4403-a0a0-2afc9f9eca42.jpg?1572892510">RNA</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/back/d/2/d2d19d33-407b-42fc-84de-d8a0642723c1.jpg?1541007138">GK1</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/8/d83648ae-b9a5-40c1-825d-287b2d4ec838.jpg?1562841191">MM3</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/8/8/880d5dc1-ceec-4c5f-93c2-c88b7dbfcac2.jpg">RTR</set>
+            <set picURL="https://api.scryfall.com/cards/91a182ce-11e6-4a7e-a306-15e3670fc433?format=image">C19</set>
+            <set picURL="https://api.scryfall.com/cards/5fc993a7-a1ce-4403-a0a0-2afc9f9eca42?format=image">RNA</set>
+            <set picURL="https://api.scryfall.com/cards/d2d19d33-407b-42fc-84de-d8a0642723c1?format=image&amp;face=back">GK1</set>
+            <set picURL="https://api.scryfall.com/cards/d83648ae-b9a5-40c1-825d-287b2d4ec838?format=image">MM3</set>
+            <set picURL="https://api.scryfall.com/cards/880d5dc1-ceec-4c5f-93c2-c88b7dbfcac2?format=image">RTR</set>
             <reverse-related>Alive // Well</reverse-related>
             <reverse-related>Call of the Conclave</reverse-related>
             <reverse-related>Centaur Glade</reverse-related>
@@ -1498,7 +1498,7 @@ This creature can't block.</text>
                 <cmc>0</cmc>
                 <pt>3/3</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/c/dcd41697-6fe6-423c-a04a-035a3d4f8fd2.jpg?1654172530">CLB</set>
+            <set picURL="https://api.scryfall.com/cards/dcd41697-6fe6-423c-a04a-035a3d4f8fd2?format=image">CLB</set>
             <reverse-related count="2">Hunted Horror</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -1512,7 +1512,7 @@ This creature can't block.</text>
                 <cmc>0</cmc>
                 <pt>3/3</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/9/8/985be507-6125-4db2-b99f-8b61149ffeeb.jpg">BNG</set>
+            <set picURL="https://api.scryfall.com/cards/985be507-6125-4db2-b99f-8b61149ffeeb?format=image">BNG</set>
             <reverse-related count="2">Fated Intervention</reverse-related>
             <reverse-related>Pheres-Band Raiders</reverse-related>
             <token>1</token>
@@ -1528,7 +1528,7 @@ This creature can't block.</text>
                 <cmc>0</cmc>
                 <pt>4/4</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/6/5/65eebe6c-5bc9-463c-b74c-eae79fc3c1b6.jpg">HOU</set>
+            <set picURL="https://api.scryfall.com/cards/65eebe6c-5bc9-463c-b74c-eae79fc3c1b6?format=image">HOU</set>
             <reverse-related>Champion of Wits</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -1543,7 +1543,7 @@ This creature can't block.</text>
                 <cmc>0</cmc>
                 <pt>4/4</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/6/065e30fe-03e5-4558-8f41-42992b07712e.jpg?1664188387">40K</set>
+            <set picURL="https://api.scryfall.com/cards/065e30fe-03e5-4558-8f41-42992b07712e?format=image">40K</set>
             <reverse-related exclude="exclude">Inquisitor Eisenhorn</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -1557,7 +1557,7 @@ This creature can't block.</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/6/165164e7-5693-4d65-b789-8ed8a222365b.jpg?1547509191">UMA</set>
+            <set picURL="https://api.scryfall.com/cards/165164e7-5693-4d65-b789-8ed8a222365b?format=image">UMA</set>
             <reverse-related count="2">Icatian Crier</reverse-related>
             <reverse-related count="4">Icatian Town</reverse-related>
             <token>1</token>
@@ -1573,7 +1573,7 @@ This creature can't block.</text>
                 <cmc>0</cmc>
                 <pt>2/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/e/de7ba875-f77b-404f-8b75-4ba6f81da410.jpg?1557575978">WAR</set>
+            <set picURL="https://api.scryfall.com/cards/de7ba875-f77b-404f-8b75-4ba6f81da410?format=image">WAR</set>
             <reverse-related>Planewide Celebration</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -1587,7 +1587,7 @@ This creature can't block.</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/3/f/3f03e9fe-cb71-498e-bf16-5af6af37a192.jpg?1650820069">SNC</set>
+            <set picURL="https://api.scryfall.com/cards/3f03e9fe-cb71-498e-bf16-5af6af37a192?format=image">SNC</set>
             <reverse-related count="x">Boss's Chauffeur</reverse-related>
             <reverse-related count="2">Cabaretti Charm</reverse-related>
             <reverse-related count="2">Caldaia Guardian</reverse-related>
@@ -1623,8 +1623,8 @@ This creature can't block.</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/8/8/88bb40e8-3057-4707-82e8-4b3d19d51e91.jpg?1552078406">GK2</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/9/a/9af74e26-69d7-4683-9a71-9b420c03d75f.jpg">GTC</set>
+            <set picURL="https://api.scryfall.com/cards/88bb40e8-3057-4707-82e8-4b3d19d51e91?format=image">GK2</set>
+            <set picURL="https://api.scryfall.com/cards/9af74e26-69d7-4683-9a71-9b420c03d75f?format=image">GTC</set>
             <reverse-related>Deathpact Angel</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -1638,7 +1638,7 @@ This creature can't block.</text>
                 <cmc>0</cmc>
                 <pt>2/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/7/e/7e4c9173-e530-4237-a03b-9aeca60ab0e4.jpg">THS</set>
+            <set picURL="https://api.scryfall.com/cards/7e4c9173-e530-4237-a03b-9aeca60ab0e4?format=image">THS</set>
             <reverse-related>Heliod, God of the Sun</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -1652,7 +1652,7 @@ This creature can't block.</text>
                 <cmc>0</cmc>
                 <pt>0/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/7/4/74791ac4-7297-4731-aff8-20130da8b4b7.jpg?1562702134">DOM</set>
+            <set picURL="https://api.scryfall.com/cards/74791ac4-7297-4731-aff8-20130da8b4b7?format=image">DOM</set>
             <reverse-related count="2">Rite of Belzenlok</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -1668,7 +1668,7 @@ Cloud Sprite can block only creatures with flying.</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/4/a/4a2144f2-d4be-419e-bfca-116cedfdf18b.jpg?1641306024">TSR</set>
+            <set picURL="https://api.scryfall.com/cards/4a2144f2-d4be-419e-bfca-116cedfdf18b?format=image">TSR</set>
             <reverse-related>Cloudseeder</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -1682,7 +1682,7 @@ Cloud Sprite can block only creatures with flying.</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/7/f/7fcd324b-8325-40f3-8a02-b84102cc63ab.jpg?1664344050">UNF</set>
+            <set picURL="https://api.scryfall.com/cards/7fcd324b-8325-40f3-8a02-b84102cc63ab?format=image">UNF</set>
             <reverse-related>Assembled Ensemble</reverse-related>
             <reverse-related count="x">Circuits Act</reverse-related>
             <reverse-related count="x">Clown Car</reverse-related>
@@ -1703,21 +1703,21 @@ Cloud Sprite can block only creatures with flying.</text>
                 <maintype>Artifact</maintype>
                 <cmc>0</cmc>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/4/3/43eab560-8ead-4383-afb9-9180a214704b.jpg?1663530503">40K</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/2/d25234a6-cb8d-479a-90f5-9d1a1084277b.jpg?1654172822">CLB</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/e/6/e69b3894-a78f-446b-9777-3c33731aa2ac.jpg?1641599918">VOC</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/4/d45eca06-2ef2-47ef-a0ab-6766bbd3ab8b.jpg?1653273214">MID</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/e/b/eb129b0d-1349-4e88-a6a7-b7968b26ee7e.jpg?1641306201">MH2</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/1/d1dfd9b9-8214-4e20-b1c9-48c9f7276883.jpg?1601138520">2XM</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/b/7/b7c52125-929a-4e03-a955-d55ae34a905b.jpg?1634242346">SLD</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/9/3/93acc8a5-c694-4ad8-b4c0-2e156424319d.jpg?1592710105">C18</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/back/9/b/9b111525-0600-4bae-94a3-df8f9472388f.jpg?1571508353">UST</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/f/2/f2c859e1-181e-44d1-afbd-bbd6e52cf42a.jpg?1562086885">SOI</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/4/f/4f1241c3-d960-4eb4-a726-ca474209645b.jpg?1562086869">SOI</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/2/7/271afa7e-2126-4497-b871-9795b7355d69.jpg?1562086861">SOI</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/2/9/291e6490-6727-45ae-90ba-de2ff8f63162.jpg?1562086863">SOI</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/b/2/b2d16818-7812-4d36-b1bf-fb954e5ac958.jpg?1562086877">SOI</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/3/d/3d66ec9c-7e5d-47ca-bce4-46798152d1f4.jpg?1562086865">SOI</set>
+            <set picURL="https://api.scryfall.com/cards/43eab560-8ead-4383-afb9-9180a214704b?format=image">40K</set>
+            <set picURL="https://api.scryfall.com/cards/d25234a6-cb8d-479a-90f5-9d1a1084277b?format=image">CLB</set>
+            <set picURL="https://api.scryfall.com/cards/e69b3894-a78f-446b-9777-3c33731aa2ac?format=image">VOC</set>
+            <set picURL="https://api.scryfall.com/cards/d45eca06-2ef2-47ef-a0ab-6766bbd3ab8b?format=image">MID</set>
+            <set picURL="https://api.scryfall.com/cards/eb129b0d-1349-4e88-a6a7-b7968b26ee7e?format=image">MH2</set>
+            <set picURL="https://api.scryfall.com/cards/d1dfd9b9-8214-4e20-b1c9-48c9f7276883?format=image">2XM</set>
+            <set picURL="https://api.scryfall.com/cards/b7c52125-929a-4e03-a955-d55ae34a905b?format=image">SLD</set>
+            <set picURL="https://api.scryfall.com/cards/93acc8a5-c694-4ad8-b4c0-2e156424319d?format=image">C18</set>
+            <set picURL="https://api.scryfall.com/cards/9b111525-0600-4bae-94a3-df8f9472388f?format=image&amp;face=back">UST</set>
+            <set picURL="https://api.scryfall.com/cards/f2c859e1-181e-44d1-afbd-bbd6e52cf42a?format=image">SOI</set>
+            <set picURL="https://api.scryfall.com/cards/4f1241c3-d960-4eb4-a726-ca474209645b?format=image">SOI</set>
+            <set picURL="https://api.scryfall.com/cards/271afa7e-2126-4497-b871-9795b7355d69?format=image">SOI</set>
+            <set picURL="https://api.scryfall.com/cards/291e6490-6727-45ae-90ba-de2ff8f63162?format=image">SOI</set>
+            <set picURL="https://api.scryfall.com/cards/b2d16818-7812-4d36-b1bf-fb954e5ac958?format=image">SOI</set>
+            <set picURL="https://api.scryfall.com/cards/3d66ec9c-7e5d-47ca-bce4-46798152d1f4?format=image">SOI</set>
             <reverse-related>Academy Manufactor</reverse-related>
             <reverse-related>Angelic Sleuth</reverse-related>
             <reverse-related count="x" exclude="exclude">Angelic Sleuth</reverse-related>
@@ -1781,8 +1781,8 @@ Cloud Sprite can block only creatures with flying.</text>
                 <cmc>0</cmc>
                 <pt>6/12</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/8/9/8936efa7-c4d0-426d-977b-38c957a9f025.jpg?1592710123">C18</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/4/04d6b47f-5c2a-4771-90ee-4aa8c1eda0be.jpg">WWK</set>
+            <set picURL="https://api.scryfall.com/cards/8936efa7-c4d0-426d-977b-38c957a9f025?format=image">C18</set>
+            <set picURL="https://api.scryfall.com/cards/04d6b47f-5c2a-4771-90ee-4aa8c1eda0be?format=image">WWK</set>
             <reverse-related>Ancient Stone Idol</reverse-related>
             <reverse-related>Stone Idol Trap</reverse-related>
             <token>1</token>
@@ -1797,8 +1797,8 @@ Cloud Sprite can block only creatures with flying.</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/7/c/7c82af53-2de8-4cd6-84bf-fb39d2693de2.jpg?1561897501">CN2</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/f/5f30e5e6-e9df-4ae2-9e40-ad2fee58fc29.jpg">CNS</set>
+            <set picURL="https://api.scryfall.com/cards/7c82af53-2de8-4cd6-84bf-fb39d2693de2?format=image">CN2</set>
+            <set picURL="https://api.scryfall.com/cards/5f30e5e6-e9df-4ae2-9e40-ad2fee58fc29?format=image">CNS</set>
             <reverse-related>Daretti, Ingenious Iconoclast</reverse-related>
             <reverse-related>Flamewright</reverse-related>
             <reverse-related>Sentinel Dispatch</reverse-related>
@@ -1813,10 +1813,10 @@ Cloud Sprite can block only creatures with flying.</text>
                 <cmc>0</cmc>
                 <pt>*/*</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/0/c083dc19-2b62-4233-9ab9-04adc758b6d9.jpg?1641306112">C21</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/9/1935902c-d84f-496a-b9f1-f96d1f5e2b84.jpg?1562899738">UST</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/6/2/623a08d1-f5ff-48b7-bdb6-54b8d7a4b931.jpg?1562639829">KLD</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/5/a55f071a-f250-4a2b-9060-da27f2fc0f48.jpg?1562639962">KLD</set>
+            <set picURL="https://api.scryfall.com/cards/c083dc19-2b62-4233-9ab9-04adc758b6d9?format=image">C21</set>
+            <set picURL="https://api.scryfall.com/cards/1935902c-d84f-496a-b9f1-f96d1f5e2b84?format=image">UST</set>
+            <set picURL="https://api.scryfall.com/cards/623a08d1-f5ff-48b7-bdb6-54b8d7a4b931?format=image">KLD</set>
+            <set picURL="https://api.scryfall.com/cards/a55f071a-f250-4a2b-9060-da27f2fc0f48?format=image">KLD</set>
             <reverse-related>Metallurgic Summonings</reverse-related>
             <reverse-related>Oviya Pashiri, Sage Lifecrafter</reverse-related>
             <reverse-related>Rapid Prototyper</reverse-related>
@@ -1832,12 +1832,12 @@ Cloud Sprite can block only creatures with flying.</text>
                 <cmc>0</cmc>
                 <pt>0/0</pt>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/4/a/4ad1fd1a-9c1e-4b01-974e-84f18d325cfc.jpg?1674397386">DMR</set>
-            <set picURL="https://cards.scryfall.io/large/front/9/1/914fecab-24c0-4179-84d6-ded78c29134f.jpg?1667886948">BRO</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/7/a7caaf39-8f16-4f1d-bee6-a45674306319.jpg?1641306203">MH2</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/0/008d3b2e-a5e6-4ac2-85a0-82628333b80c.jpg?1641306112">C21</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/8/5/85f212cd-4fc6-42fe-b268-22d8e3b2b7eb.jpg?1563073206">MH1</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/5/c5eafa38-5333-4ef2-9661-08074c580a32.jpg?1562702317">DOM</set>
+            <set picURL="https://api.scryfall.com/cards/4ad1fd1a-9c1e-4b01-974e-84f18d325cfc?format=image">DMR</set>
+            <set picURL="https://api.scryfall.com/cards/914fecab-24c0-4179-84d6-ded78c29134f?format=image">BRO</set>
+            <set picURL="https://api.scryfall.com/cards/a7caaf39-8f16-4f1d-bee6-a45674306319?format=image">MH2</set>
+            <set picURL="https://api.scryfall.com/cards/008d3b2e-a5e6-4ac2-85a0-82628333b80c?format=image">C21</set>
+            <set picURL="https://api.scryfall.com/cards/85f212cd-4fc6-42fe-b268-22d8e3b2b7eb?format=image">MH1</set>
+            <set picURL="https://api.scryfall.com/cards/c5eafa38-5333-4ef2-9661-08074c580a32?format=image">DOM</set>
             <reverse-related>Digsite Engineer</reverse-related>
             <reverse-related>Karn, Scion of Urza</reverse-related>
             <reverse-related exclude="exclude">Urza's Command</reverse-related>
@@ -1855,8 +1855,8 @@ Cloud Sprite can block only creatures with flying.</text>
                 <cmc>0</cmc>
                 <pt>4/4</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/4/0/4001c4c6-647c-4ffc-9803-81df43b77e12.jpg?1594733639">M21</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/7/f/7fee6034-f0bb-49b9-ad75-67d3d6be1159.jpg?1592710114">C18</set>
+            <set picURL="https://api.scryfall.com/cards/4001c4c6-647c-4ffc-9803-81df43b77e12?format=image">M21</set>
+            <set picURL="https://api.scryfall.com/cards/7fee6034-f0bb-49b9-ad75-67d3d6be1159?format=image">C18</set>
             <reverse-related>Chrome Replicator</reverse-related>
             <reverse-related exclude="exclude">Retrofitter Foundry</reverse-related>
             <token>1</token>
@@ -1870,9 +1870,9 @@ Cloud Sprite can block only creatures with flying.</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/f/0f5715cf-fbf6-4b13-af91-525edc7706ea.jpg?1654171646">CLB</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/2/7/2770f887-7e96-44d1-864a-8c0504a39785.jpg?1644542778">NEO</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/3/4/3462c167-e6cf-46f8-9b77-2a88815e3b82.jpg?1604194971">ZNR</set>
+            <set picURL="https://api.scryfall.com/cards/0f5715cf-fbf6-4b13-af91-525edc7706ea?format=image">CLB</set>
+            <set picURL="https://api.scryfall.com/cards/2770f887-7e96-44d1-864a-8c0504a39785?format=image">NEO</set>
+            <set picURL="https://api.scryfall.com/cards/3462c167-e6cf-46f8-9b77-2a88815e3b82?format=image">ZNR</set>
             <reverse-related count="2" exclude="exclude">Jan Jansen, Chaos Crafter</reverse-related>
             <reverse-related count="x=4">Myriad Construct</reverse-related>
             <reverse-related>Nimblewright Schematic</reverse-related>
@@ -1888,7 +1888,7 @@ Cloud Sprite can block only creatures with flying.</text>
                 <cmc>0</cmc>
                 <pt>2/2</pt>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/0/8/087ab398-474f-4455-bef4-ea42c6913486.jpg?1667886890">BRO</set>
+            <set picURL="https://api.scryfall.com/cards/087ab398-474f-4455-bef4-ea42c6913486?format=image">BRO</set>
             <reverse-related>Kayla's Command</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -1903,7 +1903,7 @@ Cloud Sprite can block only creatures with flying.</text>
                 <cmc>0</cmc>
                 <pt>3/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/b/cbafdfc0-380a-482b-b5f8-a7a00ecf8da6.jpg?1644542843">NEO</set>
+            <set picURL="https://api.scryfall.com/cards/cbafdfc0-380a-482b-b5f8-a7a00ecf8da6?format=image">NEO</set>
             <reverse-related>Sokenzan Smelter</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -1918,7 +1918,7 @@ Cloud Sprite can block only creatures with flying.</text>
                 <cmc>0</cmc>
                 <pt>4/4</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/d/dd308e57-6ded-4131-bc52-6c04025b8e60.jpg?1664346138">UNF</set>
+            <set picURL="https://api.scryfall.com/cards/dd308e57-6ded-4131-bc52-6c04025b8e60?format=image">UNF</set>
             <reverse-related>Octo Opus</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -1932,7 +1932,7 @@ Cloud Sprite can block only creatures with flying.</text>
                 <cmc>0</cmc>
                 <pt>0/3</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/7/e/7ef7f37a-b7f5-45a1-8f2b-7097089ca2e5.jpg?1641306174">MH2</set>
+            <set picURL="https://api.scryfall.com/cards/7ef7f37a-b7f5-45a1-8f2b-7097089ca2e5?format=image">MH2</set>
             <reverse-related>Hard Evidence</reverse-related>
             <reverse-related>Scuttletide</reverse-related>
             <reverse-related>Specimen Collector</reverse-related>
@@ -1949,7 +1949,7 @@ Cloud Sprite can block only creatures with flying.</text>
                 <cmc>0</cmc>
                 <pt>2/3</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/5/c58def55-f2ca-4c41-b891-c32e5220fc66.jpg?1615686348">KHM</set>
+            <set picURL="https://api.scryfall.com/cards/c58def55-f2ca-4c41-b891-c32e5220fc66?format=image">KHM</set>
             <reverse-related>The Bloodsky Massacre</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -1964,13 +1964,13 @@ Cloud Sprite can block only creatures with flying.</text>
                 <cmc>0</cmc>
                 <pt>5/5</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/3/b/3b3c99d1-ebd3-4eb4-ba04-941819394567.jpg?1598311608">2XM</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/f/5/f54c7f9f-a1ea-4bf0-8ab3-cca49f393f4a.jpg?1594733532">M21</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/f/dfb61889-9bc6-426d-8ce5-7b1c0e6e959b.jpg?1592515962">M20</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/4/14259948-5427-401f-b510-f5b705445e50.jpg">ORI</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/6/c655cd86-ed24-46e4-95d8-7eb1cf251de4.jpg">C14</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/6/a/6a3fc83f-ab02-4a44-910a-bfadc71cf162.jpg">AVR</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/7/7/771ae1f8-70b3-40da-8352-421a36c7abb5.jpg">ISD</set>
+            <set picURL="https://api.scryfall.com/cards/3b3c99d1-ebd3-4eb4-ba04-941819394567?format=image">2XM</set>
+            <set picURL="https://api.scryfall.com/cards/f54c7f9f-a1ea-4bf0-8ab3-cca49f393f4a?format=image">M21</set>
+            <set picURL="https://api.scryfall.com/cards/dfb61889-9bc6-426d-8ce5-7b1c0e6e959b?format=image">M20</set>
+            <set picURL="https://api.scryfall.com/cards/14259948-5427-401f-b510-f5b705445e50?format=image">ORI</set>
+            <set picURL="https://api.scryfall.com/cards/c655cd86-ed24-46e4-95d8-7eb1cf251de4?format=image">C14</set>
+            <set picURL="https://api.scryfall.com/cards/6a3fc83f-ab02-4a44-910a-bfadc71cf162?format=image">AVR</set>
+            <set picURL="https://api.scryfall.com/cards/771ae1f8-70b3-40da-8352-421a36c7abb5?format=image">ISD</set>
             <reverse-related>Archfiend's Vessel</reverse-related>
             <reverse-related>Bloodsoaked Altar</reverse-related>
             <reverse-related>Demonic Rising</reverse-related>
@@ -1990,11 +1990,11 @@ Cloud Sprite can block only creatures with flying.</text>
                 <cmc>0</cmc>
                 <pt>*/*</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/6/c6df5992-9c1c-407d-9602-a6c659342a15.jpg?1641306081">C21</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/9/5/952e41e4-2e1e-4977-a33b-6835446af0e6.jpg">C14</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/8/5/8597029c-3b0d-476e-a6ee-48402f815dab.jpg">CNS</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/3/6/367c872c-d019-42aa-b75a-1c66ec81e766.jpg">DDC</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/8/084c3292-c3ec-431e-b162-309b5cf6309e.jpg">MIR</set>
+            <set picURL="https://api.scryfall.com/cards/c6df5992-9c1c-407d-9602-a6c659342a15?format=image">C21</set>
+            <set picURL="https://api.scryfall.com/cards/952e41e4-2e1e-4977-a33b-6835446af0e6?format=image">C14</set>
+            <set picURL="https://api.scryfall.com/cards/8597029c-3b0d-476e-a6ee-48402f815dab?format=image">CNS</set>
+            <set picURL="https://api.scryfall.com/cards/367c872c-d019-42aa-b75a-1c66ec81e766?format=image">DDC</set>
+            <set picURL="https://api.scryfall.com/cards/084c3292-c3ec-431e-b162-309b5cf6309e?format=image">MIR</set>
             <reverse-related>Promise of Power</reverse-related>
             <reverse-related>Reign of the Pit</reverse-related>
             <reverse-related>Tivash, Gloom Summoner</reverse-related>
@@ -2012,7 +2012,7 @@ At the beginning of your upkeep, sacrifice another creature. If you can't, this 
                 <cmc>0</cmc>
                 <pt>6/6</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/7/3/73b858b5-803b-4bcf-99d6-8c20c8b37f07.jpg?1562702129">DOM</set>
+            <set picURL="https://api.scryfall.com/cards/73b858b5-803b-4bcf-99d6-8c20c8b37f07?format=image">DOM</set>
             <reverse-related exclude="exclude">Rite of Belzenlok</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -2026,7 +2026,7 @@ At the beginning of your upkeep, sacrifice another creature. If you can't, this 
                 <cmc>0</cmc>
                 <pt>3/3</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/7/d744d755-ac09-4511-8664-5ff973e92fc5.jpg?1654171411">CLB</set>
+            <set picURL="https://api.scryfall.com/cards/d744d755-ac09-4511-8664-5ff973e92fc5?format=image">CLB</set>
             <reverse-related>Tasha, the Witch Queen</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -2055,12 +2055,12 @@ At the beginning of your upkeep, sacrifice another creature. If you can't, this 
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/8/9/895df6af-6799-4ec6-b8f4-912b06f30ed2.jpg?1654171507">CLB</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/e/c/ec75fdab-818c-4f3a-94c1-fd3f577a87f5.jpg?1650819970">SNC</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/4/14f9c505-a833-4240-83a0-fbd160bdbf0f.jpg?1641305861">MID</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/e/f/efbc2ca1-4aad-4dfa-9eab-e783f5802078.jpg?1626139223">AFR</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/7/2/72dc3d65-1729-4541-9dc3-bd673e9bdc5d.jpg?1557575948">WAR</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/3/e/3e78c4b8-371b-43d7-a315-fb299704aa60.jpg?1562086867">SOI</set>
+            <set picURL="https://api.scryfall.com/cards/895df6af-6799-4ec6-b8f4-912b06f30ed2?format=image">CLB</set>
+            <set picURL="https://api.scryfall.com/cards/ec75fdab-818c-4f3a-94c1-fd3f577a87f5?format=image">SNC</set>
+            <set picURL="https://api.scryfall.com/cards/14f9c505-a833-4240-83a0-fbd160bdbf0f?format=image">MID</set>
+            <set picURL="https://api.scryfall.com/cards/efbc2ca1-4aad-4dfa-9eab-e783f5802078?format=image">AFR</set>
+            <set picURL="https://api.scryfall.com/cards/72dc3d65-1729-4541-9dc3-bd673e9bdc5d?format=image">WAR</set>
+            <set picURL="https://api.scryfall.com/cards/3e78c4b8-371b-43d7-a315-fb299704aa60?format=image">SOI</set>
             <reverse-related count="3">Burn Down the House</reverse-related>
             <reverse-related count="2">Dance with Devils</reverse-related>
             <reverse-related count="4">Devils' Playground</reverse-related>
@@ -2085,7 +2085,7 @@ At the beginning of your upkeep, sacrifice another creature. If you can't, this 
                 <cmc>0</cmc>
                 <pt>*/*</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/9/d/9d447365-3aca-4996-9098-efcbe6f28f57.jpg?1591225607">IKO</set>
+            <set picURL="https://api.scryfall.com/cards/9d447365-3aca-4996-9098-efcbe6f28f57?format=image">IKO</set>
             <reverse-related>Quartzwood Crasher</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -2099,7 +2099,7 @@ At the beginning of your upkeep, sacrifice another creature. If you can't, this 
                 <cmc>0</cmc>
                 <pt>2/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/b/cb87f3e1-f4ba-459d-9bb9-6651fe073a0a.jpg?1591319240">C20</set>
+            <set picURL="https://api.scryfall.com/cards/cb87f3e1-f4ba-459d-9bb9-6651fe073a0a?format=image">C20</set>
             <reverse-related>Gavi, Nest Warden</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -2114,7 +2114,7 @@ At the beginning of your upkeep, sacrifice another creature. If you can't, this 
                 <cmc>0</cmc>
                 <pt>3/3</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/c/1ccee594-e1e6-4a82-bc17-93bcdeb36198.jpg?1562539756">XLN</set>
+            <set picURL="https://api.scryfall.com/cards/1ccee594-e1e6-4a82-bc17-93bcdeb36198?format=image">XLN</set>
             <reverse-related>Baffling End</reverse-related>
             <reverse-related>Crested Herdcaller</reverse-related>
             <reverse-related>Huatli, Warrior Poet</reverse-related>
@@ -2134,7 +2134,7 @@ At the beginning of your upkeep, sacrifice another creature. If you can't, this 
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/f/9/f918b740-1984-4090-8886-9e290a698b95.jpg?1591225591">IKO</set>
+            <set picURL="https://api.scryfall.com/cards/f918b740-1984-4090-8886-9e290a698b95?format=image">IKO</set>
             <reverse-related>Forbidden Friendship</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -2149,7 +2149,7 @@ At the beginning of your upkeep, sacrifice another creature. If you can't, this 
                 <cmc>0</cmc>
                 <pt>2/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/f/2/f2e8077e-4400-4923-afe6-6ff5a51b5e91.jpg">DTK</set>
+            <set picURL="https://api.scryfall.com/cards/f2e8077e-4400-4923-afe6-6ff5a51b5e91?format=image">DTK</set>
             <reverse-related>Ojutai's Summons</reverse-related>
             <reverse-related>Skywise Teachings</reverse-related>
             <token>1</token>
@@ -2179,7 +2179,7 @@ At the beginning of your upkeep, sacrifice another creature. If you can't, this 
                 <cmc>0</cmc>
                 <pt>*/*</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/e/ce3c0bd9-8a37-4164-9937-f35d1c210fe8.jpg?1626139016">AFR</set>
+            <set picURL="https://api.scryfall.com/cards/ce3c0bd9-8a37-4164-9937-f35d1c210fe8?format=image">AFR</set>
             <reverse-related>Mordenkainen</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -2193,7 +2193,7 @@ At the beginning of your upkeep, sacrifice another creature. If you can't, this 
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/4/f/4f8107b3-8539-4b9c-8d0d-c512c940838f.jpg?1595212478">M21</set>
+            <set picURL="https://api.scryfall.com/cards/4f8107b3-8539-4b9c-8d0d-c512c940838f?format=image">M21</set>
             <reverse-related>Release the Dogs</reverse-related>
             <reverse-related>Rin and Seri, Inseparable</reverse-related>
             <token>1</token>
@@ -2209,7 +2209,7 @@ At the beginning of your upkeep, sacrifice another creature. If you can't, this 
                 <cmc>0</cmc>
                 <pt>3/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/6/7/6736fe71-bd55-4602-b0aa-ece6193048a9.jpg?1650819988">SNC</set>
+            <set picURL="https://api.scryfall.com/cards/6736fe71-bd55-4602-b0aa-ece6193048a9?format=image">SNC</set>
             <reverse-related count="x" exclude="exclude">Jinnie Fay, Jetmir's Second</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -2225,7 +2225,7 @@ When this creature dies, create a 2/2 red Dragon creature token with flying and 
                 <cmc>0</cmc>
                 <pt>0/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/e/0e80f154-9409-40fa-a564-6fc296498d80.jpg?1592710041">C18</set>
+            <set picURL="https://api.scryfall.com/cards/0e80f154-9409-40fa-a564-6fc296498d80?format=image">C18</set>
             <related>Dragon Token    </related>
             <reverse-related>Nesting Dragon</reverse-related>
             <token>1</token>
@@ -2241,7 +2241,7 @@ When this creature dies, create a 2/2 red Dragon creature token with flying and 
                 <cmc>0</cmc>
                 <pt>*/*</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/e/0/e04ca01e-d2ff-45ce-bf6f-9f756808c8fb.jpg?1636630045">VOW</set>
+            <set picURL="https://api.scryfall.com/cards/e04ca01e-d2ff-45ce-bf6f-9f756808c8fb?format=image">VOW</set>
             <reverse-related>Manaform Hellkite</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -2271,7 +2271,7 @@ When this creature dies, create a 2/2 red Dragon creature token with flying and 
                 <cmc>0</cmc>
                 <pt>5/4</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/b/9/b997ace9-ea21-437c-b9cd-128d02f58fa7.jpg?1641306337">AFC</set>
+            <set picURL="https://api.scryfall.com/cards/b997ace9-ea21-437c-b9cd-128d02f58fa7?format=image">AFC</set>
             <reverse-related>Vrondiss, Rage of Ancients</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -2286,7 +2286,7 @@ When this creature dies, create a 2/2 red Dragon creature token with flying and 
                 <cmc>0</cmc>
                 <pt>5/5</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/4/a4c06e08-2026-471d-a6d0-bbb0f040420a.jpg?1644542956">NEO</set>
+            <set picURL="https://api.scryfall.com/cards/a4c06e08-2026-471d-a6d0-bbb0f040420a?format=image">NEO</set>
             <reverse-related>Goro-Goro, Disciple of Ryusei</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -2301,17 +2301,17 @@ When this creature dies, create a 2/2 red Dragon creature token with flying and 
                 <cmc>0</cmc>
                 <pt>5/5</pt>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/3/1/312ea78e-a4e6-4c66-9fd7-62dc7822d89e.jpg?1675905866">ONC</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/8/c87386f2-5e90-4efd-a5d7-4716220d6ab7.jpg?1654172389">CLB</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/2/029c9790-d5f3-4fe2-a2f5-6da5d27de835.jpg?1615686423">KHM</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/3/a378702b-d074-4402-b423-2ca8f44fce7c.jpg?1572370699">C19</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/2/e/2ec9eae0-2c0b-4225-8fa5-96f04a239d47.jpg">M19</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/8/e/8e3b2942-d1a4-4d27-9d64-65712497ab2e.jpg?1561897504">CN2</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/e/2/e290b7f1-1598-4581-96b1-f57419ec408e.jpg?1562857287">C15</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/e/8/e8e4b631-7374-4503-aa66-2a45a41972d3.jpg">BFZ</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/b/8/b87835c7-4739-45c9-a15a-889aa6b6b7ab.jpg">WWK</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/9/9/993b3b90-74c3-479b-b3e6-3f1cd8f1da04.jpg">10E</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/6/56c0fa29-fbcb-41fe-94ab-a39b1154c99b.jpg">ONS</set>
+            <set picURL="https://api.scryfall.com/cards/312ea78e-a4e6-4c66-9fd7-62dc7822d89e?format=image">ONC</set>
+            <set picURL="https://api.scryfall.com/cards/c87386f2-5e90-4efd-a5d7-4716220d6ab7?format=image">CLB</set>
+            <set picURL="https://api.scryfall.com/cards/029c9790-d5f3-4fe2-a2f5-6da5d27de835?format=image">KHM</set>
+            <set picURL="https://api.scryfall.com/cards/a378702b-d074-4402-b423-2ca8f44fce7c?format=image">C19</set>
+            <set picURL="https://api.scryfall.com/cards/2ec9eae0-2c0b-4225-8fa5-96f04a239d47?format=image">M19</set>
+            <set picURL="https://api.scryfall.com/cards/8e3b2942-d1a4-4d27-9d64-65712497ab2e?format=image">CN2</set>
+            <set picURL="https://api.scryfall.com/cards/e290b7f1-1598-4581-96b1-f57419ec408e?format=image">C15</set>
+            <set picURL="https://api.scryfall.com/cards/e8e4b631-7374-4503-aa66-2a45a41972d3?format=image">BFZ</set>
+            <set picURL="https://api.scryfall.com/cards/b87835c7-4739-45c9-a15a-889aa6b6b7ab?format=image">WWK</set>
+            <set picURL="https://api.scryfall.com/cards/993b3b90-74c3-479b-b3e6-3f1cd8f1da04?format=image">10E</set>
+            <set picURL="https://api.scryfall.com/cards/56c0fa29-fbcb-41fe-94ab-a39b1154c99b?format=image">ONS</set>
             <reverse-related>Awaken the Sky Tyrant</reverse-related>
             <reverse-related>Day of the Dragons</reverse-related>
             <reverse-related>Death by Dragons</reverse-related>
@@ -2339,7 +2339,7 @@ When this creature dies, create a 2/2 red Dragon creature token with flying and 
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/b/0bb628da-a02f-4d3e-b919-0c03821dd5f2.jpg">ARB</set>
+            <set picURL="https://api.scryfall.com/cards/0bb628da-a02f-4d3e-b919-0c03821dd5f2?format=image">ARB</set>
             <reverse-related>Dragon Broodmother</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -2354,14 +2354,14 @@ When this creature dies, create a 2/2 red Dragon creature token with flying and 
                 <cmc>0</cmc>
                 <pt>4/4</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/1/d1cae334-1e24-48a3-83a2-0a27bc9d3b29.jpg?1661549438">DMU</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/e/3/e32b97de-9cbb-40a2-ba3b-54e861023df0.jpg?1654171523">CLB</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/1/a195b254-bc3c-4259-9219-5a9e085d7947.jpg?1557575956">WAR</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/b/cb928e3f-b15e-4f76-8909-0ceebe45a8ea.jpg">C17</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/4/0413b3da-fec3-4221-bcec-2b964b45dd00.jpg?1562840729">MM3</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/e/1ee0725f-8562-49c2-83fa-11a702e5c78d.jpg">DTK</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/2/529930fe-a1af-42fb-85a4-4999e787b25b.jpg">MMA</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/b/cbb3e91d-9cae-49c8-ba92-087ad8171b9d.jpg">ALA</set>
+            <set picURL="https://api.scryfall.com/cards/d1cae334-1e24-48a3-83a2-0a27bc9d3b29?format=image">DMU</set>
+            <set picURL="https://api.scryfall.com/cards/e32b97de-9cbb-40a2-ba3b-54e861023df0?format=image">CLB</set>
+            <set picURL="https://api.scryfall.com/cards/a195b254-bc3c-4259-9219-5a9e085d7947?format=image">WAR</set>
+            <set picURL="https://api.scryfall.com/cards/cb928e3f-b15e-4f76-8909-0ceebe45a8ea?format=image">C17</set>
+            <set picURL="https://api.scryfall.com/cards/0413b3da-fec3-4221-bcec-2b964b45dd00?format=image">MM3</set>
+            <set picURL="https://api.scryfall.com/cards/1ee0725f-8562-49c2-83fa-11a702e5c78d?format=image">DTK</set>
+            <set picURL="https://api.scryfall.com/cards/529930fe-a1af-42fb-85a4-4999e787b25b?format=image">MMA</set>
+            <set picURL="https://api.scryfall.com/cards/cbb3e91d-9cae-49c8-ba92-087ad8171b9d?format=image">ALA</set>
             <reverse-related>Broodmate Dragon</reverse-related>
             <reverse-related count="x">Descent of the Dragons</reverse-related>
             <reverse-related>Dragon Cultist</reverse-related>
@@ -2386,9 +2386,9 @@ When this creature dies, create a 2/2 red Dragon creature token with flying and 
                 <cmc>0</cmc>
                 <pt>6/6</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/5/d5013fdc-fae8-4170-8320-1ed13902f319.jpg?1552078407">GK2</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/7/c/7c66280f-287b-4294-9984-32484de2568a.jpg">C17</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/8/4/84310f84-3e5f-4db8-bff1-16bef64de1a0.jpg">RTR</set>
+            <set picURL="https://api.scryfall.com/cards/d5013fdc-fae8-4170-8320-1ed13902f319?format=image">GK2</set>
+            <set picURL="https://api.scryfall.com/cards/7c66280f-287b-4294-9984-32484de2568a?format=image">C17</set>
+            <set picURL="https://api.scryfall.com/cards/84310f84-3e5f-4db8-bff1-16bef64de1a0?format=image">RTR</set>
             <reverse-related>Utvara Hellkite</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -2404,12 +2404,12 @@ When this creature dies, create a 2/2 red Dragon creature token with flying and 
                 <cmc>0</cmc>
                 <pt>2/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/3/f/3f350ecf-67fa-49c8-a47d-9e5573851d62.jpg?1608908530">CMR</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/a/5afb55d9-0852-4fe5-8e3b-330714d4c245.jpg?1592710048">C18</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/f/4/f43a5ec2-8898-4645-84d7-b7218682be9b.jpg">M19</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/4/9/49d37f45-e5ad-48e2-b6d4-9f39b1643f3a.jpg?1562702041">EMA</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/9/6/9661e23a-8914-493b-a08a-e9cd29b4666e.jpg?1562639938">M15</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/e/0efaa5b5-984d-4eff-81b6-9b4989f149eb.jpg">M14</set>
+            <set picURL="https://api.scryfall.com/cards/3f350ecf-67fa-49c8-a47d-9e5573851d62?format=image">CMR</set>
+            <set picURL="https://api.scryfall.com/cards/5afb55d9-0852-4fe5-8e3b-330714d4c245?format=image">C18</set>
+            <set picURL="https://api.scryfall.com/cards/f43a5ec2-8898-4645-84d7-b7218682be9b?format=image">M19</set>
+            <set picURL="https://api.scryfall.com/cards/49d37f45-e5ad-48e2-b6d4-9f39b1643f3a?format=image">EMA</set>
+            <set picURL="https://api.scryfall.com/cards/9661e23a-8914-493b-a08a-e9cd29b4666e?format=image">M15</set>
+            <set picURL="https://api.scryfall.com/cards/0efaa5b5-984d-4eff-81b6-9b4989f149eb?format=image">M14</set>
             <reverse-related>Brood Keeper</reverse-related>
             <reverse-related>Dragon Egg</reverse-related>
             <token>1</token>
@@ -2424,9 +2424,9 @@ Flying</text>
                 <maintype>Creature</maintype>
                 <pt>4/4</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/6/8/6819b8c9-73a3-4e8e-ad7a-95cffabf873a.jpg?1584741606">UND</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/4/4/44c65dfd-69be-4345-92e9-51a35a486f21.jpg?1581535681">UST</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/8/e/8ee8b915-afd3-4fad-8aef-7e9cbbbbc2e4.jpg?1561757559">H17</set>
+            <set picURL="https://api.scryfall.com/cards/6819b8c9-73a3-4e8e-ad7a-95cffabf873a?format=image">UND</set>
+            <set picURL="https://api.scryfall.com/cards/44c65dfd-69be-4345-92e9-51a35a486f21?format=image">UST</set>
+            <set picURL="https://api.scryfall.com/cards/8ee8b915-afd3-4fad-8aef-7e9cbbbbc2e4?format=image">H17</set>
             <reverse-related>Sword of Dungeons &amp; Dragons</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -2441,14 +2441,14 @@ Flying</text>
                 <cmc>0</cmc>
                 <pt>2/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/c/dcd1cef8-d78a-4bdb-8da0-a50ad199c691.jpg?1641306072">C21</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/6/1659d2ee-1831-4ba1-a08d-03af31c9a043.jpg?1604194756">ZNR</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/7/07027a7c-5843-4d78-9b86-8799363c0b82.jpg?1591319174">C20</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/7/9/79f8b710-df8b-4b44-8f70-d5217d7b62ff.jpg?1572370675">C19</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/2/f/2fd81e9a-69b5-4764-91a7-8b6cdddcaa40.jpg?1547509215">UMA</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/6/5/65844e72-aa84-483f-b07e-9e34e798aaec.jpg">AKH</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/8/f/8fb5229a-8bdf-4090-8a5c-a35780bd6ff9.jpg?1562857271">C15</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/9/3/93679bb9-ee1c-4eea-bcdd-72785d5788af.jpg">M13</set>
+            <set picURL="https://api.scryfall.com/cards/dcd1cef8-d78a-4bdb-8da0-a50ad199c691?format=image">C21</set>
+            <set picURL="https://api.scryfall.com/cards/1659d2ee-1831-4ba1-a08d-03af31c9a043?format=image">ZNR</set>
+            <set picURL="https://api.scryfall.com/cards/07027a7c-5843-4d78-9b86-8799363c0b82?format=image">C20</set>
+            <set picURL="https://api.scryfall.com/cards/79f8b710-df8b-4b44-8f70-d5217d7b62ff?format=image">C19</set>
+            <set picURL="https://api.scryfall.com/cards/2fd81e9a-69b5-4764-91a7-8b6cdddcaa40?format=image">UMA</set>
+            <set picURL="https://api.scryfall.com/cards/65844e72-aa84-483f-b07e-9e34e798aaec?format=image">AKH</set>
+            <set picURL="https://api.scryfall.com/cards/8fb5229a-8bdf-4090-8a5c-a35780bd6ff9?format=image">C15</set>
+            <set picURL="https://api.scryfall.com/cards/93679bb9-ee1c-4eea-bcdd-72785d5788af?format=image">M13</set>
             <reverse-related>Drake Haven</reverse-related>
             <reverse-related>Roost of Drakes</reverse-related>
             <reverse-related count="2">Talrand's Invocation</reverse-related>
@@ -2466,7 +2466,7 @@ Flying</text>
                 <cmc>0</cmc>
                 <pt>2/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/0/c06d2c07-7d3e-46e3-86f0-7ceba3b0aee0.jpg">CMA</set>
+            <set picURL="https://api.scryfall.com/cards/c06d2c07-7d3e-46e3-86f0-7ceba3b0aee0?format=image">CMA</set>
             <reverse-related>Leafdrake Roost</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -2482,7 +2482,7 @@ Whenever Dreamstealer deals combat damage to a player, that player discards that
                 <cmc>0</cmc>
                 <pt>4/4</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/8/c/8c362d05-f2f7-4415-8937-f9f368986e61.jpg">HOU</set>
+            <set picURL="https://api.scryfall.com/cards/8c362d05-f2f7-4415-8937-f9f368986e61?format=image">HOU</set>
             <reverse-related>Dreamstealer</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -2497,7 +2497,7 @@ When this creature leaves the battlefield, each opponent loses 2 life and you ga
                 <cmc>0</cmc>
                 <pt>2/2</pt>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/c/f/cfacac5f-7685-4792-9e4c-166d4b421240.jpg?1675095803">ONE</set>
+            <set picURL="https://api.scryfall.com/cards/cfacac5f-7685-4792-9e4c-166d4b421240?format=image">ONE</set>
             <reverse-related>Kaito, Dancing Shadow</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -2511,7 +2511,7 @@ When this creature leaves the battlefield, each opponent loses 2 life and you ga
                 <cmc>0</cmc>
                 <pt>2/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/4/142bbbe1-4446-4d80-b82d-0df8ef17eac1.jpg?1615686398">KHM</set>
+            <set picURL="https://api.scryfall.com/cards/142bbbe1-4446-4d80-b82d-0df8ef17eac1?format=image">KHM</set>
             <reverse-related attach="attach">Dwarven Hammer</reverse-related>
             <reverse-related count="2">Dwarven Reinforcements</reverse-related>
             <reverse-related>Fearless Liberator</reverse-related>
@@ -2529,7 +2529,7 @@ When this creature leaves the battlefield, each opponent loses 2 life and you ga
                 <maintype>Creature</maintype>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/a/cab5d0dd-8095-4410-8feb-8c13edfcb2e5.jpg?1610066785">ELD</set>
+            <set picURL="https://api.scryfall.com/cards/cab5d0dd-8095-4410-8feb-8c13edfcb2e5?format=image">ELD</set>
             <reverse-related>Dwarven Mine</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -2545,7 +2545,7 @@ When Earthshaker Khenra enters the battlefield, target creature with power less 
                 <cmc>0</cmc>
                 <pt>4/4</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/4/c4bb3bd7-5aef-495e-81ba-f5d287981dbd.jpg">HOU</set>
+            <set picURL="https://api.scryfall.com/cards/c4bb3bd7-5aef-495e-81ba-f5d287981dbd?format=image">HOU</set>
             <reverse-related>Earthshaker Khenra</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -2560,8 +2560,8 @@ When Earthshaker Khenra enters the battlefield, target creature with power less 
                 <maintype>Creature</maintype>
                 <pt>0/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/4/8/48cc199d-9596-4d6a-9ed3-b1f599a03741.jpg?1662663443">DMC</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/b/b/bb66de6b-8815-4e6c-a093-18607b003b88.jpg?1568003463">C19</set>
+            <set picURL="https://api.scryfall.com/cards/48cc199d-9596-4d6a-9ed3-b1f599a03741?format=image">DMC</set>
+            <set picURL="https://api.scryfall.com/cards/bb66de6b-8815-4e6c-a093-18607b003b88?format=image">C19</set>
             <reverse-related>Atla Palani, Nest Tender</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -2574,8 +2574,8 @@ When Earthshaker Khenra enters the battlefield, target creature with power less 
                 <cmc>0</cmc>
                 <pt>3/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/6/0/60abe28a-342e-49d0-80f6-6b3ce041372b.jpg?1654172564">CLB</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/1/11d25bde-a303-4b06-a3e1-4ad642deae58.jpg?1562636737">EMN</set>
+            <set picURL="https://api.scryfall.com/cards/60abe28a-342e-49d0-80f6-6b3ce041372b?format=image">CLB</set>
+            <set picURL="https://api.scryfall.com/cards/11d25bde-a303-4b06-a3e1-4ad642deae58?format=image">EMN</set>
             <reverse-related>Desperate Sentry</reverse-related>
             <reverse-related count="x">Emrakul's Evangel</reverse-related>
             <reverse-related>Enlightened Maniac</reverse-related>
@@ -2598,15 +2598,15 @@ When Earthshaker Khenra enters the battlefield, target creature with power less 
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/0/a03edf14-3495-4f61-ad73-f16e9456472c.jpg">OGW</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/f/8/f88da33f-a944-4cc4-978e-3858c2e17e3a.jpg">OGW</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/0/10e69ee5-ea72-4f0b-91fe-152b1459e318.jpg">OGW</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/b/b/bb2f495f-3b50-4b59-a2aa-d33c1767cf7c.jpg">OGW</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/8/d8e91066-63ee-40f7-aa69-0603b61ea49e.jpg">OGW</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/2/0/20b7443e-7eb2-4fcb-8114-23bad3b3bf51.jpg">OGW</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/b/9/b999a0fe-d2d0-4367-9abb-6ce5f3764f19.jpg">BFZ</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/b/abcdf03d-d237-4ceb-91fa-8f95341af369.jpg">BFZ</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/a/5a5c74d5-b219-4514-8fd6-62705459422c.jpg">BFZ</set>
+            <set picURL="https://api.scryfall.com/cards/a03edf14-3495-4f61-ad73-f16e9456472c?format=image">OGW</set>
+            <set picURL="https://api.scryfall.com/cards/f88da33f-a944-4cc4-978e-3858c2e17e3a?format=image">OGW</set>
+            <set picURL="https://api.scryfall.com/cards/10e69ee5-ea72-4f0b-91fe-152b1459e318?format=image">OGW</set>
+            <set picURL="https://api.scryfall.com/cards/bb2f495f-3b50-4b59-a2aa-d33c1767cf7c?format=image">OGW</set>
+            <set picURL="https://api.scryfall.com/cards/d8e91066-63ee-40f7-aa69-0603b61ea49e?format=image">OGW</set>
+            <set picURL="https://api.scryfall.com/cards/20b7443e-7eb2-4fcb-8114-23bad3b3bf51?format=image">OGW</set>
+            <set picURL="https://api.scryfall.com/cards/b999a0fe-d2d0-4367-9abb-6ce5f3764f19?format=image">BFZ</set>
+            <set picURL="https://api.scryfall.com/cards/abcdf03d-d237-4ceb-91fa-8f95341af369?format=image">BFZ</set>
+            <set picURL="https://api.scryfall.com/cards/5a5c74d5-b219-4514-8fd6-62705459422c?format=image">BFZ</set>
             <reverse-related>Abstruse Interference</reverse-related>
             <reverse-related>Adverse Conditions</reverse-related>
             <reverse-related count="2">Birthing Hulk</reverse-related>
@@ -2641,14 +2641,14 @@ When Earthshaker Khenra enters the battlefield, target creature with power less 
                 <cmc>0</cmc>
                 <pt>0/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/6/06e3f3c1-866c-4214-82e0-dcca2d1aba1e.jpg?1601138478">2XM</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/f/1feaa879-ceb3-4b20-8021-ae41d8be9005.jpg">C17</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/d/cd1ef4fc-9b03-4750-90c9-aaa0017579dc.jpg">MM2</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/b/9/b94559ea-b4c8-42e5-81b5-df45b2d711fd.jpg">MM2</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/e/e/eeaae110-ef18-44fa-b8a8-c68bd439581e.jpg">MM2</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/e/0/e0e3826c-3c85-4910-bd6c-04894ea328d0.jpg">ROE</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/3/5/35fb1a3d-3f1a-45ba-a643-1dca435c77de.jpg">ROE</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/0/d0da4f8d-cce9-4d08-8d11-792e0b2af7d0.jpg">ROE</set>
+            <set picURL="https://api.scryfall.com/cards/06e3f3c1-866c-4214-82e0-dcca2d1aba1e?format=image">2XM</set>
+            <set picURL="https://api.scryfall.com/cards/1feaa879-ceb3-4b20-8021-ae41d8be9005?format=image">C17</set>
+            <set picURL="https://api.scryfall.com/cards/cd1ef4fc-9b03-4750-90c9-aaa0017579dc?format=image">MM2</set>
+            <set picURL="https://api.scryfall.com/cards/b94559ea-b4c8-42e5-81b5-df45b2d711fd?format=image">MM2</set>
+            <set picURL="https://api.scryfall.com/cards/eeaae110-ef18-44fa-b8a8-c68bd439581e?format=image">MM2</set>
+            <set picURL="https://api.scryfall.com/cards/e0e3826c-3c85-4910-bd6c-04894ea328d0?format=image">ROE</set>
+            <set picURL="https://api.scryfall.com/cards/35fb1a3d-3f1a-45ba-a643-1dca435c77de?format=image">ROE</set>
+            <set picURL="https://api.scryfall.com/cards/d0da4f8d-cce9-4d08-8d11-792e0b2af7d0?format=image">ROE</set>
             <reverse-related>Awakening Zone</reverse-related>
             <reverse-related count="3">Brood Birthing</reverse-related>
             <reverse-related count="2">Corpsehatch</reverse-related>
@@ -2674,10 +2674,10 @@ When Earthshaker Khenra enters the battlefield, target creature with power less 
                 <cmc>0</cmc>
                 <pt>10/10</pt>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/3/e/3e66f1df-e269-458a-8197-1e8145c7678e.jpg?1675905853">ONC</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/3/9/390b256c-3381-4807-85a6-ff9e62a99bae.jpg?1641306070">C21</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/9/c9854bcf-8729-45b9-9ea3-c43898e4fe5f.jpg?1572370795">C19</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/3/0/30ff04d5-ecaf-4be2-94f4-d5409f1c1e4e.jpg">BFZ</set>
+            <set picURL="https://api.scryfall.com/cards/3e66f1df-e269-458a-8197-1e8145c7678e?format=image">ONC</set>
+            <set picURL="https://api.scryfall.com/cards/390b256c-3381-4807-85a6-ff9e62a99bae?format=image">C21</set>
+            <set picURL="https://api.scryfall.com/cards/c9854bcf-8729-45b9-9ea3-c43898e4fe5f?format=image">C19</set>
+            <set picURL="https://api.scryfall.com/cards/30ff04d5-ecaf-4be2-94f4-d5409f1c1e4e?format=image">BFZ</set>
             <reverse-related>Desolation Twin</reverse-related>
             <reverse-related>Idol of Oblivion</reverse-related>
             <token>1</token>
@@ -2692,7 +2692,7 @@ When Earthshaker Khenra enters the battlefield, target creature with power less 
                 <cmc>0</cmc>
                 <pt>7/7</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/f/9/f9a7ed9a-25e4-41ad-a53e-d589e923af2c.jpg">PCA</set>
+            <set picURL="https://api.scryfall.com/cards/f9a7ed9a-25e4-41ad-a53e-d589e923af2c?format=image">PCA</set>
             <reverse-related>Hedron Fields of Agadeem</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -2707,7 +2707,7 @@ When Earthshaker Khenra enters the battlefield, target creature with power less 
                 <maintype>Creature</maintype>
                 <pt>4/4</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/5/a5582cd9-97e7-426f-a084-c05e2113ad13.jpg?1592515955">M20</set>
+            <set picURL="https://api.scryfall.com/cards/a5582cd9-97e7-426f-a084-c05e2113ad13?format=image">M20</set>
             <reverse-related>Mu Yanling, Sky Dancer</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -2735,9 +2735,9 @@ When Earthshaker Khenra enters the battlefield, target creature with power less 
                 <cmc>0</cmc>
                 <pt>3/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/2/12b27173-a486-4c03-8fce-e334f35d40b6.jpg?1562857258">C15</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/a/da6283ba-1297-4c7d-8744-f530c04194cd.jpg">DD2</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/2/a280aee2-e15a-4625-b429-4032eae08a41.jpg">LRW</set>
+            <set picURL="https://api.scryfall.com/cards/12b27173-a486-4c03-8fce-e334f35d40b6?format=image">C15</set>
+            <set picURL="https://api.scryfall.com/cards/da6283ba-1297-4c7d-8744-f530c04194cd?format=image">DD2</set>
+            <set picURL="https://api.scryfall.com/cards/a280aee2-e15a-4625-b429-4032eae08a41?format=image">LRW</set>
             <reverse-related count="2">Hearthcage Giant</reverse-related>
             <reverse-related count="x">Hostility</reverse-related>
             <reverse-related>Rebellion of the Flamekin</reverse-related>
@@ -2753,15 +2753,15 @@ When Earthshaker Khenra enters the battlefield, target creature with power less 
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/f/6/f66ddc60-4015-4c62-8e13-bc30edef5e37.jpg?1644543433">NEC</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/5/0574973b-a0d1-4e17-9ed7-42a98d25bb8d.jpg?1592515980">M20</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/e/5/e5b57672-c346-42f5-ac3e-82466a13b957.jpg?1563073089">MH1</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/7/a/7ae1c136-7319-45d1-882a-3d838b344773.jpg?1547509297">UMA</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/f/0f7cb791-ac35-4c69-aa85-23e14b821c6a.jpg?1547509309">UMA</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/7/577a3396-e974-47fb-91bd-01751cae83bf.jpg?1561757178">RIX</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/back/7/2/72b45263-d4e9-4a53-a78b-be651e18b615.jpg?1571508472">UST</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/8/b/8b4f81e2-916f-4af4-9e63-f4469e953122.jpg?1562702183">EMA</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/e/d/ed37fa8e-5930-4e57-8ead-73894ac40c19.jpg">M14</set>
+            <set picURL="https://api.scryfall.com/cards/f66ddc60-4015-4c62-8e13-bc30edef5e37?format=image">NEC</set>
+            <set picURL="https://api.scryfall.com/cards/0574973b-a0d1-4e17-9ed7-42a98d25bb8d?format=image">M20</set>
+            <set picURL="https://api.scryfall.com/cards/e5b57672-c346-42f5-ac3e-82466a13b957?format=image">MH1</set>
+            <set picURL="https://api.scryfall.com/cards/7ae1c136-7319-45d1-882a-3d838b344773?format=image">UMA</set>
+            <set picURL="https://api.scryfall.com/cards/0f7cb791-ac35-4c69-aa85-23e14b821c6a?format=image">UMA</set>
+            <set picURL="https://api.scryfall.com/cards/577a3396-e974-47fb-91bd-01751cae83bf?format=image">RIX</set>
+            <set picURL="https://api.scryfall.com/cards/72b45263-d4e9-4a53-a78b-be651e18b615?format=image&amp;face=back">UST</set>
+            <set picURL="https://api.scryfall.com/cards/8b4f81e2-916f-4af4-9e63-f4469e953122?format=image">EMA</set>
+            <set picURL="https://api.scryfall.com/cards/ed37fa8e-5930-4e57-8ead-73894ac40c19?format=image">M14</set>
             <reverse-related count="2">Chandra, Acolyte of Flame</reverse-related>
             <reverse-related count="x">Elemental Mastery</reverse-related>
             <reverse-related attach="attach">Mask of Immolation</reverse-related>
@@ -2784,9 +2784,9 @@ When Earthshaker Khenra enters the battlefield, target creature with power less 
                 <cmc>0</cmc>
                 <pt>3/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/9/d/9d952cde-4b40-4a05-833e-029da3554c6d.jpg?1591319193">C20</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/b/c/bc6f27f7-0248-4c04-8022-41073966e4d8.jpg">OGW</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/a/daf56553-2ecc-4fe8-8730-917d891f6882.jpg">CON</set>
+            <set picURL="https://api.scryfall.com/cards/9d952cde-4b40-4a05-833e-029da3554c6d?format=image">C20</set>
+            <set picURL="https://api.scryfall.com/cards/bc6f27f7-0248-4c04-8022-41073966e4d8?format=image">OGW</set>
+            <set picURL="https://api.scryfall.com/cards/daf56553-2ecc-4fe8-8730-917d891f6882?format=image">CON</set>
             <reverse-related count="2">Chandra, Flamecaller</reverse-related>
             <reverse-related count="3">Feral Lightning</reverse-related>
             <reverse-related>Lightning Coils</reverse-related>
@@ -2804,7 +2804,7 @@ When Earthshaker Khenra enters the battlefield, target creature with power less 
                 <cmc>0</cmc>
                 <pt>*/*</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/f/d/fd0c9fb3-5f4c-47f9-a9b3-369d4936de60.jpg">ROE</set>
+            <set picURL="https://api.scryfall.com/cards/fd0c9fb3-5f4c-47f9-a9b3-369d4936de60?format=image">ROE</set>
             <reverse-related count="2">Devastating Summons</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -2819,7 +2819,7 @@ When Earthshaker Khenra enters the battlefield, target creature with power less 
                 <cmc>0</cmc>
                 <pt>7/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/f/9/f9e12780-9c25-4cb0-b1ff-a36ca50b19d8.jpg">ZEN</set>
+            <set picURL="https://api.scryfall.com/cards/f9e12780-9c25-4cb0-b1ff-a36ca50b19d8?format=image">ZEN</set>
             <reverse-related>Elemental Appeal</reverse-related>
             <reverse-related>Zektar Shrine Expedition</reverse-related>
             <token>1</token>
@@ -2848,9 +2848,9 @@ When Earthshaker Khenra enters the battlefield, target creature with power less 
                 <cmc>0</cmc>
                 <pt>4/4</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/f/e/fea0857b-0f9e-4a87-83d7-85723e33f26c.jpg?1560081229">UMA</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/e/0e9c63b7-ec72-443f-9216-5cb7bd07e940.jpg">MMA</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/8/b/8b4ef48d-a328-4eb9-a2e3-925c1cd38b1a.jpg?1562636788">LRW</set>
+            <set picURL="https://api.scryfall.com/cards/fea0857b-0f9e-4a87-83d7-85723e33f26c?format=image">UMA</set>
+            <set picURL="https://api.scryfall.com/cards/0e9c63b7-ec72-443f-9216-5cb7bd07e940?format=image">MMA</set>
+            <set picURL="https://api.scryfall.com/cards/8b4ef48d-a328-4eb9-a2e3-925c1cd38b1a?format=image">LRW</set>
             <reverse-related>Eyes of the Wisent</reverse-related>
             <reverse-related>Walker of the Grove</reverse-related>
             <token>1</token>
@@ -2865,8 +2865,8 @@ When Earthshaker Khenra enters the battlefield, target creature with power less 
                 <cmc>0</cmc>
                 <pt>*/*</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/5/c5ad13b4-bbf5-4c98-868f-4d105eaf8833.jpg?1592710082">C18</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/b/db67bc06-b6c9-49a0-beef-4d35842497cb.jpg">OGW</set>
+            <set picURL="https://api.scryfall.com/cards/c5ad13b4-bbf5-4c98-868f-4d105eaf8833?format=image">C18</set>
+            <set picURL="https://api.scryfall.com/cards/db67bc06-b6c9-49a0-beef-4d35842497cb?format=image">OGW</set>
             <reverse-related>Dokai, Weaver of Life</reverse-related>
             <reverse-related>Marath, Will of the Wild</reverse-related>
             <reverse-related>Seed Guardian</reverse-related>
@@ -2883,7 +2883,7 @@ When Earthshaker Khenra enters the battlefield, target creature with power less 
                 <cmc>0</cmc>
                 <pt>7/7</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/c/acd51eed-bd5a-417a-811d-fbd1c08a3715.jpg">EVG</set>
+            <set picURL="https://api.scryfall.com/cards/acd51eed-bd5a-417a-811d-fbd1c08a3715?format=image">EVG</set>
             <reverse-related>Voice of the Woods</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -2898,8 +2898,8 @@ When Earthshaker Khenra enters the battlefield, target creature with power less 
                 <cmc>0</cmc>
                 <pt>4/4</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/7/8/7810827c-55ab-431d-a342-d115d97da082.jpg?1562919055">C16</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/c/1c791044-be86-47d8-8c1b-299f6ab254e6.jpg">LRW</set>
+            <set picURL="https://api.scryfall.com/cards/7810827c-55ab-431d-a342-d115d97da082?format=image">C16</set>
+            <set picURL="https://api.scryfall.com/cards/1c791044-be86-47d8-8c1b-299f6ab254e6?format=image">LRW</set>
             <reverse-related>Hoofprints of the Stag</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -2928,7 +2928,7 @@ When Earthshaker Khenra enters the battlefield, target creature with power less 
                 <cmc>0</cmc>
                 <pt>5/5</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/c/0c5afb0a-a158-4995-881e-eae0f20805a6.jpg">SHM</set>
+            <set picURL="https://api.scryfall.com/cards/0c5afb0a-a158-4995-881e-eae0f20805a6?format=image">SHM</set>
             <reverse-related>Din of the Fireherd</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -2943,10 +2943,10 @@ When Earthshaker Khenra enters the battlefield, target creature with power less 
                 <cmc>0</cmc>
                 <pt>5/5</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/6/6/66029f69-2dc3-44e3-aa0d-4fe9a33b06f5.jpg?1641306108">C21</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/e/ae82b600-c406-4c3b-a09b-a18e18fc57b1.jpg?1562702258">EMA</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/2/123f4998-2fee-4533-97ea-3afba67e6b80.jpg?1562857256">C15</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/7/c702fc63-4a79-4c54-b22e-7e479b8354d2.jpg">EVE</set>
+            <set picURL="https://api.scryfall.com/cards/66029f69-2dc3-44e3-aa0d-4fe9a33b06f5?format=image">C21</set>
+            <set picURL="https://api.scryfall.com/cards/ae82b600-c406-4c3b-a09b-a18e18fc57b1?format=image">EMA</set>
+            <set picURL="https://api.scryfall.com/cards/123f4998-2fee-4533-97ea-3afba67e6b80?format=image">C15</set>
+            <set picURL="https://api.scryfall.com/cards/c702fc63-4a79-4c54-b22e-7e479b8354d2?format=image">EVE</set>
             <reverse-related>Call the Skybreaker</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -2961,8 +2961,8 @@ When Earthshaker Khenra enters the battlefield, target creature with power less 
                 <cmc>0</cmc>
                 <pt>8/8</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/2/d2d19d33-407b-42fc-84de-d8a0642723c1.jpg?1541007138">GK1</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/b/6/b64c5f80-4676-4860-be0e-20bcf2227405.jpg">RTR</set>
+            <set picURL="https://api.scryfall.com/cards/d2d19d33-407b-42fc-84de-d8a0642723c1?format=image">GK1</set>
+            <set picURL="https://api.scryfall.com/cards/b64c5f80-4676-4860-be0e-20bcf2227405?format=image">RTR</set>
             <reverse-related>Grove of the Guardian</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -2977,10 +2977,10 @@ When Earthshaker Khenra enters the battlefield, target creature with power less 
                 <cmc>0</cmc>
                 <pt>*/*</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/8/6/8676704a-419e-4a00-a052-bca2ad34ecae.jpg?1601138189">2XM</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/back/7/0/70f1f745-9fc2-41a6-9d39-fb4964595cf5.jpg?1571508365">UST</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/4/04b980ff-02ad-447e-8815-16cd0112ce60.jpg?1562840731">MM3</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/b/5bfb1440-d4c1-42cf-a777-ee1644dbbac7.jpg">DGM</set>
+            <set picURL="https://api.scryfall.com/cards/8676704a-419e-4a00-a052-bca2ad34ecae?format=image">2XM</set>
+            <set picURL="https://api.scryfall.com/cards/70f1f745-9fc2-41a6-9d39-fb4964595cf5?format=image&amp;face=back">UST</set>
+            <set picURL="https://api.scryfall.com/cards/04b980ff-02ad-447e-8815-16cd0112ce60?format=image">MM3</set>
+            <set picURL="https://api.scryfall.com/cards/5bfb1440-d4c1-42cf-a777-ee1644dbbac7?format=image">DGM</set>
             <reverse-related>Voice of Resurgence</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -2994,7 +2994,7 @@ When Earthshaker Khenra enters the battlefield, target creature with power less 
                 <cmc>0</cmc>
                 <pt>1/0</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/f/0/f0e68ed9-d863-4822-b281-e184f3d62faa.jpg">THS</set>
+            <set picURL="https://api.scryfall.com/cards/f0e68ed9-d863-4822-b281-e184f3d62faa?format=image">THS</set>
             <reverse-related count="x">Master of Waves</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -3008,7 +3008,7 @@ When Earthshaker Khenra enters the battlefield, target creature with power less 
                 <cmc>0</cmc>
                 <pt>3/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/9/7/97e5fee3-6dd9-4bbe-b64d-ddfa4b9d4256.jpg">BNG</set>
+            <set picURL="https://api.scryfall.com/cards/97e5fee3-6dd9-4bbe-b64d-ddfa4b9d4256?format=image">BNG</set>
             <reverse-related>Satyr Nyx-Smith</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -3022,8 +3022,8 @@ When Earthshaker Khenra enters the battlefield, target creature with power less 
                 <cmc>0</cmc>
                 <pt>5/3</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/c/5cddb130-a354-4373-9dc4-60c7d57eec8b.jpg?1641306193">MH2</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/4/1449862b-309e-4c58-ac94-13d1acdd363f.jpg">C14</set>
+            <set picURL="https://api.scryfall.com/cards/5cddb130-a354-4373-9dc4-60c7d57eec8b?format=image">MH2</set>
+            <set picURL="https://api.scryfall.com/cards/1449862b-309e-4c58-ac94-13d1acdd363f?format=image">C14</set>
             <reverse-related>Titania, Protector of Argoth</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -3037,7 +3037,7 @@ When Earthshaker Khenra enters the battlefield, target creature with power less 
                 <cmc>0</cmc>
                 <pt>2/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/b/7/b7047838-ac9f-4ca1-9827-73d87098124f.jpg">ORI</set>
+            <set picURL="https://api.scryfall.com/cards/b7047838-ac9f-4ca1-9827-73d87098124f?format=image">ORI</set>
             <reverse-related>Zendikar's Roil</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -3052,10 +3052,10 @@ When Earthshaker Khenra enters the battlefield, target creature with power less 
                 <cmc>0</cmc>
                 <pt>3/1</pt>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/5/7/57ae1be7-f2f6-4aef-8764-4af5ca963c9e.jpg?1674397390">DMR</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/d/addc39de-db64-41d8-9185-67a09d3e326d.jpg?1563073102">MH1</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/9/b/9b9cc37a-b9c3-40c2-a3e4-abfec86e199b.jpg?1562702213">DOM</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/0/10cb10f5-e22a-4ccd-a1b0-c6f245b15f64.jpg">BFZ</set>
+            <set picURL="https://api.scryfall.com/cards/57ae1be7-f2f6-4aef-8764-4af5ca963c9e?format=image">DMR</set>
+            <set picURL="https://api.scryfall.com/cards/addc39de-db64-41d8-9185-67a09d3e326d?format=image">MH1</set>
+            <set picURL="https://api.scryfall.com/cards/9b9cc37a-b9c3-40c2-a3e4-abfec86e199b?format=image">DOM</set>
+            <set picURL="https://api.scryfall.com/cards/10cb10f5-e22a-4ccd-a1b0-c6f245b15f64?format=image">BFZ</set>
             <reverse-related>Akoum Stonewaker</reverse-related>
             <reverse-related count="2">Force of Rage</reverse-related>
             <reverse-related count="x">Valduk, Keeper of the Flame</reverse-related>
@@ -3071,7 +3071,7 @@ When Earthshaker Khenra enters the battlefield, target creature with power less 
                 <cmc>0</cmc>
                 <pt>5/5</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/e/d/ed666385-a2e7-4e1f-ad2c-babbfc0c50b3.jpg">BFZ</set>
+            <set picURL="https://api.scryfall.com/cards/ed666385-a2e7-4e1f-ad2c-babbfc0c50b3?format=image">BFZ</set>
             <reverse-related>Omnath, Locus of Rage</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -3100,7 +3100,7 @@ When Earthshaker Khenra enters the battlefield, target creature with power less 
                 <cmc>0</cmc>
                 <pt>0/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/b/d/bd0bf1d7-2e66-41fd-ae9a-ea86b939e7c9.jpg?1572258674">RIX</set>
+            <set picURL="https://api.scryfall.com/cards/bd0bf1d7-2e66-41fd-ae9a-ea86b939e7c9?format=image">RIX</set>
             <reverse-related>Rekindling Phoenix</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -3115,7 +3115,7 @@ When Earthshaker Khenra enters the battlefield, target creature with power less 
                 <maintype>Creature</maintype>
                 <pt>*/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/6/0/60466c78-155e-442b-8022-795e1e9de8df.jpg?1581901998">THB</set>
+            <set picURL="https://api.scryfall.com/cards/60466c78-155e-442b-8022-795e1e9de8df?format=image">THB</set>
             <reverse-related>Purphoros's Intervention</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -3130,7 +3130,7 @@ When Earthshaker Khenra enters the battlefield, target creature with power less 
                 <cmc>0</cmc>
                 <pt>4/4</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/7/17057115-9163-4f91-b2b9-8387ea547c9d.jpg?1591319124">C20</set>
+            <set picURL="https://api.scryfall.com/cards/17057115-9163-4f91-b2b9-8387ea547c9d?format=image">C20</set>
             <reverse-related>Hoofprints of the Stag</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -3144,7 +3144,7 @@ When Earthshaker Khenra enters the battlefield, target creature with power less 
                 <cmc>0</cmc>
                 <pt>4/4</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/3/d/3d0b9b88-705e-4df0-8a93-3e240b81355b.jpg?1641306151">STX</set>
+            <set picURL="https://api.scryfall.com/cards/3d0b9b88-705e-4df0-8a93-3e240b81355b?format=image">STX</set>
             <reverse-related>Elemental Expressionist</reverse-related>
             <reverse-related count="2">Elemental Masterpiece</reverse-related>
             <reverse-related>Elemental Summoning</reverse-related>
@@ -3168,7 +3168,7 @@ This creature's power and toughness are each equal to the number of instant and 
                 <cmc>0</cmc>
                 <pt>*/*</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/4/c4052aed-981b-41d0-85f0-20c2599811ba.jpg?1641305864">MID</set>
+            <set picURL="https://api.scryfall.com/cards/c4052aed-981b-41d0-85f0-20c2599811ba?format=image">MID</set>
             <reverse-related>Seize the Storm</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -3183,7 +3183,7 @@ This creature's power and toughness are each equal to the number of instant and 
                 <cmc>0</cmc>
                 <pt>2/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/6/c6b2ff6f-d55a-4fa2-86be-e2e012267de4.jpg?1661549478">DMU</set>
+            <set picURL="https://api.scryfall.com/cards/c6b2ff6f-d55a-4fa2-86be-e2e012267de4?format=image">DMU</set>
             <reverse-related>Lagomos, Hand of Hatred</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -3197,24 +3197,24 @@ This creature's power and toughness are each equal to the number of instant and 
                 <cmc>0</cmc>
                 <pt>3/3</pt>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/0/3/0305cc06-f0c2-4ac1-8717-9720cb97d269.jpg?1675905872">ONC</set>
-            <set picURL="https://cards.scryfall.io/large/front/c/b/cb05000b-0ac3-4856-b25d-c87c19bda451.jpg?1674397394">DMR</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/8/5/85218405-499b-4311-83d0-aebec5d02f8e.jpg?1662663464">DMC</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/4/6/46c63821-49f6-4b9a-80a1-18e9c79c5c1a.jpg?1644543311">NEC</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/2/8/2853ba8b-650e-49e3-ab12-86b76e02743b.jpg?1641306093">C21</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/8/c/8c4d495a-b4b7-4119-ae2d-5b602a0b309f.jpg?1620573835">CMR</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/9/8/98e49e47-d658-4378-9e83-7946f7346ede.jpg?1598311699">2XM</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/a/1ae11d5f-f29d-44f4-8d90-cdada1040435.jpg?1563073138">MH1</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/f/e/fe0ea880-0158-4faa-8018-f6626f25dd02.jpg?1562841192">MM3</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/e/de85f692-4c8b-45b5-af8b-05a4c2a6cebf.jpg?1562702390">EMA</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/3/d/3dfc158c-bc5a-4f4b-a813-8ae372dbb0e7.jpg?1562857265">C15</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/2/d/2dbccfc7-427b-41e6-b770-92d73994bf3b.jpg">MM2</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/9/c/9ce92a71-b1f8-4393-90ce-2807c74217be.jpg">C14</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/7/572840b5-c0a1-4a9d-8913-f38fc7b2da78.jpg">CNS</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/c/1c5a05d3-7824-4570-b32d-91fe2dced952.jpg">WWK</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/e/3/e357b329-b624-4c9a-bacf-d4744745860a.jpg">DDD</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/3/d/3dc13cf6-665a-4d92-836f-b2e10ca08ecd.jpg">ODY</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/4/540a3b26-ca61-46c6-9e75-981cae435b2e.jpg">INV</set>
+            <set picURL="https://api.scryfall.com/cards/0305cc06-f0c2-4ac1-8717-9720cb97d269?format=image">ONC</set>
+            <set picURL="https://api.scryfall.com/cards/cb05000b-0ac3-4856-b25d-c87c19bda451?format=image">DMR</set>
+            <set picURL="https://api.scryfall.com/cards/85218405-499b-4311-83d0-aebec5d02f8e?format=image">DMC</set>
+            <set picURL="https://api.scryfall.com/cards/46c63821-49f6-4b9a-80a1-18e9c79c5c1a?format=image">NEC</set>
+            <set picURL="https://api.scryfall.com/cards/2853ba8b-650e-49e3-ab12-86b76e02743b?format=image">C21</set>
+            <set picURL="https://api.scryfall.com/cards/8c4d495a-b4b7-4119-ae2d-5b602a0b309f?format=image">CMR</set>
+            <set picURL="https://api.scryfall.com/cards/98e49e47-d658-4378-9e83-7946f7346ede?format=image">2XM</set>
+            <set picURL="https://api.scryfall.com/cards/1ae11d5f-f29d-44f4-8d90-cdada1040435?format=image">MH1</set>
+            <set picURL="https://api.scryfall.com/cards/fe0ea880-0158-4faa-8018-f6626f25dd02?format=image">MM3</set>
+            <set picURL="https://api.scryfall.com/cards/de85f692-4c8b-45b5-af8b-05a4c2a6cebf?format=image">EMA</set>
+            <set picURL="https://api.scryfall.com/cards/3dfc158c-bc5a-4f4b-a813-8ae372dbb0e7?format=image">C15</set>
+            <set picURL="https://api.scryfall.com/cards/2dbccfc7-427b-41e6-b770-92d73994bf3b?format=image">MM2</set>
+            <set picURL="https://api.scryfall.com/cards/9ce92a71-b1f8-4393-90ce-2807c74217be?format=image">C14</set>
+            <set picURL="https://api.scryfall.com/cards/572840b5-c0a1-4a9d-8913-f38fc7b2da78?format=image">CNS</set>
+            <set picURL="https://api.scryfall.com/cards/1c5a05d3-7824-4570-b32d-91fe2dced952?format=image">WWK</set>
+            <set picURL="https://api.scryfall.com/cards/e357b329-b624-4c9a-bacf-d4744745860a?format=image">DDD</set>
+            <set picURL="https://api.scryfall.com/cards/3dc13cf6-665a-4d92-836f-b2e10ca08ecd?format=image">ODY</set>
+            <set picURL="https://api.scryfall.com/cards/540a3b26-ca61-46c6-9e75-981cae435b2e?format=image">INV</set>
             <reverse-related>Assault // Battery</reverse-related>
             <reverse-related>Bestial Menace</reverse-related>
             <reverse-related>Call of the Herd</reverse-related>
@@ -3240,7 +3240,7 @@ This creature's power and toughness are each equal to the number of instant and 
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/1/01b1f130-2e12-4e57-876b-fc81619ff01f.jpg">C14</set>
+            <set picURL="https://api.scryfall.com/cards/01b1f130-2e12-4e57-876b-fc81619ff01f?format=image">C14</set>
             <reverse-related>Freyalise, Llanowar's Fury</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -3255,8 +3255,8 @@ This creature's power and toughness are each equal to the number of instant and 
                 <cmc>0</cmc>
                 <pt>2/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/back/c/c/cc77373d-34d1-475b-ade9-f49bb64bff9c.jpg?1541007432">GK1</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/7/4/74506297-41ad-40e5-bb05-175650ff4907.jpg?1572892512">GRN</set>
+            <set picURL="https://api.scryfall.com/cards/cc77373d-34d1-475b-ade9-f49bb64bff9c?format=image&amp;face=back">GK1</set>
+            <set picURL="https://api.scryfall.com/cards/74506297-41ad-40e5-bb05-175650ff4907?format=image">GRN</set>
             <reverse-related count="3">Assure // Assemble</reverse-related>
             <reverse-related count="2">Conclave Cavalier</reverse-related>
             <reverse-related>Conclave Guildmage</reverse-related>
@@ -3273,17 +3273,17 @@ This creature's power and toughness are each equal to the number of instant and 
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/1/118d0655-5719-4512-8bc1-fe759669811b.jpg?1615686731">KHM</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/f/f/ff2aea59-c5f1-4927-8534-2215ef79bec7.jpg?1608908549">CMR</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/8/0/808b9201-6fc5-4613-85d6-6e66c6e36a8e.jpg">M19</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/9/5/959ed4bf-b276-45ed-b44d-c757e9c25846.jpg?1562702204">A25</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/9/e/9e0eeebf-7c4a-436b-8cb4-292e53783ff2.jpg?1562926847">C16</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/3/5/355eaeb4-582f-4b74-b573-3dd68f376317.jpg?1562702022">EMA</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/4/b/4bb75376-3b3c-4957-bf87-952f8cfc1da7.jpg">ORI</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/2/0/209af8af-7c40-4e87-8a4e-926c7ea76fb1.jpg">EVG</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/1/a1ad366d-645c-4b14-8e51-437431eb0fa5.jpg">C14</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/b/7/b7663358-c85c-4ba4-ac9b-6be6105363a9.jpg">SHM</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/2/7/27b171ac-b2ef-4a80-92d1-6d9e71f3e3ca.jpg">LRW</set>
+            <set picURL="https://api.scryfall.com/cards/118d0655-5719-4512-8bc1-fe759669811b?format=image">KHM</set>
+            <set picURL="https://api.scryfall.com/cards/ff2aea59-c5f1-4927-8534-2215ef79bec7?format=image">CMR</set>
+            <set picURL="https://api.scryfall.com/cards/808b9201-6fc5-4613-85d6-6e66c6e36a8e?format=image">M19</set>
+            <set picURL="https://api.scryfall.com/cards/959ed4bf-b276-45ed-b44d-c757e9c25846?format=image">A25</set>
+            <set picURL="https://api.scryfall.com/cards/9e0eeebf-7c4a-436b-8cb4-292e53783ff2?format=image">C16</set>
+            <set picURL="https://api.scryfall.com/cards/355eaeb4-582f-4b74-b573-3dd68f376317?format=image">EMA</set>
+            <set picURL="https://api.scryfall.com/cards/4bb75376-3b3c-4957-bf87-952f8cfc1da7?format=image">ORI</set>
+            <set picURL="https://api.scryfall.com/cards/209af8af-7c40-4e87-8a4e-926c7ea76fb1?format=image">EVG</set>
+            <set picURL="https://api.scryfall.com/cards/a1ad366d-645c-4b14-8e51-437431eb0fa5?format=image">C14</set>
+            <set picURL="https://api.scryfall.com/cards/b7663358-c85c-4ba4-ac9b-6be6105363a9?format=image">SHM</set>
+            <set picURL="https://api.scryfall.com/cards/27b171ac-b2ef-4a80-92d1-6d9e71f3e3ca?format=image">LRW</set>
             <reverse-related>Ambassador Oak</reverse-related>
             <reverse-related exclude="exclude">Battle for Bretagard</reverse-related>
             <reverse-related>Dwynen's Elite</reverse-related>
@@ -3322,8 +3322,8 @@ This creature's power and toughness are each equal to the number of instant and 
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/b/cb8caa61-e294-4501-b357-a44abd77d09a.jpg?1601138497">2XM</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/4/9/49180301-f72f-48ca-8be1-df295e89cdd7.jpg">SHM</set>
+            <set picURL="https://api.scryfall.com/cards/cb8caa61-e294-4501-b357-a44abd77d09a?format=image">2XM</set>
+            <set picURL="https://api.scryfall.com/cards/49180301-f72f-48ca-8be1-df295e89cdd7?format=image">SHM</set>
             <reverse-related count="x">Mercy Killing</reverse-related>
             <reverse-related>Rhys the Redeemed</reverse-related>
             <token>1</token>
@@ -3337,7 +3337,7 @@ This creature's power and toughness are each equal to the number of instant and 
                 <maintype>Artifact</maintype>
                 <cmc>0</cmc>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/9/6/9616ca53-ea6a-4fc1-8e01-94e0fb47e5ed.jpg">AER</set>
+            <set picURL="https://api.scryfall.com/cards/9616ca53-ea6a-4fc1-8e01-94e0fb47e5ed?format=image">AER</set>
             <reverse-related>Tezzeret the Schemer</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -3352,8 +3352,8 @@ This creature's power and toughness are each equal to the number of instant and 
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/6/f/6f1eb498-8496-4234-8e87-78dc3f647534.jpg?1654171383">CLB</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/7/8/78eb6e0c-3630-46bf-b124-1ff2ddddf63e.jpg?1626139073">AFR</set>
+            <set picURL="https://api.scryfall.com/cards/6f1eb498-8496-4234-8e87-78dc3f647534?format=image">CLB</set>
+            <set picURL="https://api.scryfall.com/cards/78eb6e0c-3630-46bf-b124-1ff2ddddf63e?format=image">AFR</set>
             <reverse-related count="x">Ancient Gold Dragon</reverse-related>
             <reverse-related count="x">Elminster</reverse-related>
             <reverse-related exclude="exclude">Feywild Caretaker</reverse-related>
@@ -3372,9 +3372,9 @@ This creature's power and toughness are each equal to the number of instant and 
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/6/7/67457137-64f2-413d-b62e-658b3f1b1043.jpg?1547509251">UMA</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/8/1/81b53311-d007-42e8-94c0-c18052b6ef09.jpg">MM2</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/6/1666cae8-8750-4091-8e45-259e76268db9.jpg">MOR</set>
+            <set picURL="https://api.scryfall.com/cards/67457137-64f2-413d-b62e-658b3f1b1043?format=image">UMA</set>
+            <set picURL="https://api.scryfall.com/cards/81b53311-d007-42e8-94c0-c18052b6ef09?format=image">MM2</set>
+            <set picURL="https://api.scryfall.com/cards/1666cae8-8750-4091-8e45-259e76268db9?format=image">MOR</set>
             <reverse-related>Bitterblossom</reverse-related>
             <reverse-related count="x">Notorious Throng</reverse-related>
             <reverse-related>Violet Pall</reverse-related>
@@ -3391,8 +3391,8 @@ This creature's power and toughness are each equal to the number of instant and 
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/e/1/e1eb3b8a-f9d3-4ce1-b171-ba7b0c3f4830.jpg">MMA</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/0/a07b4786-1592-42c7-9d3e-d0d66abaed99.jpg">SHM</set>
+            <set picURL="https://api.scryfall.com/cards/e1eb3b8a-f9d3-4ce1-b171-ba7b0c3f4830?format=image">MMA</set>
+            <set picURL="https://api.scryfall.com/cards/a07b4786-1592-42c7-9d3e-d0d66abaed99?format=image">SHM</set>
             <reverse-related count="x">Oona, Queen of the Fae</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -3407,7 +3407,7 @@ Whenever this creature deals combat damage to a player, draw a card.</text>
                 <maintype>Creature</maintype>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/0/1008e47a-a8c4-4f4f-8628-ac4b8f978dd0.jpg?1562898122">UST</set>
+            <set picURL="https://api.scryfall.com/cards/1008e47a-a8c4-4f4f-8628-ac4b8f978dd0?format=image">UST</set>
             <reverse-related count="2">Faerie Aerie</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -3422,7 +3422,7 @@ Whenever this creature deals combat damage to a player, draw a card.</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/b/c/bcd82cb0-ff4b-4f4d-b3d0-3ac53883b099.jpg?1572489144">ELD</set>
+            <set picURL="https://api.scryfall.com/cards/bcd82cb0-ff4b-4f4d-b3d0-3ac53883b099?format=image">ELD</set>
             <reverse-related>Alela, Artful Provocateur</reverse-related>
             <reverse-related count="x=1">Faerie Formation</reverse-related>
             <reverse-related count="4">Hunted Troll</reverse-related>
@@ -3440,7 +3440,7 @@ Whenever this creature deals combat damage to a player, draw a card.</text>
                 <maintype>Artifact</maintype>
                 <cmc>0</cmc>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/9/a9cc7c63-5d13-4fd6-af9d-4a26c2bab8e6.jpg?1591225596">IKO</set>
+            <set picURL="https://api.scryfall.com/cards/a9cc7c63-5d13-4fd6-af9d-4a26c2bab8e6?format=image">IKO</set>
             <reverse-related>Everquill Phoenix</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -3470,9 +3470,9 @@ Whenever this creature deals combat damage to a player, draw a card.</text>
                 <cmc>0</cmc>
                 <pt>3/3</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/3/a/3abd270d-55d0-40f8-9864-4a7d7b9310ff.jpg?1641306072">C21</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/9/b/9badcaa0-8abb-4654-b947-b5ff254a8d19.jpg?1569406051">A25</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/f/1f3cea7c-d092-410d-8c32-af0f4c8bc878.jpg">C14</set>
+            <set picURL="https://api.scryfall.com/cards/3abd270d-55d0-40f8-9864-4a7d7b9310ff?format=image">C21</set>
+            <set picURL="https://api.scryfall.com/cards/9badcaa0-8abb-4654-b947-b5ff254a8d19?format=image">A25</set>
+            <set picURL="https://api.scryfall.com/cards/1f3cea7c-d092-410d-8c32-af0f4c8bc878?format=image">C14</set>
             <related>Whale Token</related>
             <reverse-related>Reef Worm</reverse-related>
             <token>1</token>
@@ -3488,7 +3488,7 @@ Whenever this creature deals combat damage to a player, draw a card.</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/3/b/3b2e726b-f124-43f7-87e4-bb06bbe8e3d7.jpg?1650128407">SNC</set>
+            <set picURL="https://api.scryfall.com/cards/3b2e726b-f124-43f7-87e4-bb06bbe8e3d7?format=image">SNC</set>
             <reverse-related count="2">Exotic Pets</reverse-related>
             <reverse-related>Expendable Lackey</reverse-related>
             <reverse-related>Reservoir Kraken</reverse-related>
@@ -3504,13 +3504,13 @@ Whenever this creature deals combat damage to a player, draw a card.</text>
                 <type>Token Artifact — Food</type>
                 <maintype>Artifact</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/1/01136e91-1ad3-4e01-8f7e-2718c3a9da27.jpg?1664344184">UNF</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/3/7/37e32ba6-108a-421f-9dad-3d03f7ebe239.jpg?1641306206">MH2</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/9/6/965bef73-eb93-4512-91b4-bf2ce7d27d42.jpg?1641306116">C21</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/b/f/bf36408d-ed85-497f-8e68-d3a922c388a0.jpg?1572489210">ELD</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/3/13e8f518-1c0d-4c01-a397-71481839d02b.jpg?1572489217">ELD</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/4/6/46582e55-c6f4-46e4-a78e-2c586ca4cf4d.jpg?1572489226">ELD</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/2/6/261aed78-2d57-4ed4-b3d2-53b139b6bd44.jpg?1572489232">ELD</set>
+            <set picURL="https://api.scryfall.com/cards/01136e91-1ad3-4e01-8f7e-2718c3a9da27?format=image">UNF</set>
+            <set picURL="https://api.scryfall.com/cards/37e32ba6-108a-421f-9dad-3d03f7ebe239?format=image">MH2</set>
+            <set picURL="https://api.scryfall.com/cards/965bef73-eb93-4512-91b4-bf2ce7d27d42?format=image">C21</set>
+            <set picURL="https://api.scryfall.com/cards/bf36408d-ed85-497f-8e68-d3a922c388a0?format=image">ELD</set>
+            <set picURL="https://api.scryfall.com/cards/13e8f518-1c0d-4c01-a397-71481839d02b?format=image">ELD</set>
+            <set picURL="https://api.scryfall.com/cards/46582e55-c6f4-46e4-a78e-2c586ca4cf4d?format=image">ELD</set>
+            <set picURL="https://api.scryfall.com/cards/261aed78-2d57-4ed4-b3d2-53b139b6bd44?format=image">ELD</set>
             <reverse-related>Academy Manufactor</reverse-related>
             <reverse-related>Bake into a Pie</reverse-related>
             <reverse-related>Bartered Cow</reverse-related>
@@ -3555,7 +3555,7 @@ Whenever this creature deals combat damage to a player, draw a card.</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/7/4/74de70f2-93b6-4fc5-8c4d-464f880d3c54.jpg?1667886857">BRO</set>
+            <set picURL="https://api.scryfall.com/cards/74de70f2-93b6-4fc5-8c4d-464f880d3c54?format=image">BRO</set>
             <reverse-related count="x">Awaken the Woods</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -3569,7 +3569,7 @@ Whenever this creature deals combat damage to a player, draw a card.</text>
                 <cmc>0</cmc>
                 <pt>0/0</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/9/1/910f48ab-b04e-4874-b31d-a86a7bc5af14.jpg?1641306151">STX</set>
+            <set picURL="https://api.scryfall.com/cards/910f48ab-b04e-4874-b31d-a86a7bc5af14?format=image">STX</set>
             <reverse-related>Biomathematician</reverse-related>
             <reverse-related>Body of Research</reverse-related>
             <reverse-related>Deekah, Fractal Theorist</reverse-related>
@@ -3597,10 +3597,10 @@ Whenever this creature deals combat damage to a player, draw a card.</text>
                 <cmc>0</cmc>
                 <pt>3/3</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/e/5/e54486a4-f432-4e50-8639-799e036d0657.jpg?1641306095">C21</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/4/9/495d3391-6311-418e-b55a-10c0af751026.jpg?1572892517">RNA</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/3/b/3bb5609e-6e4b-4af5-838d-88b76582ae70.jpg?1562857263">C15</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/b/9/b938d2e0-7e90-4f57-b363-5c68a6207d6c.jpg">GTC</set>
+            <set picURL="https://api.scryfall.com/cards/e54486a4-f432-4e50-8639-799e036d0657?format=image">C21</set>
+            <set picURL="https://api.scryfall.com/cards/495d3391-6311-418e-b55a-10c0af751026?format=image">RNA</set>
+            <set picURL="https://api.scryfall.com/cards/3bb5609e-6e4b-4af5-838d-88b76582ae70?format=image">C15</set>
+            <set picURL="https://api.scryfall.com/cards/b938d2e0-7e90-4f57-b363-5c68a6207d6c?format=image">GTC</set>
             <reverse-related>Incubation // Incongruity</reverse-related>
             <reverse-related>Rapid Hybridization</reverse-related>
             <token>1</token>
@@ -3616,7 +3616,7 @@ Whenever this creature deals combat damage to a player, draw a card.</text>
                 <cmc>0</cmc>
                 <pt>4/4</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/b/f/bfaa2850-3846-4c6a-8e08-937645db3752.jpg?1641306096">C21</set>
+            <set picURL="https://api.scryfall.com/cards/bfaa2850-3846-4c6a-8e08-937645db3752?format=image">C21</set>
             <reverse-related>Trudge Garden</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -3630,9 +3630,9 @@ Whenever this creature deals combat damage to a player, draw a card.</text>
                 <cmc>0</cmc>
                 <pt>3/4</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/b/1/b10d8407-03a8-4ab8-a30a-4d9b651be863.jpg?1568003524">C19</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/4/d41faa34-e156-4ca3-a528-dc78a442d261.jpg">C14</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/f/af3aa149-00fa-4932-b004-f64c8b5d3ca7.jpg">M10</set>
+            <set picURL="https://api.scryfall.com/cards/b10d8407-03a8-4ab8-a30a-4d9b651be863?format=image">C19</set>
+            <set picURL="https://api.scryfall.com/cards/d41faa34-e156-4ca3-a528-dc78a442d261?format=image">C14</set>
+            <set picURL="https://api.scryfall.com/cards/af3aa149-00fa-4932-b004-f64c8b5d3ca7?format=image">M10</set>
             <reverse-related>Gargoyle Castle</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -3645,7 +3645,7 @@ Whenever this creature deals combat damage to a player, draw a card.</text>
                 <maintype>Creature</maintype>
                 <pt>5/5</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/6/2/628c542b-7579-4070-9143-6f1f7221468f.jpg?1609977149">UND</set>
+            <set picURL="https://api.scryfall.com/cards/628c542b-7579-4070-9143-6f1f7221468f?format=image">UND</set>
             <reverse-related>Water Gun Balloon Game</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -3659,7 +3659,7 @@ Whenever this creature deals combat damage to a player, draw a card.</text>
                 <cmc>0</cmc>
                 <pt>4/4</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/1/0197284c-3c17-438b-a46d-83131d56c768.jpg?1641306033">TSR</set>
+            <set picURL="https://api.scryfall.com/cards/0197284c-3c17-438b-a46d-83131d56c768?format=image">TSR</set>
             <reverse-related>Pact of the Titan</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -3673,7 +3673,7 @@ Whenever this creature deals combat damage to a player, draw a card.</text>
                 <maintype>Creature</maintype>
                 <pt>7/7</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/3/c/3c1debc4-0b12-4848-b551-90680ab8c0ab.jpg?1572489176">ELD</set>
+            <set picURL="https://api.scryfall.com/cards/3c1debc4-0b12-4848-b551-90680ab8c0ab?format=image">ELD</set>
             <reverse-related>Giant Opportunity</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -3687,8 +3687,8 @@ Whenever this creature deals combat damage to a player, draw a card.</text>
                 <cmc>0</cmc>
                 <pt>5/5</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/1/c1a41d0d-aaf5-4cb4-a9db-07992c57e436.jpg">MMA</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/6/0661166a-7d6c-4cba-8190-8d3eedf7f58c.jpg">MOR</set>
+            <set picURL="https://api.scryfall.com/cards/c1a41d0d-aaf5-4cb4-a9db-07992c57e436?format=image">MMA</set>
+            <set picURL="https://api.scryfall.com/cards/0661166a-7d6c-4cba-8190-8d3eedf7f58c?format=image">MOR</set>
             <reverse-related>Feudkiller's Verdict</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -3703,8 +3703,8 @@ Whenever this creature deals combat damage to a player, draw a card.</text>
                 <cmc>0</cmc>
                 <pt>4/4</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/0/a06eea30-810b-4623-9862-ec71c4bed11a.jpg?1562841186">MM3</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/6/f/6f84b406-112d-4b01-8500-60391692a17e.jpg">SHM</set>
+            <set picURL="https://api.scryfall.com/cards/a06eea30-810b-4623-9862-ec71c4bed11a?format=image">MM3</set>
+            <set picURL="https://api.scryfall.com/cards/6f84b406-112d-4b01-8500-60391692a17e?format=image">SHM</set>
             <reverse-related>Giantbaiting</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -3718,7 +3718,7 @@ Whenever this creature deals combat damage to a player, draw a card.</text>
                 <cmc>0</cmc>
                 <pt>4/4</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/4/a40a0cb8-0caf-4dd1-b7d0-abbc626985d2.jpg?1615686247">KHM</set>
+            <set picURL="https://api.scryfall.com/cards/a40a0cb8-0caf-4dd1-b7d0-abbc626985d2?format=image">KHM</set>
             <reverse-related attach="attach">Giant's Amulet</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -3734,7 +3734,7 @@ Whenever Glyph Keeper becomes the target of a spell or ability for the first tim
                 <cmc>0</cmc>
                 <pt>5/3</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/e/3/e3d97a02-9187-4dbc-a511-2a15ca840cda.jpg">AKH</set>
+            <set picURL="https://api.scryfall.com/cards/e3d97a02-9187-4dbc-a511-2a15ca840cda?format=image">AKH</set>
             <reverse-related>Glyph Keeper</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -3747,7 +3747,7 @@ Whenever Glyph Keeper becomes the target of a spell or ability for the first tim
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/b/dbf33cc3-254f-4c5c-be22-3a2d96f29b80.jpg?1581535770">UST</set>
+            <set picURL="https://api.scryfall.com/cards/dbf33cc3-254f-4c5c-be22-3a2d96f29b80?format=image">UST</set>
             <reverse-related>By Gnome Means</reverse-related>
             <reverse-related>Gnome-Made Engine</reverse-related>
             <reverse-related count="2">Gnomeball Machine</reverse-related>
@@ -3765,15 +3765,15 @@ Whenever Glyph Keeper becomes the target of a spell or ability for the first tim
                 <cmc>0</cmc>
                 <pt>0/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/c/5ce4f2b0-d63e-4f65-8261-ae61a8c9f591.jpg?1654171289">CLB</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/3/6/36cd5f96-5683-4959-b973-37f3c2fcf9bf.jpg?1581901929">THB</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/2/1/213be25c-88db-440b-83c3-973586a4f320.jpg?1572489117">ELD</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/4/c4b44a88-85e8-4f82-8968-cf1352f0fb87.jpg?1562931813">UST</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/d/ad511e21-5139-43d4-b07a-9d340465e100.jpg?1562929903">C16</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/b/5ba0e1c8-bb8e-4be4-8177-b2175e0c33fb.jpg">C14</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/6/4/64e90524-bad8-4d24-85be-9402401e7b42.jpg">M14</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/f/a/fa0f1de9-464c-4f12-bd1d-a4a5b88fe803.jpg">M13</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/9/0/90f67615-8a09-4ab9-9927-899a15e72c03.jpg">EVE</set>
+            <set picURL="https://api.scryfall.com/cards/5ce4f2b0-d63e-4f65-8261-ae61a8c9f591?format=image">CLB</set>
+            <set picURL="https://api.scryfall.com/cards/36cd5f96-5683-4959-b973-37f3c2fcf9bf?format=image">THB</set>
+            <set picURL="https://api.scryfall.com/cards/213be25c-88db-440b-83c3-973586a4f320?format=image">ELD</set>
+            <set picURL="https://api.scryfall.com/cards/c4b44a88-85e8-4f82-8968-cf1352f0fb87?format=image">UST</set>
+            <set picURL="https://api.scryfall.com/cards/ad511e21-5139-43d4-b07a-9d340465e100?format=image">C16</set>
+            <set picURL="https://api.scryfall.com/cards/5ba0e1c8-bb8e-4be4-8177-b2175e0c33fb?format=image">C14</set>
+            <set picURL="https://api.scryfall.com/cards/64e90524-bad8-4d24-85be-9402401e7b42?format=image">M14</set>
+            <set picURL="https://api.scryfall.com/cards/fa0f1de9-464c-4f12-bd1d-a4a5b88fe803?format=image">M13</set>
+            <set picURL="https://api.scryfall.com/cards/90f67615-8a09-4ab9-9927-899a15e72c03?format=image">EVE</set>
             <reverse-related count="3">Clackbridge Troll</reverse-related>
             <reverse-related exclude="exclude">Contraband Livestock</reverse-related>
             <reverse-related>Discordant Piper</reverse-related>
@@ -3796,7 +3796,7 @@ At the beginning of your upkeep, this creature deals 1 damage to you.</text>
                 <cmc>0</cmc>
                 <pt>0/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/b/2/b24a63e2-c2b3-43f8-a15a-68886bec7d60.jpg?1604195010">ZNR</set>
+            <set picURL="https://api.scryfall.com/cards/b24a63e2-c2b3-43f8-a15a-68886bec7d60?format=image">ZNR</set>
             <reverse-related>Relic Robber</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -3810,8 +3810,8 @@ At the beginning of your upkeep, this creature deals 1 damage to you.</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/3/3/33bd708d-dc84-44d3-a563-536ade028bd0.jpg">MMA</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/f/4/f44d5271-5d10-46b2-9ba2-5788d99de2e6.jpg">LRW</set>
+            <set picURL="https://api.scryfall.com/cards/33bd708d-dc84-44d3-a563-536ade028bd0?format=image">MMA</set>
+            <set picURL="https://api.scryfall.com/cards/f44d5271-5d10-46b2-9ba2-5788d99de2e6?format=image">LRW</set>
             <reverse-related>Boggart Mob</reverse-related>
             <reverse-related count="2">Marsh Flitter</reverse-related>
             <reverse-related count="2">Warren Weirding</reverse-related>
@@ -3844,7 +3844,7 @@ At the beginning of your upkeep, this creature deals 1 damage to you.</text>
                 <cmc>0</cmc>
                 <pt>2/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/d/0d9461c3-f545-4efb-926e-759961db0495.jpg?1644543098">NEO</set>
+            <set picURL="https://api.scryfall.com/cards/0d9461c3-f545-4efb-926e-759961db0495?format=image">NEO</set>
             <related>Treasure Token</related>
             <reverse-related>Fable of the Mirror-Breaker</reverse-related>
             <token>1</token>
@@ -3859,9 +3859,9 @@ At the beginning of your upkeep, this creature deals 1 damage to you.</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/3/0/3022b41d-05c1-452e-a1cd-5ec5a7f4d79d.jpg?1562701996">EMA</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/e/8/e836db04-161c-4f4f-88d2-4271cec62008.jpg">EVE</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/b/3/b3b52233-d240-4be5-bbde-b1e67367ede4.jpg">APC</set>
+            <set picURL="https://api.scryfall.com/cards/3022b41d-05c1-452e-a1cd-5ec5a7f4d79d?format=image">EMA</set>
+            <set picURL="https://api.scryfall.com/cards/e836db04-161c-4f4f-88d2-4271cec62008?format=image">EVE</set>
+            <set picURL="https://api.scryfall.com/cards/b3b52233-d240-4be5-bbde-b1e67367ede4?format=image">APC</set>
             <reverse-related count="2">Goblin Trenches</reverse-related>
             <reverse-related count="x">Rise of the Hobgoblins</reverse-related>
             <token>1</token>
@@ -3876,43 +3876,43 @@ At the beginning of your upkeep, this creature deals 1 damage to you.</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/5/1/51782bd0-178e-40e2-9c4f-8ea4e8e11345.jpg?1675905868">ONC</set>
-            <set picURL="https://cards.scryfall.io/large/front/f/9/f9b8316a-ec6d-43de-a1c5-6ef3c5c53146.jpg?1674397397">DMR</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/2/128511d0-bc4c-48d9-9e8e-9c7c945cfaeb.jpg?1661549497">DMU</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/4/b/4b02577e-62ec-4716-8e4c-51630cf1d49e.jpg?1644543414">NEC</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/4/1425e965-7eea-419c-a7ec-c8169fa9edbf.jpg?1626139812">AFR</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/4/1/41268b47-df00-41db-92d7-991c7945e4c6.jpg?1641306189">MH2</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/2/3/234007e2-624f-42d0-af7f-9788f9f35fab.jpg?1641306034">TSR</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/6/0/60f874f9-7ac2-4d1a-97e3-722db719cd1c.jpg?1584752869">UND</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/5/c5522b39-802a-4508-a671-2f73b0633032.jpg?1563073114">MH1</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/0/c0861b13-6cf8-4078-9178-e223a4041a8b.jpg?1557575963">WAR</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/9/9/993613a6-09a9-45a5-b35f-5a5fdb6d14ec.jpg?1572892502">RNA</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/back/1/d/1d34ff67-24e1-4cf5-b032-8be6b83e0819.jpg?1632381617">GK1</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/6/4/64f4dc68-060b-4c63-8f43-00f53c52a251.jpg?1541007299">GK1</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/b/2/b27dc0bd-ba46-4a5c-9559-7c11eb4ec37b.jpg?1572892497">GRN</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/4/f/4f736760-60d5-412d-9877-753eb7b5f926.jpg">M19</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/b/d/bd79264f-0734-48b7-8333-4035e518d46c.jpg?1562702307">DOM</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/7/9/7913ab41-f5d1-43d3-85e3-451befc97753.jpg?1562702140">A25</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/6/b/6be4b0d5-b3f8-4a5d-8a38-eb0e1886f655.jpg?1562915022">UST</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/8/f/8fbf199b-2c3f-441d-950e-c4a3d3086e4b.jpg?1562841185">MM3</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/3/d3ad6525-af56-4512-9a6e-3441e686c367.jpg?1562702366">EMA</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/b/2/b21498f5-9098-4e50-b1d3-bd64cba1372a.jpg">ORI</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/e/5/e55d42ad-63b1-4468-8da0-c245db4d0ae3.jpg">DTK</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/f/f/ff1df646-52f5-4292-9fd5-5b8393f63931.jpg">EVG</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/7/4/74502af2-3428-4003-9ee5-418af848af2f.jpg">C14</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/e/d/ed418a8b-f158-492d-a323-6265b3175292.jpg">KTK</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/9/8/98993a45-4aff-4f9b-a030-7d72fbb4ec6c.jpg?1562639941">M15</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/2/b/2b1ac66f-4b21-4acf-b51b-41c9d241d971.jpg">MMA</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/7/577c2e32-deb6-40d9-a050-c2acb5bfc05f.jpg">RTR</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/e/0e67efea-8a80-42ec-8e77-07d387d933d4.jpg">M13</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/f/e/feeae905-e456-4598-b3de-b339397983bf.jpg">NPH</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/4/b/4bca62e7-8fb5-45ff-ac9a-17db8095e76c.jpg">DDG</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/b/3/b37f4fdb-1533-4c38-a654-f715fbef6abf.jpg">SOM</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/3/f/3f8cdaea-32da-4c18-bcd0-18bbbda54afb.jpg">M10</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/2/b/2b2b01b8-3dcb-4eab-9402-0db343543c38.jpg">ALA</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/e/9/e9577d3c-ee19-4b53-adac-b304287a066f.jpg">10E</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/6/062043de-a199-408d-8d77-09531ad38b16.jpg">LGN</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/f/b/fbd728ed-d5dc-44b3-9159-6c86cab3be0c.jpg?1561758473">UGL</set>
+            <set picURL="https://api.scryfall.com/cards/51782bd0-178e-40e2-9c4f-8ea4e8e11345?format=image">ONC</set>
+            <set picURL="https://api.scryfall.com/cards/f9b8316a-ec6d-43de-a1c5-6ef3c5c53146?format=image">DMR</set>
+            <set picURL="https://api.scryfall.com/cards/128511d0-bc4c-48d9-9e8e-9c7c945cfaeb?format=image">DMU</set>
+            <set picURL="https://api.scryfall.com/cards/4b02577e-62ec-4716-8e4c-51630cf1d49e?format=image">NEC</set>
+            <set picURL="https://api.scryfall.com/cards/1425e965-7eea-419c-a7ec-c8169fa9edbf?format=image">AFR</set>
+            <set picURL="https://api.scryfall.com/cards/41268b47-df00-41db-92d7-991c7945e4c6?format=image">MH2</set>
+            <set picURL="https://api.scryfall.com/cards/234007e2-624f-42d0-af7f-9788f9f35fab?format=image">TSR</set>
+            <set picURL="https://api.scryfall.com/cards/60f874f9-7ac2-4d1a-97e3-722db719cd1c?format=image">UND</set>
+            <set picURL="https://api.scryfall.com/cards/c5522b39-802a-4508-a671-2f73b0633032?format=image">MH1</set>
+            <set picURL="https://api.scryfall.com/cards/c0861b13-6cf8-4078-9178-e223a4041a8b?format=image">WAR</set>
+            <set picURL="https://api.scryfall.com/cards/993613a6-09a9-45a5-b35f-5a5fdb6d14ec?format=image">RNA</set>
+            <set picURL="https://api.scryfall.com/cards/1d34ff67-24e1-4cf5-b032-8be6b83e0819?format=image&amp;face=back">GK1</set>
+            <set picURL="https://api.scryfall.com/cards/64f4dc68-060b-4c63-8f43-00f53c52a251?format=image">GK1</set>
+            <set picURL="https://api.scryfall.com/cards/b27dc0bd-ba46-4a5c-9559-7c11eb4ec37b?format=image">GRN</set>
+            <set picURL="https://api.scryfall.com/cards/4f736760-60d5-412d-9877-753eb7b5f926?format=image">M19</set>
+            <set picURL="https://api.scryfall.com/cards/bd79264f-0734-48b7-8333-4035e518d46c?format=image">DOM</set>
+            <set picURL="https://api.scryfall.com/cards/7913ab41-f5d1-43d3-85e3-451befc97753?format=image">A25</set>
+            <set picURL="https://api.scryfall.com/cards/6be4b0d5-b3f8-4a5d-8a38-eb0e1886f655?format=image">UST</set>
+            <set picURL="https://api.scryfall.com/cards/8fbf199b-2c3f-441d-950e-c4a3d3086e4b?format=image">MM3</set>
+            <set picURL="https://api.scryfall.com/cards/d3ad6525-af56-4512-9a6e-3441e686c367?format=image">EMA</set>
+            <set picURL="https://api.scryfall.com/cards/b21498f5-9098-4e50-b1d3-bd64cba1372a?format=image">ORI</set>
+            <set picURL="https://api.scryfall.com/cards/e55d42ad-63b1-4468-8da0-c245db4d0ae3?format=image">DTK</set>
+            <set picURL="https://api.scryfall.com/cards/ff1df646-52f5-4292-9fd5-5b8393f63931?format=image">EVG</set>
+            <set picURL="https://api.scryfall.com/cards/74502af2-3428-4003-9ee5-418af848af2f?format=image">C14</set>
+            <set picURL="https://api.scryfall.com/cards/ed418a8b-f158-492d-a323-6265b3175292?format=image">KTK</set>
+            <set picURL="https://api.scryfall.com/cards/98993a45-4aff-4f9b-a030-7d72fbb4ec6c?format=image">M15</set>
+            <set picURL="https://api.scryfall.com/cards/2b1ac66f-4b21-4acf-b51b-41c9d241d971?format=image">MMA</set>
+            <set picURL="https://api.scryfall.com/cards/577c2e32-deb6-40d9-a050-c2acb5bfc05f?format=image">RTR</set>
+            <set picURL="https://api.scryfall.com/cards/0e67efea-8a80-42ec-8e77-07d387d933d4?format=image">M13</set>
+            <set picURL="https://api.scryfall.com/cards/feeae905-e456-4598-b3de-b339397983bf?format=image">NPH</set>
+            <set picURL="https://api.scryfall.com/cards/4bca62e7-8fb5-45ff-ac9a-17db8095e76c?format=image">DDG</set>
+            <set picURL="https://api.scryfall.com/cards/b37f4fdb-1533-4c38-a654-f715fbef6abf?format=image">SOM</set>
+            <set picURL="https://api.scryfall.com/cards/3f8cdaea-32da-4c18-bcd0-18bbbda54afb?format=image">M10</set>
+            <set picURL="https://api.scryfall.com/cards/2b2b01b8-3dcb-4eab-9402-0db343543c38?format=image">ALA</set>
+            <set picURL="https://api.scryfall.com/cards/e9577d3c-ee19-4b53-adac-b304287a066f?format=image">10E</set>
+            <set picURL="https://api.scryfall.com/cards/062043de-a199-408d-8d77-09531ad38b16?format=image">LGN</set>
+            <set picURL="https://api.scryfall.com/cards/fbd728ed-d5dc-44b3-9159-6c86cab3be0c?format=image">UGL</set>
             <reverse-related>Battle Cry Goblin</reverse-related>
             <reverse-related count="2">Beetleback Chief</reverse-related>
             <reverse-related count="x">Box of Free-Range Goblins</reverse-related>
@@ -3971,7 +3971,7 @@ At the beginning of your upkeep, this creature deals 1 damage to you.</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/6/c63967fe-62da-4c27-9aa7-67adc77b2baf.jpg?1561897507">CN2</set>
+            <set picURL="https://api.scryfall.com/cards/c63967fe-62da-4c27-9aa7-67adc77b2baf?format=image">CN2</set>
             <reverse-related>Hold the Perimeter</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -3986,7 +3986,7 @@ At the beginning of your upkeep, this creature deals 1 damage to you.</text>
                 <cmc>0</cmc>
                 <pt>2/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/7/2/72230a1b-90ba-4564-9164-90cffdf34b93.jpg?1577661705">GK2</set>
+            <set picURL="https://api.scryfall.com/cards/72230a1b-90ba-4564-9164-90cffdf34b93?format=image">GK2</set>
             <reverse-related>Rakdos Guildmage</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -4001,8 +4001,8 @@ At the beginning of your upkeep, this creature deals 1 damage to you.</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/d/1db51576-a755-45de-b37b-f16b27e8f3a1.jpg?1654172896">CLB</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/9/9/99a6ebce-f391-4642-857a-4dc1466895f3.jpg?1562926018">C16</set>
+            <set picURL="https://api.scryfall.com/cards/1db51576-a755-45de-b37b-f16b27e8f3a1?format=image">CLB</set>
+            <set picURL="https://api.scryfall.com/cards/99a6ebce-f391-4642-857a-4dc1466895f3?format=image">C16</set>
             <reverse-related>Goblin Spymaster</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -4016,9 +4016,9 @@ At the beginning of your upkeep, this creature deals 1 damage to you.</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/6/d6b6561b-d6f0-4eea-8bc4-e3cd35b38c90.jpg?1591319247">C20</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/f/0f827ad1-4931-404d-a0ff-bff8b98eae42.jpg?1562840734">MM3</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/e/3/e36334f1-afe3-497c-82d9-aaf149934b54.jpg">SHM</set>
+            <set picURL="https://api.scryfall.com/cards/d6b6561b-d6f0-4eea-8bc4-e3cd35b38c90?format=image">C20</set>
+            <set picURL="https://api.scryfall.com/cards/0f827ad1-4931-404d-a0ff-bff8b98eae42?format=image">MM3</set>
+            <set picURL="https://api.scryfall.com/cards/e36334f1-afe3-497c-82d9-aaf149934b54?format=image">SHM</set>
             <reverse-related count="2">Wort, the Raidmother</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -4033,7 +4033,7 @@ At the beginning of your upkeep, this creature deals 1 damage to you.</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/f/d/fd7094d6-6e23-47f2-a9da-4dd680294ac8.jpg?1594733537">M21</set>
+            <set picURL="https://api.scryfall.com/cards/fd7094d6-6e23-47f2-a9da-4dd680294ac8?format=image">M21</set>
             <reverse-related count="2">Goblin Wizardry</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -4046,11 +4046,11 @@ At the beginning of your upkeep, this creature deals 1 damage to you.</text>
                 <maintype>Artifact</maintype>
                 <cmc>0</cmc>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/9/19b15a8a-58bd-4b7e-9b7f-e143c90f35d7.jpg?1654172368">CLB</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/2/c/2c315a76-9561-426e-b726-288424a5069b.jpg?1581902168">THB</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/9/b/9b180a33-65ef-43b3-b969-f603b1fc23fb.jpg">C17</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/c/0ca10abd-8d9d-4c0b-9d33-c3516abdf6b3.jpg?1562857254">C15</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/f/8/f8b8298e-5ce6-4ff6-9563-fcd158ce841e.jpg">BNG</set>
+            <set picURL="https://api.scryfall.com/cards/19b15a8a-58bd-4b7e-9b7f-e143c90f35d7?format=image">CLB</set>
+            <set picURL="https://api.scryfall.com/cards/2c315a76-9561-426e-b726-288424a5069b?format=image">THB</set>
+            <set picURL="https://api.scryfall.com/cards/9b180a33-65ef-43b3-b969-f603b1fc23fb?format=image">C17</set>
+            <set picURL="https://api.scryfall.com/cards/0ca10abd-8d9d-4c0b-9d33-c3516abdf6b3?format=image">C15</set>
+            <set picURL="https://api.scryfall.com/cards/f8b8298e-5ce6-4ff6-9563-fcd158ce841e?format=image">BNG</set>
             <reverse-related>Curse of Opulence</reverse-related>
             <reverse-related>Gild</reverse-related>
             <reverse-related>King Macar, the Gold-Cursed</reverse-related>
@@ -4081,10 +4081,10 @@ At the beginning of your upkeep, this creature deals 1 damage to you.</text>
                 <cmc>0</cmc>
                 <pt>3/3</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/7/b/7becaa04-f142-4163-9286-00018b95c4ca.jpg?1601138543">2XM</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/7/8/78ea4711-a951-4a1b-88cb-f628f97b6164.jpg?1592516001">M20</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/e/ae65394e-0c97-4cde-8591-13d081192e26.jpg">MM2</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/7/c705b843-ca62-47bb-95dd-f303c60088bb.jpg">SOM</set>
+            <set picURL="https://api.scryfall.com/cards/7becaa04-f142-4163-9286-00018b95c4ca?format=image">2XM</set>
+            <set picURL="https://api.scryfall.com/cards/78ea4711-a951-4a1b-88cb-f628f97b6164?format=image">M20</set>
+            <set picURL="https://api.scryfall.com/cards/ae65394e-0c97-4cde-8591-13d081192e26?format=image">MM2</set>
+            <set picURL="https://api.scryfall.com/cards/c705b843-ca62-47bb-95dd-f303c60088bb?format=image">SOM</set>
             <reverse-related>Cavalier of Dawn</reverse-related>
             <reverse-related>Golem Foundry</reverse-related>
             <reverse-related count="2">Masterful Replication</reverse-related>
@@ -4100,7 +4100,7 @@ At the beginning of your upkeep, this creature deals 1 damage to you.</text>
                 <cmc>0</cmc>
                 <pt>9/9</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/2/d/2d84926d-5892-4c62-a943-fac9f0ddc569.jpg">MBS</set>
+            <set picURL="https://api.scryfall.com/cards/2d84926d-5892-4c62-a943-fac9f0ddc569?format=image">MBS</set>
             <reverse-related>Titan Forge</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -4126,7 +4126,7 @@ At the beginning of your upkeep, this creature deals 1 damage to you.</text>
                 <cmc>0</cmc>
                 <pt>4/4</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/7/a7820eb9-6d7f-4bc4-b421-4e4420642fb7.jpg?1561757771">RIX</set>
+            <set picURL="https://api.scryfall.com/cards/a7820eb9-6d7f-4bc4-b421-4e4420642fb7?format=image">RIX</set>
             <reverse-related>Gold-Forge Garrison</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -4139,7 +4139,7 @@ At the beginning of your upkeep, this creature deals 1 damage to you.</text>
                 <cmc>0</cmc>
                 <pt>3/3</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/c/dcee70ef-6285-4f09-8a71-8b7960e8fa99.jpg">THS</set>
+            <set picURL="https://api.scryfall.com/cards/dcee70ef-6285-4f09-8a71-8b7960e8fa99?format=image">THS</set>
             <reverse-related>Hammer of Purphoros</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -4153,7 +4153,7 @@ At the beginning of your upkeep, this creature deals 1 damage to you.</text>
                 <cmc>0</cmc>
                 <pt>3/3</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/6/c6a3a35a-ebd8-47e5-a5ed-c736b8bed968.jpg?1641306118">C21</set>
+            <set picURL="https://api.scryfall.com/cards/c6a3a35a-ebd8-47e5-a5ed-c736b8bed968?format=image">C21</set>
             <reverse-related>Triplicate Titan</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -4167,7 +4167,7 @@ At the beginning of your upkeep, this creature deals 1 damage to you.</text>
                 <cmc>0</cmc>
                 <pt>3/3</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/4/0/40c50c6d-5116-4acb-89d3-f27efb20d336.jpg?1641306120">C21</set>
+            <set picURL="https://api.scryfall.com/cards/40c50c6d-5116-4acb-89d3-f27efb20d336?format=image">C21</set>
             <reverse-related>Triplicate Titan</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -4181,7 +4181,7 @@ At the beginning of your upkeep, this creature deals 1 damage to you.</text>
                 <cmc>0</cmc>
                 <pt>3/3</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/f/2/f27efb56-7fd4-4d0e-b641-a152b3ef8953.jpg?1641306122">C21</set>
+            <set picURL="https://api.scryfall.com/cards/f27efb56-7fd4-4d0e-b641-a152b3ef8953?format=image">C21</set>
             <reverse-related>Triplicate Titan</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -4194,7 +4194,7 @@ At the beginning of your upkeep, this creature deals 1 damage to you.</text>
                 <cmc>0</cmc>
                 <pt>*/*</pt>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/4/7/474c8cfe-71ce-46c7-8cf4-dfeae3c0e73b.jpg?1667916342">BRO</set>
+            <set picURL="https://api.scryfall.com/cards/474c8cfe-71ce-46c7-8cf4-dfeae3c0e73b?format=image">BRO</set>
             <reverse-related>Mask of the Jadecrafter</reverse-related>
             <reverse-related>Rootwire Amalgam</reverse-related>
             <token>1</token>
@@ -4209,7 +4209,7 @@ At the beginning of your upkeep, this creature deals 1 damage to you.</text>
                 <cmc>0</cmc>
                 <pt>4/4</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/7/d/7ddb9e14-b299-4064-a41b-0fb6b078942e.jpg?1641306196">MH2</set>
+            <set picURL="https://api.scryfall.com/cards/7ddb9e14-b299-4064-a41b-0fb6b078942e?format=image">MH2</set>
             <reverse-related>General Ferrous Rokiric</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -4223,7 +4223,7 @@ At the beginning of your upkeep, this creature deals 1 damage to you.</text>
                 <cmc>0</cmc>
                 <pt>*/*</pt>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/6/2/621738c7-24f6-469e-9e44-8c80cd85ba08.jpg?1675905878">ONC</set>
+            <set picURL="https://api.scryfall.com/cards/621738c7-24f6-469e-9e44-8c80cd85ba08?format=image">ONC</set>
             <reverse-related>Vulshok Factory</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -4253,7 +4253,7 @@ At the beginning of your upkeep, this creature deals 1 damage to you.</text>
                 <cmc>0</cmc>
                 <pt>2/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/6/c6071fed-39c1-4f3b-a821-1611aedd8054.jpg">AER</set>
+            <set picURL="https://api.scryfall.com/cards/c6071fed-39c1-4f3b-a821-1611aedd8054?format=image">AER</set>
             <reverse-related>Gremlin Infestation</reverse-related>
             <reverse-related count="x">Release the Gremlins</reverse-related>
             <token>1</token>
@@ -4269,12 +4269,12 @@ At the beginning of your upkeep, this creature deals 1 damage to you.</text>
                 <cmc>0</cmc>
                 <pt>2/2</pt>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/c/a/caeea28b-c11b-4fa0-a64c-637bc58171cc.jpg?1674397400">DMR</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/8/c/8cd2c057-4cfd-4c45-a089-dbbe14b3ea53.jpg?1662663514">DMC</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/2/e/2e7a7388-3f80-41c0-a042-d6b8ef3cf291.jpg?1641306021">TSR</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/e/b/ebbaae25-d0cd-416a-a44a-5b258fd1d9fd.jpg?1594733476">M21</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/e/0/e0e3a11d-c7a3-495b-add9-0503141b1cfe.jpg">DDL</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/9/6/96c36884-df5e-435d-9473-65da550535fb.jpg">DDH</set>
+            <set picURL="https://api.scryfall.com/cards/caeea28b-c11b-4fa0-a64c-637bc58171cc?format=image">DMR</set>
+            <set picURL="https://api.scryfall.com/cards/8cd2c057-4cfd-4c45-a089-dbbe14b3ea53?format=image">DMC</set>
+            <set picURL="https://api.scryfall.com/cards/2e7a7388-3f80-41c0-a042-d6b8ef3cf291?format=image">TSR</set>
+            <set picURL="https://api.scryfall.com/cards/ebbaae25-d0cd-416a-a44a-5b258fd1d9fd?format=image">M21</set>
+            <set picURL="https://api.scryfall.com/cards/e0e3a11d-c7a3-495b-add9-0503141b1cfe?format=image">DDL</set>
+            <set picURL="https://api.scryfall.com/cards/96c36884-df5e-435d-9473-65da550535fb?format=image">DDH</set>
             <reverse-related>Griffin Aerie</reverse-related>
             <reverse-related>Griffin Guide</reverse-related>
             <reverse-related>Zeriam, Golden Wind</reverse-related>
@@ -4292,7 +4292,7 @@ At the beginning of your upkeep, this creature deals 1 damage to you.</text>
                 <cmc>0</cmc>
                 <pt>4/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/6/b/6b2c8f52-1580-42d5-8434-c4c70e31e31b.jpg?1625831431">AFR</set>
+            <set picURL="https://api.scryfall.com/cards/6b2c8f52-1580-42d5-8434-c4c70e31e31b?format=image">AFR</set>
             <reverse-related>Drizzt Do'Urden</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -4307,7 +4307,7 @@ At the beginning of your upkeep, this creature deals 1 damage to you.</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/2/6/26b24bbe-f5bc-44d3-b716-6612d39b07bc.jpg">THS</set>
+            <set picURL="https://api.scryfall.com/cards/26b24bbe-f5bc-44d3-b716-6612d39b07bc?format=image">THS</set>
             <reverse-related count="x">Abhorrent Overlord</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -4322,8 +4322,8 @@ At the beginning of your upkeep, this creature deals 1 damage to you.</text>
                 <cmc>0</cmc>
                 <pt>4/3</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/d/ad1863c6-13c8-4116-9312-32c215f88ee1.jpg?1572370671">C19</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/6/e/6e534d68-a97f-4ae1-b202-31c7a5366b58.jpg">AKH</set>
+            <set picURL="https://api.scryfall.com/cards/ad1863c6-13c8-4116-9312-32c215f88ee1?format=image">C19</set>
+            <set picURL="https://api.scryfall.com/cards/6e534d68-a97f-4ae1-b202-31c7a5366b58?format=image">AKH</set>
             <reverse-related>Heart-Piercer Manticore</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -4337,8 +4337,8 @@ At the beginning of your upkeep, this creature deals 1 damage to you.</text>
                 <cmc>0</cmc>
                 <pt>4/4</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/3/b/3b43b811-ec0f-4ad7-a152-f7f077bafaa4.jpg">M13</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/c/acabc3ce-a3c1-4c6c-8022-9a96ffba59c6.jpg">ROE</set>
+            <set picURL="https://api.scryfall.com/cards/3b43b811-ec0f-4ad7-a152-f7f077bafaa4?format=image">M13</set>
+            <set picURL="https://api.scryfall.com/cards/acabc3ce-a3c1-4c6c-8022-9a96ffba59c6?format=image">ROE</set>
             <reverse-related>Hellion Crucible</reverse-related>
             <reverse-related>Hellion Eruption</reverse-related>
             <token>1</token>
@@ -4368,7 +4368,7 @@ At the beginning of your upkeep, this creature deals 1 damage to you.</text>
                 <cmc>0</cmc>
                 <pt>3/3</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/a/1aea5e0b-dc4e-4055-9e13-1dfbc25a2f00.jpg">AKH</set>
+            <set picURL="https://api.scryfall.com/cards/1aea5e0b-dc4e-4055-9e13-1dfbc25a2f00?format=image">AKH</set>
             <reverse-related>Mouth // Feed</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -4382,8 +4382,8 @@ At the beginning of your upkeep, this creature deals 1 damage to you.</text>
                 <cmc>0</cmc>
                 <pt>2/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/f/3/f3c6ef29-b879-4813-87b0-0e3ba2b5cb29.jpg?1547509238">UMA</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/e/2/e2020f53-d012-4d26-be13-87ed0f196c53.jpg">ISD</set>
+            <set picURL="https://api.scryfall.com/cards/f3c6ef29-b879-4813-87b0-0e3ba2b5cb29?format=image">UMA</set>
+            <set picURL="https://api.scryfall.com/cards/e2020f53-d012-4d26-be13-87ed0f196c53?format=image">ISD</set>
             <reverse-related>Handy Dandy Clone Machine</reverse-related>
             <reverse-related>Stitcher's Apprentice</reverse-related>
             <token>1</token>
@@ -4398,7 +4398,7 @@ At the beginning of your upkeep, this creature deals 1 damage to you.</text>
                 <cmc>0</cmc>
                 <pt>0/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/3/5/3546df95-926d-421d-a763-e559a1847273.jpg">ALA</set>
+            <set picURL="https://api.scryfall.com/cards/3546df95-926d-421d-a763-e559a1847273?format=image">ALA</set>
             <reverse-related>Puppet Conjurer</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -4413,7 +4413,7 @@ At the beginning of your upkeep, this creature deals 1 damage to you.</text>
                 <cmc>0</cmc>
                 <pt>6/6</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/7/3/7365ffff-b171-4275-9fdb-e622f8456858.jpg">AKH</set>
+            <set picURL="https://api.scryfall.com/cards/7365ffff-b171-4275-9fdb-e622f8456858?format=image">AKH</set>
             <reverse-related>Honored Hydra</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -4427,7 +4427,7 @@ At the beginning of your upkeep, this creature deals 1 damage to you.</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/4/54ec2cd6-51f6-4e12-af90-fa254f14ad32.jpg">DDE</set>
+            <set picURL="https://api.scryfall.com/cards/54ec2cd6-51f6-4e12-af90-fa254f14ad32?format=image">DDE</set>
             <reverse-related>Hornet Cannon</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -4440,11 +4440,11 @@ At the beginning of your upkeep, this creature deals 1 damage to you.</text>
                 <cmc>0</cmc>
                 <pt>*/*</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/7/d/7db68985-a1d5-4bd5-bfc6-c7208689d7df.jpg?1608908587">CMR</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/6/1/6188c0f0-0346-46d4-8a45-ae2749bf246f.jpg?1572370790">C19</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/e/ae98a532-2e83-46bc-b391-cc0ab20ea0da.jpg?1592710130">C18</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/2/4/248ae300-40cc-4e6f-8fa6-2bd6ab85fee6.jpg?1562902339">C16</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/a/5a4c5954-da2b-498a-9e86-eb4d6dc95cb8.jpg">MBS</set>
+            <set picURL="https://api.scryfall.com/cards/7db68985-a1d5-4bd5-bfc6-c7208689d7df?format=image">CMR</set>
+            <set picURL="https://api.scryfall.com/cards/6188c0f0-0346-46d4-8a45-ae2749bf246f?format=image">C19</set>
+            <set picURL="https://api.scryfall.com/cards/ae98a532-2e83-46bc-b391-cc0ab20ea0da?format=image">C18</set>
+            <set picURL="https://api.scryfall.com/cards/248ae300-40cc-4e6f-8fa6-2bd6ab85fee6?format=image">C16</set>
+            <set picURL="https://api.scryfall.com/cards/5a4c5954-da2b-498a-9e86-eb4d6dc95cb8?format=image">MBS</set>
             <reverse-related>Profane Transfusion</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -4459,8 +4459,8 @@ At the beginning of your upkeep, this creature deals 1 damage to you.</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/back/a/0/a020dc47-3747-4123-9954-f0e87a858b8c.jpg?1639374083">GK1</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/7/9/79a71b52-58f9-4945-9557-0fbcbbf5a241.jpg">GTC</set>
+            <set picURL="https://api.scryfall.com/cards/a020dc47-3747-4123-9954-f0e87a858b8c?format=image&amp;face=back">GK1</set>
+            <set picURL="https://api.scryfall.com/cards/79a71b52-58f9-4945-9557-0fbcbbf5a241?format=image">GTC</set>
             <reverse-related>Call of the Nightwing</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -4474,7 +4474,7 @@ At the beginning of your upkeep, this creature deals 1 damage to you.</text>
                 <cmc>0</cmc>
                 <pt>4/4</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/0/a0b5e1f4-9206-40b6-9cf6-331f6a95d045.jpg?1641306083">C21</set>
+            <set picURL="https://api.scryfall.com/cards/a0b5e1f4-9206-40b6-9cf6-331f6a95d045?format=image">C21</set>
             <reverse-related>Hunted Lammasu</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -4488,7 +4488,7 @@ At the beginning of your upkeep, this creature deals 1 damage to you.</text>
                 <cmc>0</cmc>
                 <pt>*/*</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/f/a/fadae5ee-1973-4905-8b37-69e826523905.jpg">C14</set>
+            <set picURL="https://api.scryfall.com/cards/fadae5ee-1973-4905-8b37-69e826523905?format=image">C14</set>
             <reverse-related>Flesh Carver</reverse-related>
             <reverse-related>Spoils of Blood</reverse-related>
             <token>1</token>
@@ -4503,7 +4503,7 @@ At the beginning of your upkeep, this creature deals 1 damage to you.</text>
                 <cmc>0</cmc>
                 <pt>3/3</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/8/c/8cfb1a9c-3f34-4362-bc2d-4cd584488820.jpg">E01</set>
+            <set picURL="https://api.scryfall.com/cards/8cfb1a9c-3f34-4362-bc2d-4cd584488820?format=image">E01</set>
             <reverse-related>For Each of You, a Gift</reverse-related>
             <reverse-related>My Forces Are Innumerable</reverse-related>
             <reverse-related>There Is No Refuge</reverse-related>
@@ -4519,7 +4519,7 @@ At the beginning of your upkeep, this creature deals 1 damage to you.</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/d/1ddf9fb5-473f-44a2-98bd-93b4f7478d4f.jpg?1654172487">CLB</set>
+            <set picURL="https://api.scryfall.com/cards/1ddf9fb5-473f-44a2-98bd-93b4f7478d4f?format=image">CLB</set>
             <reverse-related>Zellix, Sanity Flayer</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -4533,7 +4533,7 @@ At the beginning of your upkeep, this creature deals 1 damage to you.</text>
                 <cmc>0</cmc>
                 <pt>5/5</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/f/3/f3dd4d92-6471-4f4b-9c70-cbd2196e8c7b.jpg">HOU</set>
+            <set picURL="https://api.scryfall.com/cards/f3dd4d92-6471-4f4b-9c70-cbd2196e8c7b?format=image">HOU</set>
             <reverse-related>Crested Sunmare</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -4561,7 +4561,7 @@ At the beginning of your upkeep, this creature deals 1 damage to you.</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/9/4/94ed2eca-1579-411d-af6f-c7359c65de30.jpg?1562086876">SOI</set>
+            <set picURL="https://api.scryfall.com/cards/94ed2eca-1579-411d-af6f-c7359c65de30?format=image">SOI</set>
             <reverse-related>Westvale Abbey</reverse-related>
             <reverse-related>Westvale Cult Leader</reverse-related>
             <token>1</token>
@@ -4577,7 +4577,7 @@ At the beginning of your upkeep, this creature deals 1 damage to you.</text>
                 <maintype>Creature</maintype>
                 <pt>2/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/b/db951f76-b785-453e-91b9-b3b8a5c1cfd4.jpg?1572489184">ELD</set>
+            <set picURL="https://api.scryfall.com/cards/db951f76-b785-453e-91b9-b3b8a5c1cfd4?format=image">ELD</set>
             <reverse-related exclude="exclude">Outlaws' Merriment</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -4592,7 +4592,7 @@ At the beginning of your upkeep, this creature deals 1 damage to you.</text>
                 <maintype>Creature</maintype>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/8/6/86dd086e-c757-4a6a-8838-51860f2095f8.jpg?1644542713">NEO</set>
+            <set picURL="https://api.scryfall.com/cards/86dd086e-c757-4a6a-8838-51860f2095f8?format=image">NEO</set>
             <reverse-related>Careful Cultivation</reverse-related>
             <reverse-related>Jugan Defends the Temple</reverse-related>
             <token>1</token>
@@ -4609,7 +4609,7 @@ When this creature enters the battlefield, it deals 1 damage to any target.</tex
                 <maintype>Creature</maintype>
                 <pt>1/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/d/cd3ca6d5-4b2c-46d4-95f3-f0f2fa47f447.jpg?1572489191">ELD</set>
+            <set picURL="https://api.scryfall.com/cards/cd3ca6d5-4b2c-46d4-95f3-f0f2fa47f447?format=image">ELD</set>
             <reverse-related exclude="exclude">Outlaws' Merriment</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -4623,13 +4623,13 @@ When this creature enters the battlefield, it deals 1 damage to any target.</tex
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/4/9/493bb455-ee32-4cbe-bcaa-8df5b16e7b96.jpg?1675905861">ONC</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/e/3/e3683cc6-70e0-4d33-9fed-6a56ba8b6e9b.jpg?1598311517">2XM</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/9/0/90de6d1e-e654-4f4a-8014-061ce69e540f.jpg?1591225563">IKO</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/6/d/6d9669b1-04bd-4620-9856-04ea0473ec57.jpg?1591225569">IKO</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/e/4/e406949f-c629-48fa-9fb0-ba6191054d35.jpg?1591225575">IKO</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/e/1e76f0e3-9411-401d-ab38-9c3c64769483.jpg?1581901930">THB</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/9/d9cbf36e-4044-4f08-9bae-f0dcb2455716.jpg?1562086882">SOI</set>
+            <set picURL="https://api.scryfall.com/cards/493bb455-ee32-4cbe-bcaa-8df5b16e7b96?format=image">ONC</set>
+            <set picURL="https://api.scryfall.com/cards/e3683cc6-70e0-4d33-9fed-6a56ba8b6e9b?format=image">2XM</set>
+            <set picURL="https://api.scryfall.com/cards/90de6d1e-e654-4f4a-8014-061ce69e540f?format=image">IKO</set>
+            <set picURL="https://api.scryfall.com/cards/6d9669b1-04bd-4620-9856-04ea0473ec57?format=image">IKO</set>
+            <set picURL="https://api.scryfall.com/cards/e406949f-c629-48fa-9fb0-ba6191054d35?format=image">IKO</set>
+            <set picURL="https://api.scryfall.com/cards/1e76f0e3-9411-401d-ab38-9c3c64769483?format=image">THB</set>
+            <set picURL="https://api.scryfall.com/cards/d9cbf36e-4044-4f08-9bae-f0dcb2455716?format=image">SOI</set>
             <reverse-related>Bastion of Remembrance</reverse-related>
             <reverse-related count="x">Call the Coppercoats</reverse-related>
             <reverse-related>Commanding Presence</reverse-related>
@@ -4664,7 +4664,7 @@ When this creature enters the battlefield, it deals 1 damage to any target.</tex
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/f/5f3c4810-7359-42b7-905f-4845f6d1daf6.jpg?1636630218">VOW</set>
+            <set picURL="https://api.scryfall.com/cards/5f3c4810-7359-42b7-905f-4845f6d1daf6?format=image">VOW</set>
             <reverse-related>Torens, Fist of the Angels</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -4678,18 +4678,18 @@ When this creature enters the battlefield, it deals 1 damage to any target.</tex
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/3/4/34e52e1d-dcf7-485c-a29f-78e75581c3a4.jpg?1675905858">ONC</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/4/b/4b5469aa-0f24-43ed-b605-35c344eebf96.jpg?1662663524">DMC</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/6/4/64dad439-cae3-4f65-b6fb-c737321d322c.jpg?1654172003">CLB</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/7/d/7d13a93a-a43d-4cf5-8300-8341f3b7f1b1.jpg?1636629870">VOW</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/b/7/b7667345-e11b-4cad-ac4c-84eb1c5656c5.jpg?1653273217">MID</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/d/0dffd473-2b89-4f74-8bff-39b8eb408b26.jpg?1591319133">C20</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/9/4/94057dc6-e589-4a29-9bda-90f5bece96c4.jpg?1572489125">ELD</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/9/5/95f99a6a-dcd9-412e-84cf-916aafad5dfb.jpg?1572370424">C19</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/f/5f2a2483-d21f-4c31-9a36-ed7c5672894b.jpg?1572892480">RNA</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/8/8/8894949b-f190-461e-996a-cf2b39f08a5d.jpg">AVR</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/b/d/bd5cd362-34f9-445f-85e1-9f6694f0f90a.jpg">DKA</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/3/a/3a98c51f-c55c-4bd9-853b-65b8bad5a29f.jpg">F12</set>
+            <set picURL="https://api.scryfall.com/cards/34e52e1d-dcf7-485c-a29f-78e75581c3a4?format=image">ONC</set>
+            <set picURL="https://api.scryfall.com/cards/4b5469aa-0f24-43ed-b605-35c344eebf96?format=image">DMC</set>
+            <set picURL="https://api.scryfall.com/cards/64dad439-cae3-4f65-b6fb-c737321d322c?format=image">CLB</set>
+            <set picURL="https://api.scryfall.com/cards/7d13a93a-a43d-4cf5-8300-8341f3b7f1b1?format=image">VOW</set>
+            <set picURL="https://api.scryfall.com/cards/b7667345-e11b-4cad-ac4c-84eb1c5656c5?format=image">MID</set>
+            <set picURL="https://api.scryfall.com/cards/0dffd473-2b89-4f74-8bff-39b8eb408b26?format=image">C20</set>
+            <set picURL="https://api.scryfall.com/cards/94057dc6-e589-4a29-9bda-90f5bece96c4?format=image">ELD</set>
+            <set picURL="https://api.scryfall.com/cards/95f99a6a-dcd9-412e-84cf-916aafad5dfb?format=image">C19</set>
+            <set picURL="https://api.scryfall.com/cards/5f2a2483-d21f-4c31-9a36-ed7c5672894b?format=image">RNA</set>
+            <set picURL="https://api.scryfall.com/cards/8894949b-f190-461e-996a-cf2b39f08a5d?format=image">AVR</set>
+            <set picURL="https://api.scryfall.com/cards/bd5cd362-34f9-445f-85e1-9f6694f0f90a?format=image">DKA</set>
+            <set picURL="https://api.scryfall.com/cards/3a98c51f-c55c-4bd9-853b-65b8bad5a29f?format=image">F12</set>
             <reverse-related count="x">Adeline, Resplendent Cathar</reverse-related>
             <reverse-related>Castle Ardenvale</reverse-related>
             <reverse-related>Cathar's Call</reverse-related>
@@ -4730,9 +4730,9 @@ When this creature enters the battlefield, it deals 1 damage to any target.</tex
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/1/11c8ff82-b598-4ccc-83a7-99f1e53b64d3.jpg?1636630064">VOW</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/b/dbd994fc-f3f0-4c81-86bd-14ca63ec229b.jpg?1562636922">EMN</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/d/5da1ef9d-878a-49d8-afe5-86ad18e30c3d.jpg">AVR</set>
+            <set picURL="https://api.scryfall.com/cards/11c8ff82-b598-4ccc-83a7-99f1e53b64d3?format=image">VOW</set>
+            <set picURL="https://api.scryfall.com/cards/dbd994fc-f3f0-4c81-86bd-14ca63ec229b?format=image">EMN</set>
+            <set picURL="https://api.scryfall.com/cards/5da1ef9d-878a-49d8-afe5-86ad18e30c3d?format=image">AVR</set>
             <reverse-related count="2">Hanweir Garrison</reverse-related>
             <reverse-related>Stensia Uprising</reverse-related>
             <reverse-related count="3">Thatcher Revolt</reverse-related>
@@ -4749,7 +4749,7 @@ When this creature enters the battlefield, it deals 1 damage to any target.</tex
                 <maintype>Creature</maintype>
                 <pt>3/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/9/c994ea90-71f4-403f-9418-2b72cc2de14d.jpg?1572489198">ELD</set>
+            <set picURL="https://api.scryfall.com/cards/c994ea90-71f4-403f-9418-2b72cc2de14d?format=image">ELD</set>
             <reverse-related exclude="exclude">Outlaws' Merriment</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -4763,7 +4763,7 @@ When this creature enters the battlefield, it deals 1 damage to any target.</tex
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/6/06fbcd85-c54e-492e-9e42-5e101cac4255.jpg?1615686169">KHM</set>
+            <set picURL="https://api.scryfall.com/cards/06fbcd85-c54e-492e-9e42-5e101cac4255?format=image">KHM</set>
             <reverse-related>Battle for Bretagard</reverse-related>
             <reverse-related>Beskir Shieldmate</reverse-related>
             <reverse-related>Maja, Bretagard Protector</reverse-related>
@@ -4781,7 +4781,7 @@ When this creature enters the battlefield, it deals 1 damage to any target.</tex
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/e/4/e4439a8b-ef98-428d-a274-53c660b23afe.jpg?1562636929">EMN</set>
+            <set picURL="https://api.scryfall.com/cards/e4439a8b-ef98-428d-a274-53c660b23afe?format=image">EMN</set>
             <reverse-related>Docent of Perfection</reverse-related>
             <reverse-related>Final Iteration</reverse-related>
             <token>1</token>
@@ -4796,8 +4796,8 @@ When this creature enters the battlefield, it deals 1 damage to any target.</tex
                 <cmc>0</cmc>
                 <pt>*/*</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/7/5/75961f7c-fc3b-49c6-96cc-c42d2aa1a044.jpg?1641306099">C21</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/9/d/9d1af553-ec9f-46fd-9c6d-49436e93e682.jpg">JOU</set>
+            <set picURL="https://api.scryfall.com/cards/75961f7c-fc3b-49c6-96cc-c42d2aa1a044?format=image">C21</set>
+            <set picURL="https://api.scryfall.com/cards/9d1af553-ec9f-46fd-9c6d-49436e93e682?format=image">JOU</set>
             <reverse-related count="x">Hydra Broodmaster</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -4811,8 +4811,8 @@ When this creature enters the battlefield, it deals 1 damage to any target.</tex
                 <cmc>0</cmc>
                 <pt>0/0</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/5/d50eb149-015c-49c9-a3de-c62189c5582d.jpg?1662663482">DMC</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/e/b/ebe2f431-75b6-4c3c-a601-15814752ea6c.jpg?1591319211">C20</set>
+            <set picURL="https://api.scryfall.com/cards/d50eb149-015c-49c9-a3de-c62189c5582d?format=image">DMC</set>
+            <set picURL="https://api.scryfall.com/cards/ebe2f431-75b6-4c3c-a601-15814752ea6c?format=image">C20</set>
             <reverse-related>Zaxara, the Exemplary</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -4826,7 +4826,7 @@ When this creature enters the battlefield, it deals 1 damage to any target.</tex
                 <cmc>0</cmc>
                 <pt>*/*</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/f/2/f2ad0395-190d-4779-81b7-2832dc257828.jpg?1604194909">ZNR</set>
+            <set picURL="https://api.scryfall.com/cards/f2ad0395-190d-4779-81b7-2832dc257828?format=image">ZNR</set>
             <reverse-related>Grakmaw, Skyclave Ravager</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -4842,7 +4842,7 @@ Equip {2}</text>
                 <maintype>Artifact</maintype>
                 <cmc>0</cmc>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/9/a9c981c9-3376-4f6e-b30d-859e5fc7347e.jpg?1626138970">AFR</set>
+            <set picURL="https://api.scryfall.com/cards/a9c981c9-3376-4f6e-b30d-859e5fc7347e?format=image">AFR</set>
             <reverse-related>Icingdeath, Frost Tyrant</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -4855,7 +4855,7 @@ Equip {2}</text>
                 <maintype>Artifact</maintype>
                 <cmc>0</cmc>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/3/d/3db39e3b-fad4-4c9b-911f-69883ac7e0e1.jpg?1615686788">KHM</set>
+            <set picURL="https://api.scryfall.com/cards/3db39e3b-fad4-4c9b-911f-69883ac7e0e1?format=image">KHM</set>
             <reverse-related>Svella, Ice Shaper</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -4869,7 +4869,7 @@ Equip {2}</text>
                 <cmc>0</cmc>
                 <pt>2/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/d/5dcbf662-7263-414a-b64b-ccf9aab20faa.jpg">ZEN</set>
+            <set picURL="https://api.scryfall.com/cards/5dcbf662-7263-414a-b64b-ccf9aab20faa?format=image">ZEN</set>
             <reverse-related>Summoner's Bane</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -4884,9 +4884,9 @@ Equip {2}</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/7/2/7274e711-42fd-489e-809d-77d3bce24422.jpg?1620573789">CMR</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/e/b/ebccb29b-8b69-4813-94bb-d96e117b609e.jpg?1563073051">MH1</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/b/2/b24ae780-d226-4deb-9a4a-91262763d0cd.jpg">MMA</set>
+            <set picURL="https://api.scryfall.com/cards/7274e711-42fd-489e-809d-77d3bce24422?format=image">CMR</set>
+            <set picURL="https://api.scryfall.com/cards/ebccb29b-8b69-4813-94bb-d96e117b609e?format=image">MH1</set>
+            <set picURL="https://api.scryfall.com/cards/b24ae780-d226-4deb-9a4a-91262763d0cd?format=image">MMA</set>
             <reverse-related>Meloku the Clouded Mirror</reverse-related>
             <reverse-related>Moonblade Shinobi</reverse-related>
             <token>1</token>
@@ -4902,7 +4902,7 @@ Equip {2}</text>
                 <cmc>0</cmc>
                 <pt>2/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/1/a10729a5-061a-4daf-91d6-0f6ce813a992.jpg?1562539791">XLN</set>
+            <set picURL="https://api.scryfall.com/cards/a10729a5-061a-4daf-91d6-0f6ce813a992?format=image">XLN</set>
             <reverse-related>Jace, Cunning Castaway</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -4917,7 +4917,7 @@ Equip {2}</text>
                 <cmc>0</cmc>
                 <pt>0/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/c/ccc3d8da-9005-44d9-bb10-18cdac7a32f5.jpg?1572892488">RNA</set>
+            <set picURL="https://api.scryfall.com/cards/ccc3d8da-9005-44d9-bb10-18cdac7a32f5?format=image">RNA</set>
             <reverse-related count="2">Mesmerizing Benthid</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -4931,7 +4931,7 @@ Equip {2}</text>
                 <cmc>0</cmc>
                 <pt>*/*</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/2/3/2300635e-7771-4676-a5a5-29a9d8f49f1a.jpg?1604194799">ZNR</set>
+            <set picURL="https://api.scryfall.com/cards/2300635e-7771-4676-a5a5-29a9d8f49f1a?format=image">ZNR</set>
             <reverse-related>Inscription of Insight</reverse-related>
             <reverse-related>Skyclave Apparition</reverse-related>
             <token>1</token>
@@ -4947,7 +4947,7 @@ Equip {2}</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/4/2/42a6bc0b-e76d-4c45-b39d-0186d9bc9c42.jpg?1641306328">AFC</set>
+            <set picURL="https://api.scryfall.com/cards/42a6bc0b-e76d-4c45-b39d-0186d9bc9c42?format=image">AFC</set>
             <reverse-related>Minn, Wily Illusionist</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -4962,8 +4962,8 @@ Equip {2}</text>
                 <cmc>0</cmc>
                 <pt>2/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/2/b/2b57d024-2ff6-467f-bb4e-37270be60104.jpg?1654172666">CLB</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/9/c9deae5c-80d4-4701-b425-91853b7ee03b.jpg?1641306154">STX</set>
+            <set picURL="https://api.scryfall.com/cards/2b57d024-2ff6-467f-bb4e-37270be60104?format=image">CLB</set>
+            <set picURL="https://api.scryfall.com/cards/c9deae5c-80d4-4701-b425-91853b7ee03b?format=image">STX</set>
             <reverse-related count="x">Blot Out the Sky</reverse-related>
             <reverse-related>Combat Calligrapher</reverse-related>
             <reverse-related>Dramatic Finale</reverse-related>
@@ -4987,10 +4987,10 @@ Equip {2}</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/3/c/3ca5cf3c-18f8-430a-a20f-2226d9cac387.jpg?1654171961">CLB</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/4/14da0d99-9717-47b3-990b-bed6fde78373.jpg?1641306101">C21</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/a/1a9b06fb-4617-4e2d-9747-e12791565527.jpg?1591319219">C20</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/e/1/e101a5b1-614e-43a0-9e7e-de5a248e2e43.jpg?1562640090">M15</set>
+            <set picURL="https://api.scryfall.com/cards/3ca5cf3c-18f8-430a-a20f-2226d9cac387?format=image">CLB</set>
+            <set picURL="https://api.scryfall.com/cards/14da0d99-9717-47b3-990b-bed6fde78373?format=image">C21</set>
+            <set picURL="https://api.scryfall.com/cards/1a9b06fb-4617-4e2d-9747-e12791565527?format=image">C20</set>
+            <set picURL="https://api.scryfall.com/cards/e101a5b1-614e-43a0-9e7e-de5a248e2e43?format=image">M15</set>
             <reverse-related>Hornet Nest</reverse-related>
             <reverse-related count="4">Hornet Queen</reverse-related>
             <token>1</token>
@@ -5005,15 +5005,15 @@ Equip {2}</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/e/6/e662eefb-c454-44b9-8270-f2229e20024e.jpg?1674397404">DMR</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/f/3/f3ac66f8-4bb2-42bd-9a18-7da9c3839c8b.jpg?1636630149">VOW</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/8/4/84da9c36-5d9c-4e29-b6cc-c5c10e490f2e.jpg?1604194822">ZNR</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/4/3/43d7c6dc-4d0b-4a05-8b79-5dd728a74bb3.jpg?1562702029">A25</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/3/6/36fcdda7-8fe7-4cf0-9025-89ff88398994.jpg?1561897493">CN2</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/0/0057f94e-c2be-44e1-a93b-e31432f4ffa5.jpg?1562086858">SOI</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/9/599b5074-86a5-4666-8cf4-3deb83c09ba0.jpg">MM2</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/6/7/67563770-a392-4f69-b93b-6029da639993.jpg">M10</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/a/aa47df37-f246-4f80-a944-008cdf347dad.jpg">ONS</set>
+            <set picURL="https://api.scryfall.com/cards/e662eefb-c454-44b9-8270-f2229e20024e?format=image">DMR</set>
+            <set picURL="https://api.scryfall.com/cards/f3ac66f8-4bb2-42bd-9a18-7da9c3839c8b?format=image">VOW</set>
+            <set picURL="https://api.scryfall.com/cards/84da9c36-5d9c-4e29-b6cc-c5c10e490f2e?format=image">ZNR</set>
+            <set picURL="https://api.scryfall.com/cards/43d7c6dc-4d0b-4a05-8b79-5dd728a74bb3?format=image">A25</set>
+            <set picURL="https://api.scryfall.com/cards/36fcdda7-8fe7-4cf0-9025-89ff88398994?format=image">CN2</set>
+            <set picURL="https://api.scryfall.com/cards/0057f94e-c2be-44e1-a93b-e31432f4ffa5?format=image">SOI</set>
+            <set picURL="https://api.scryfall.com/cards/599b5074-86a5-4666-8cf4-3deb83c09ba0?format=image">MM2</set>
+            <set picURL="https://api.scryfall.com/cards/67563770-a392-4f69-b93b-6029da639993?format=image">M10</set>
+            <set picURL="https://api.scryfall.com/cards/aa47df37-f246-4f80-a944-008cdf347dad?format=image">ONS</set>
             <reverse-related>Ant Queen</reverse-related>
             <reverse-related count="x">Beacon of Creation</reverse-related>
             <reverse-related>Broodhatch Nantuko</reverse-related>
@@ -5053,7 +5053,7 @@ Equip {2}</text>
                 <cmc>0</cmc>
                 <pt>6/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/f/0ff2e2bd-b8e9-4563-85ad-fdbb0607fb7c.jpg?1641306039">TSR</set>
+            <set picURL="https://api.scryfall.com/cards/0ff2e2bd-b8e9-4563-85ad-fdbb0607fb7c?format=image">TSR</set>
             <reverse-related>Deadly Grub</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -5081,7 +5081,7 @@ Equip {2}</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/2/4/242c381e-df58-4365-a68c-add1127a83cc.jpg">AKH</set>
+            <set picURL="https://api.scryfall.com/cards/242c381e-df58-4365-a68c-add1127a83cc?format=image">AKH</set>
             <reverse-related>Nest of Scarabs</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -5096,8 +5096,8 @@ Equip {2}</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/6/b/6bc05773-3721-4748-a218-97868e544b90.jpg?1591319256">C20</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/e/ae56d9e8-de05-456b-af32-b5992992ee15.jpg">HOU</set>
+            <set picURL="https://api.scryfall.com/cards/6bc05773-3721-4748-a218-97868e544b90?format=image">C20</set>
+            <set picURL="https://api.scryfall.com/cards/ae56d9e8-de05-456b-af32-b5992992ee15?format=image">HOU</set>
             <reverse-related>The Locust God</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -5111,9 +5111,9 @@ Equip {2}</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/3/03ce1033-ce07-40ef-9315-beb759af9465.jpg?1641306199">MH2</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/back/c/0/c06bcc5b-4ccd-452d-8579-beee6c5cbe98.jpg?1654766742">GK1</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/4/0436e71b-c1f9-4ca8-a29c-775da858a0cd.jpg?1572892506">GRN</set>
+            <set picURL="https://api.scryfall.com/cards/03ce1033-ce07-40ef-9315-beb759af9465?format=image">MH2</set>
+            <set picURL="https://api.scryfall.com/cards/c06bcc5b-4ccd-452d-8579-beee6c5cbe98?format=image&amp;face=back">GK1</set>
+            <set picURL="https://api.scryfall.com/cards/0436e71b-c1f9-4ca8-a29c-775da858a0cd?format=image">GRN</set>
             <reverse-related>Grist, the Hunger Tide</reverse-related>
             <reverse-related count="x">Izoni, Thousand-Eyed</reverse-related>
             <token>1</token>
@@ -5128,7 +5128,7 @@ Equip {2}</text>
                 <cmc>0</cmc>
                 <pt>3/3</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/5/d53e20ee-b43c-45aa-9921-2c6f7ddc27fb.jpg?1641305867">MID</set>
+            <set picURL="https://api.scryfall.com/cards/d53e20ee-b43c-45aa-9921-2c6f7ddc27fb?format=image">MID</set>
             <reverse-related count="2">Rise of the Ants</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -5143,7 +5143,7 @@ Equip {2}</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/4/c41933b2-a91f-4c43-8734-08fc3a392ac2.jpg?1662835154">DMC</set>
+            <set picURL="https://api.scryfall.com/cards/c41933b2-a91f-4c43-8734-08fc3a392ac2?format=image">DMC</set>
             <reverse-related>Xira, the Golden Sting</reverse-related>
             <reverse-related count="x" exclude="exclude">Xira, the Golden Sting</reverse-related>
             <token>1</token>
@@ -5158,7 +5158,7 @@ Equip {2}</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/9/a/9af00a97-9938-4ab2-938a-669cdfe4332a.jpg?1663862211">40K</set>
+            <set picURL="https://api.scryfall.com/cards/9af00a97-9938-4ab2-938a-669cdfe4332a?format=image">40K</set>
             <reverse-related count="x">Canoptek Scarab Swarm</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -5186,7 +5186,7 @@ Equip {2}</text>
                 <cmc>0</cmc>
                 <pt>4/4</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/7/c/7c0cdb0d-f720-4ed2-af08-ced9b54f6702.jpg?1562702146">DOM</set>
+            <set picURL="https://api.scryfall.com/cards/7c0cdb0d-f720-4ed2-af08-ced9b54f6702?format=image">DOM</set>
             <reverse-related>Verix Bladewing</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -5216,7 +5216,7 @@ Trample</text>
                 <cmc>0</cmc>
                 <pt>3/3</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/e/5/e50f89a6-26bd-4144-8c4a-ee9f293bd9c4.jpg?1662663538">DMC</set>
+            <set picURL="https://api.scryfall.com/cards/e50f89a6-26bd-4144-8c4a-ee9f293bd9c4?format=image">DMC</set>
             <reverse-related>Jared Carthalion</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -5231,7 +5231,7 @@ Trample</text>
                 <cmc>0</cmc>
                 <pt>3/3</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/f/b/fbb5b3f9-0012-4deb-b795-c377cdfe546b.jpg?1644542759">NEO</set>
+            <set picURL="https://api.scryfall.com/cards/fbb5b3f9-0012-4deb-b795-c377cdfe546b?format=image">NEO</set>
             <reverse-related>Tatsunari, Toad Rider</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -5260,9 +5260,9 @@ Trample</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/2/8/28adced8-4f86-4dc7-bd21-e20ba403219c.jpg">MMA</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/6/061cb705-695a-4f65-adbf-869ebb4eb946.jpg">SHM</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/d/ad29eb21-7ee3-4a67-9601-a62ea0cbe4c0.jpg">LRW</set>
+            <set picURL="https://api.scryfall.com/cards/28adced8-4f86-4dc7-bd21-e20ba403219c?format=image">MMA</set>
+            <set picURL="https://api.scryfall.com/cards/061cb705-695a-4f65-adbf-869ebb4eb946?format=image">SHM</set>
+            <set picURL="https://api.scryfall.com/cards/ad29eb21-7ee3-4a67-9601-a62ea0cbe4c0?format=image">LRW</set>
             <reverse-related count="2">Cenn's Enlistment</reverse-related>
             <reverse-related count="3">Cloudgoat Ranger</reverse-related>
             <reverse-related count="3">Guardian of Cloverdell</reverse-related>
@@ -5283,7 +5283,7 @@ Trample</text>
                 <cmc>0</cmc>
                 <pt>2/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/4/0419a202-6e32-4f0a-a032-72f6c00cae5e.jpg">BFZ</set>
+            <set picURL="https://api.scryfall.com/cards/0419a202-6e32-4f0a-a032-72f6c00cae5e?format=image">BFZ</set>
             <reverse-related count="2">Allied Reinforcements</reverse-related>
             <reverse-related>Gideon, Ally of Zendikar</reverse-related>
             <token>1</token>
@@ -5299,15 +5299,15 @@ Trample</text>
                 <cmc>0</cmc>
                 <pt>2/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/4/b/4bd69d39-c2ce-44b4-b2d0-5e384d69db02.jpg?1662663534">DMC</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/7/076f934b-a244-45f1-bcb3-7c5e882e9911.jpg?1594733476">M21</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/7/0/703e7ecf-3d73-40c1-8cfe-0758778817cf.jpg?1572489131">ELD</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/f/d/fd8ca5ee-7b93-4248-8f4a-b88261ee1eed.jpg">M19</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/c/cc7d137c-f6c0-44e5-af9f-a8bbd52d3b2a.jpg?1562702338">DOM</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/e/0/e0bce908-fc95-40c6-a04a-752d56aca836.jpg?1562702400">DOM</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/f/b/fb900962-2273-4e13-92c5-e9aced0d322d.jpg?1562857292">C15</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/b/1bc2969b-2176-4471-b316-9c80443866dd.jpg">ORI</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/6/7/67d3d039-248a-4eb8-be5c-12959b458fea.jpg">RTR</set>
+            <set picURL="https://api.scryfall.com/cards/4bd69d39-c2ce-44b4-b2d0-5e384d69db02?format=image">DMC</set>
+            <set picURL="https://api.scryfall.com/cards/076f934b-a244-45f1-bcb3-7c5e882e9911?format=image">M21</set>
+            <set picURL="https://api.scryfall.com/cards/703e7ecf-3d73-40c1-8cfe-0758778817cf?format=image">ELD</set>
+            <set picURL="https://api.scryfall.com/cards/fd8ca5ee-7b93-4248-8f4a-b88261ee1eed?format=image">M19</set>
+            <set picURL="https://api.scryfall.com/cards/cc7d137c-f6c0-44e5-af9f-a8bbd52d3b2a?format=image">DOM</set>
+            <set picURL="https://api.scryfall.com/cards/e0bce908-fc95-40c6-a04a-752d56aca836?format=image">DOM</set>
+            <set picURL="https://api.scryfall.com/cards/fb900962-2273-4e13-92c5-e9aced0d322d?format=image">C15</set>
+            <set picURL="https://api.scryfall.com/cards/1bc2969b-2176-4471-b316-9c80443866dd?format=image">ORI</set>
+            <set picURL="https://api.scryfall.com/cards/67d3d039-248a-4eb8-be5c-12959b458fea?format=image">RTR</set>
             <reverse-related>Aryel, Knight of Windgrace</reverse-related>
             <reverse-related>Banish into Fable</reverse-related>
             <reverse-related>Basri's Lieutenant</reverse-related>
@@ -5343,7 +5343,7 @@ Trample</text>
                 <cmc>0</cmc>
                 <pt>2/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/2/a/2a6415b3-cd84-41fc-95cd-3d2dd84911cb.jpg?1562857262">C15</set>
+            <set picURL="https://api.scryfall.com/cards/2a6415b3-cd84-41fc-95cd-3d2dd84911cb?format=image">C15</set>
             <reverse-related count="3">Hunted Dragon</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -5357,7 +5357,7 @@ Trample</text>
                 <cmc>0</cmc>
                 <pt>2/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/0/50633bba-9402-4d8c-a277-c370f25bd01f.jpg?1654171282">CLB</set>
+            <set picURL="https://api.scryfall.com/cards/50633bba-9402-4d8c-a277-c370f25bd01f?format=image">CLB</set>
             <reverse-related count="2">Recruitment Drive</reverse-related>
             <reverse-related count="3" exclude="exclude">Recruitment Drive</reverse-related>
             <reverse-related>The Council of Four</reverse-related>
@@ -5391,7 +5391,7 @@ Flanking</text>
                 <cmc>0</cmc>
                 <pt>2/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/3/c31ce82f-6c4a-4986-be1e-032348504ad6.jpg?1641306027">TSR</set>
+            <set picURL="https://api.scryfall.com/cards/c31ce82f-6c4a-4986-be1e-032348504ad6?format=image">TSR</set>
             <reverse-related>Riftmarked Knight</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -5406,7 +5406,7 @@ Flanking</text>
                 <cmc>0</cmc>
                 <pt>2/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/9/19e893e5-12a8-4ecb-adcd-9e7b26b01de2.jpg?1662835101">DMU</set>
+            <set picURL="https://api.scryfall.com/cards/19e893e5-12a8-4ecb-adcd-9e7b26b01de2?format=image">DMU</set>
             <reverse-related>Rasputin, the Oneiromancer</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -5420,11 +5420,11 @@ Flanking</text>
                 <cmc>0</cmc>
                 <pt>0/1</pt>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/6/7/67615047-1b17-4dc1-80d2-2d5da109db94.jpg?1675905868">ONC</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/7/4/74f7dd3d-dbb9-4cbd-8d06-381cb6a0de33.jpg?1662835165">DMU</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/3/c/3c9bfd0a-9a31-4191-a615-a747cbca2015.jpg?1654172358">CLB</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/4/f/4f4e8e64-7caa-4d98-8e20-0a4a20056143.jpg?1641306038">TSR</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/f/dfc03591-1114-4e36-a397-0bb3db8a153c.jpg?1562702392">A25</set>
+            <set picURL="https://api.scryfall.com/cards/67615047-1b17-4dc1-80d2-2d5da109db94?format=image">ONC</set>
+            <set picURL="https://api.scryfall.com/cards/74f7dd3d-dbb9-4cbd-8d06-381cb6a0de33?format=image">DMU</set>
+            <set picURL="https://api.scryfall.com/cards/3c9bfd0a-9a31-4191-a615-a747cbca2015?format=image">CLB</set>
+            <set picURL="https://api.scryfall.com/cards/4f4e8e64-7caa-4d98-8e20-0a4a20056143?format=image">TSR</set>
+            <set picURL="https://api.scryfall.com/cards/dfc03591-1114-4e36-a397-0bb3db8a153c?format=image">A25</set>
             <reverse-related>Kher Keep</reverse-related>
             <reverse-related count="x">Prossh, Skyraider of Kher</reverse-related>
             <reverse-related>Rohgahh, Kher Keep Overlord</reverse-related>
@@ -5442,7 +5442,7 @@ Flanking</text>
                 <cmc>0</cmc>
                 <pt>3/3</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/4/54a1c6a9-3531-4432-9157-e4400dbc89fd.jpg?1615686273">KHM</set>
+            <set picURL="https://api.scryfall.com/cards/54a1c6a9-3531-4432-9157-e4400dbc89fd?format=image">KHM</set>
             <reverse-related>Koma, Cosmos Serpent</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -5456,7 +5456,7 @@ Flanking</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/b/e/be224180-a482-4b94-8a9d-3a92ee0eb34b.jpg">BFZ</set>
+            <set picURL="https://api.scryfall.com/cards/be224180-a482-4b94-8a9d-3a92ee0eb34b?format=image">BFZ</set>
             <reverse-related>Captain's Claws</reverse-related>
             <reverse-related count="2">Oath of Gideon</reverse-related>
             <reverse-related>Retreat to Emeria</reverse-related>
@@ -5473,8 +5473,8 @@ Flanking</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/9/d9c95045-e806-4933-94a4-cb52ae1a215b.jpg">C14</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/9/d9623e74-3b94-4842-903f-ed52931bdf6a.jpg">ZEN</set>
+            <set picURL="https://api.scryfall.com/cards/d9c95045-e806-4933-94a4-cb52ae1a215b?format=image">C14</set>
+            <set picURL="https://api.scryfall.com/cards/d9623e74-3b94-4842-903f-ed52931bdf6a?format=image">ZEN</set>
             <reverse-related count="6">Conqueror's Pledge</reverse-related>
             <reverse-related count="12" exclude="exclude">Conqueror's Pledge</reverse-related>
             <reverse-related>Nahiri, the Lithomancer</reverse-related>
@@ -5491,8 +5491,8 @@ Flanking</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/2/1/2138b304-4dc0-48bb-a043-6246abafef53.jpg?1654172641">CLB</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/3/13412797-f831-49fe-adf3-369cdfacdbd5.jpg?1604194720">ZNR</set>
+            <set picURL="https://api.scryfall.com/cards/2138b304-4dc0-48bb-a043-6246abafef53?format=image">CLB</set>
+            <set picURL="https://api.scryfall.com/cards/13412797-f831-49fe-adf3-369cdfacdbd5?format=image">ZNR</set>
             <reverse-related>Nahiri, Heir of the Ancients</reverse-related>
             <reverse-related count="x=1">Squad Commander</reverse-related>
             <token>1</token>
@@ -5507,10 +5507,10 @@ Flanking</text>
                 <cmc>0</cmc>
                 <pt>9/9</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/f/6/f62080da-a11b-4da3-bb8f-57f543bf076a.jpg?1641306076">C21</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/6/2/622397a1-6513-44b9-928a-388be06d4022.jpg?1562702085">A25</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/b/4/b4ed9fe6-50cc-45e2-aeaa-df6e34eb7fe4.jpg">C14</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/f/9/f9576efe-03eb-49da-bb00-5bf8e50877fb.jpg">BNG</set>
+            <set picURL="https://api.scryfall.com/cards/f62080da-a11b-4da3-bb8f-57f543bf076a?format=image">C21</set>
+            <set picURL="https://api.scryfall.com/cards/622397a1-6513-44b9-928a-388be06d4022?format=image">A25</set>
+            <set picURL="https://api.scryfall.com/cards/b4ed9fe6-50cc-45e2-aeaa-df6e34eb7fe4?format=image">C14</set>
+            <set picURL="https://api.scryfall.com/cards/f9576efe-03eb-49da-bb00-5bf8e50877fb?format=image">BNG</set>
             <reverse-related>Spawning Kraken</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -5525,7 +5525,7 @@ Flanking</text>
                 <maintype>Creature</maintype>
                 <pt>8/8</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/3/c3365aea-823d-44a9-94d3-ed2a31d85f34.jpg?1581901935">THB</set>
+            <set picURL="https://api.scryfall.com/cards/c3365aea-823d-44a9-94d3-ed2a31d85f34?format=image">THB</set>
             <reverse-related>Kiora Bests the Sea God</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -5539,7 +5539,7 @@ Flanking</text>
                 <cmc>0</cmc>
                 <pt>8/8</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/a/ca17c7b2-180a-4bd1-9ab2-152f8f656dba.jpg?1591225580">IKO</set>
+            <set picURL="https://api.scryfall.com/cards/ca17c7b2-180a-4bd1-9ab2-152f8f656dba?format=image">IKO</set>
             <reverse-related>Ominous Seas</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -5554,7 +5554,7 @@ Flanking</text>
                 <cmc>0</cmc>
                 <pt>2/3</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/7/5/754eeff5-b495-4aa5-94ce-ff20216c952b.jpg">AKH</set>
+            <set picURL="https://api.scryfall.com/cards/754eeff5-b495-4aa5-94ce-ff20216c952b?format=image">AKH</set>
             <reverse-related>Labyrinth Guardian</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -5567,7 +5567,7 @@ Flanking</text>
                 <maintype>Artifact</maintype>
                 <cmc>0</cmc>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/3/0/30093c6e-505e-4902-b535-707e364059b4.jpg?1562639734">M15</set>
+            <set picURL="https://api.scryfall.com/cards/30093c6e-505e-4902-b535-707e364059b4?format=image">M15</set>
             <reverse-related>Goblin Kaboomist</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -5582,7 +5582,7 @@ Flanking</text>
                 <cmc>0</cmc>
                 <pt>2/2</pt>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/4/7/47b48ea5-a12f-4a3b-b7d9-2124e43d8833.jpg?1664561190">BOT</set>
+            <set picURL="https://api.scryfall.com/cards/47b48ea5-a12f-4a3b-b7d9-2124e43d8833?format=image">BOT</set>
             <reverse-related>Soundwave, Superior Captain</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -5598,7 +5598,7 @@ At the beginning of the end step, sacrifice this creature.</text>
                 <cmc>0</cmc>
                 <pt>5/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/d/cde2b3db-d71b-401f-852c-81c39d585a16.jpg?1562857284">C15</set>
+            <set picURL="https://api.scryfall.com/cards/cde2b3db-d71b-401f-852c-81c39d585a16?format=image">C15</set>
             <reverse-related>Rite of the Raging Storm</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -5612,7 +5612,7 @@ At the beginning of the end step, sacrifice this creature.</text>
                 <cmc>0</cmc>
                 <pt>2/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/8/3/83790fd3-f371-494c-97a2-3aa469a399f1.jpg">ARB</set>
+            <set picURL="https://api.scryfall.com/cards/83790fd3-f371-494c-97a2-3aa469a399f1?format=image">ARB</set>
             <reverse-related>Predatory Advantage</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -5626,7 +5626,7 @@ At the beginning of the end step, sacrifice this creature.</text>
                 <cmc>0</cmc>
                 <pt>8/8</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/7/0/70345006-5cde-44f8-ab66-9d8163d4c4f6.jpg?1561897499">CN2</set>
+            <set picURL="https://api.scryfall.com/cards/70345006-5cde-44f8-ab66-9d8163d4c4f6?format=image">CN2</set>
             <reverse-related>Subterranean Tremors</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -5641,7 +5641,7 @@ At the beginning of the end step, sacrifice this creature.</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/b/cbcb0668-e88c-4462-b079-34f140c0277e.jpg?1641306044">TSR</set>
+            <set picURL="https://api.scryfall.com/cards/cbcb0668-e88c-4462-b079-34f140c0277e?format=image">TSR</set>
             <reverse-related>Llanowar Mentor</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -5656,9 +5656,9 @@ A manifested creature card can be turned face up any time for its mana cost. A f
                 <cmc>0</cmc>
                 <pt>2/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/e/3/e3088dea-11fd-403b-aaf4-56852283ba3d.jpg?1572370832">C19</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/6/d6fb189b-20a3-4ba4-86ec-f84513e0281a.jpg?1592709971">C18</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/e/9/e9f896d4-34b4-407d-be7e-bf7a69aaf811.jpg">FRF</set>
+            <set picURL="https://api.scryfall.com/cards/e3088dea-11fd-403b-aaf4-56852283ba3d?format=image">C19</set>
+            <set picURL="https://api.scryfall.com/cards/d6fb189b-20a3-4ba4-86ec-f84513e0281a?format=image">C18</set>
+            <set picURL="https://api.scryfall.com/cards/e9f896d4-34b4-407d-be7e-bf7a69aaf811?format=image">FRF</set>
             <reverse-related>Arashin War Beast</reverse-related>
             <reverse-related>Arbiter of the Ideal</reverse-related>
             <reverse-related>Cloudform</reverse-related>
@@ -5692,11 +5692,11 @@ A manifested creature card can be turned face up any time for its mana cost. A f
                 <cmc>0</cmc>
                 <pt>20/20</pt>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/3/4/34db5e62-4792-4207-b008-7d62bae683a7.jpg?1674397410">DMR</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/f/b/fb248ba0-2ee7-4994-be57-2bcc8df29680.jpg?1598311645">2XM</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/7/b/7b993828-e139-4cb6-a329-487accc1c515.jpg?1563073064">MH1</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/0/105e687e-7196-4010-a6b7-cfa42d998fa4.jpg?1560096976">UMA</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/8/f/8f5c3863-c876-48a8-9bc8-be20cd61074c.jpg">CSP</set>
+            <set picURL="https://api.scryfall.com/cards/34db5e62-4792-4207-b008-7d62bae683a7?format=image">DMR</set>
+            <set picURL="https://api.scryfall.com/cards/fb248ba0-2ee7-4994-be57-2bcc8df29680?format=image">2XM</set>
+            <set picURL="https://api.scryfall.com/cards/7b993828-e139-4cb6-a329-487accc1c515?format=image">MH1</set>
+            <set picURL="https://api.scryfall.com/cards/105e687e-7196-4010-a6b7-cfa42d998fa4?format=image">UMA</set>
+            <set picURL="https://api.scryfall.com/cards/8f5c3863-c876-48a8-9bc8-be20cd61074c?format=image">CSP</set>
             <reverse-related>Dark Depths</reverse-related>
             <reverse-related>Marit Lage's Slumber</reverse-related>
             <token>1</token>
@@ -5712,7 +5712,7 @@ Totem armor</text>
                 <maintype>Enchantment</maintype>
                 <cmc>0</cmc>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/b/2/b21b5504-c5ef-4dfc-8219-8db90aca7694.jpg?1592709997">C18</set>
+            <set picURL="https://api.scryfall.com/cards/b21b5504-c5ef-4dfc-8219-8db90aca7694?format=image">C18</set>
             <reverse-related>Estrid, the Masked</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -5728,7 +5728,7 @@ Flying, vigilance, trample, lifelink, haste</text>
                 <cmc>0</cmc>
                 <pt>10/10</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/2/0281825d-9d38-4b56-b522-a8d3cf8c77c9.jpg?1643668066">NEO</set>
+            <set picURL="https://api.scryfall.com/cards/0281825d-9d38-4b56-b522-a8d3cf8c77c9?format=image">NEO</set>
             <reverse-related>Mechtitan Core</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -5742,8 +5742,8 @@ Flying, vigilance, trample, lifelink, haste</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/b/1bad1c90-a3ea-469e-ba0b-91c75ea5b1a3.jpg?1662835149">DMU</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/f/b/fb1b292b-2da6-4601-9f93-5eb273ce3a50.jpg">ZEN</set>
+            <set picURL="https://api.scryfall.com/cards/1bad1c90-a3ea-469e-ba0b-91c75ea5b1a3?format=image">DMU</set>
+            <set picURL="https://api.scryfall.com/cards/fb1b292b-2da6-4601-9f93-5eb273ce3a50?format=image">ZEN</set>
             <reverse-related>Emperor Mihail II</reverse-related>
             <reverse-related>Lullmage Mentor</reverse-related>
             <token>1</token>
@@ -5759,7 +5759,7 @@ Flying, vigilance, trample, lifelink, haste</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/9/0/90317f5e-d121-4c00-86cc-5bbee953f600.jpg?1562539786">XLN</set>
+            <set picURL="https://api.scryfall.com/cards/90317f5e-d121-4c00-86cc-5bbee953f600?format=image">XLN</set>
             <reverse-related count="2">Aquatic Incursion</reverse-related>
             <reverse-related>Deeproot Waters</reverse-related>
             <reverse-related>Jungleborn Pioneer</reverse-related>
@@ -5775,7 +5775,7 @@ Flying, vigilance, trample, lifelink, haste</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/2/526da544-23dd-42b8-8c00-c3609eea4489.jpg">LRW</set>
+            <set picURL="https://api.scryfall.com/cards/526da544-23dd-42b8-8c00-c3609eea4489?format=image">LRW</set>
             <reverse-related count="2">Benthicore</reverse-related>
             <reverse-related>Stonybrook Schoolmaster</reverse-related>
             <reverse-related count="2">Summon the School</reverse-related>
@@ -5790,7 +5790,7 @@ Flying, vigilance, trample, lifelink, haste</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/2/c/2c7e0d67-b627-4cf7-8f56-e1f0bd75cd5c.jpg?1641306052">TSR</set>
+            <set picURL="https://api.scryfall.com/cards/2c7e0d67-b627-4cf7-8f56-e1f0bd75cd5c?format=image">TSR</set>
             <reverse-related>Sliversmith</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -5832,7 +5832,7 @@ Flying, vigilance, trample, lifelink, haste</text>
                 <cmc>0</cmc>
                 <pt>2/3</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/d/5d2a3833-ab5b-4f84-b39c-d0eeb7b474d3.jpg">JOU</set>
+            <set picURL="https://api.scryfall.com/cards/5d2a3833-ab5b-4f84-b39c-d0eeb7b474d3?format=image">JOU</set>
             <reverse-related count="2">Flurry of Horns</reverse-related>
             <reverse-related>Sethron, Hurloon General</reverse-related>
             <token>1</token>
@@ -5848,7 +5848,7 @@ Flying, vigilance, trample, lifelink, haste</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/3/1/3142cb28-23cc-405f-9db5-7c4d168aab19.jpg">FRF</set>
+            <set picURL="https://api.scryfall.com/cards/3142cb28-23cc-405f-9db5-7c4d168aab19?format=image">FRF</set>
             <reverse-related>Monastery Mentor</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -5863,7 +5863,7 @@ Flying, vigilance, trample, lifelink, haste</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/3/8/388180bd-cc96-4b18-9ddd-18a3f7e06282.jpg?1661549560">DMU</set>
+            <set picURL="https://api.scryfall.com/cards/388180bd-cc96-4b18-9ddd-18a3f7e06282?format=image">DMU</set>
             <reverse-related>Jaya, Fiery Negotiator</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -5892,10 +5892,10 @@ A card with morph can be turned face up any time for its morph cost.)</text>
                 <cmc>0</cmc>
                 <pt>2/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/e/9/e9375cbe-93c0-41a5-a6e3-fb4416f54a69.jpg?1572370830">C19</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/d/cd0b42a0-5e08-406d-82b0-be5f72870c47.jpg?1562702342">A25</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/f/5f29231c-dd21-4a45-a1f0-464d338128ed.jpg">DTK</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/b/c/bc513990-b4e8-498b-84d5-8317bc79a667.jpg">KTK</set>
+            <set picURL="https://api.scryfall.com/cards/e9375cbe-93c0-41a5-a6e3-fb4416f54a69?format=image">C19</set>
+            <set picURL="https://api.scryfall.com/cards/cd0b42a0-5e08-406d-82b0-be5f72870c47?format=image">A25</set>
+            <set picURL="https://api.scryfall.com/cards/5f29231c-dd21-4a45-a1f0-464d338128ed?format=image">DTK</set>
+            <set picURL="https://api.scryfall.com/cards/bc513990-b4e8-498b-84d5-8317bc79a667?format=image">KTK</set>
             <reverse-related attach="attach">Abomination of Gudul</reverse-related>
             <reverse-related attach="attach">Abzan Guide</reverse-related>
             <reverse-related attach="attach">Acid-Spewer Dragon</reverse-related>
@@ -6090,7 +6090,7 @@ A card with morph can be turned face up any time for its morph cost.)</text>
                 <maintype>Creature</maintype>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/f/e/fe10da68-dd05-4e8e-ab94-37262e835fb3.jpg?1572489138">ELD</set>
+            <set picURL="https://api.scryfall.com/cards/fe10da68-dd05-4e8e-ab94-37262e835fb3?format=image">ELD</set>
             <reverse-related count="2">Enchanted Carriage</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -6104,8 +6104,8 @@ A card with morph can be turned face up any time for its morph cost.)</text>
                 <maintype>Creature</maintype>
                 <pt>3/3</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/b/1/b10441dd-9029-4f95-9566-d3771ebd36bd.jpg?1626729696">GS1</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/back/b/1/b10441dd-9029-4f95-9566-d3771ebd36bd.jpg?1626729696">GS1</set>
+            <set picURL="https://api.scryfall.com/cards/b10441dd-9029-4f95-9566-d3771ebd36bd?format=image">GS1</set>
+            <set picURL="https://api.scryfall.com/cards/b10441dd-9029-4f95-9566-d3771ebd36bd?format=image&amp;face=back">GS1</set>
             <reverse-related>Jiang Yanggu</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -6118,18 +6118,18 @@ A card with morph can be turned face up any time for its morph cost.)</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/1/9/195b7790-7d01-48f4-a3d9-84ea94fc79ef.jpg?1675905880">ONC</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/e/b/eb47cd56-8f1f-49c9-8f19-8b1507063a9a.jpg?1644543291">NEC</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/4/a4ca03f7-3442-4256-a830-fc2cbcd356db.jpg?1641306122">C21</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/5/d57daa4d-c6d2-4d36-bb7b-2cc705d1a659.jpg?1601138602">2XM</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/3/2/323e26b2-1f7d-4a30-a0ef-1aa91e91d551.jpg?1563073235">MH1</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/e/9/e9c49fa9-6f8b-4d3a-9b11-edbf4c8b8baa.jpg?1592710137">C18</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/f/3/f32ad93f-3fd5-465c-ac6a-6f8fb57c19bd.jpg?1561758422">BBD</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/7/9/799070d9-2e04-49a0-ba2d-fe149f23fa4a.jpg?1562919412">C16</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/1/c1a8c1a6-a88a-4b23-bd80-95769ea4917c.jpg">MM2</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/b/dbad9b20-0b13-41b9-a84a-06b691ee6c71.jpg">C14</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/8/182308b3-86e0-46d8-9104-95576a3d3921.jpg">SOM</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/8/187cf6d5-c352-48f2-b8bf-fe1bf946e2ac.jpg">MRD</set>
+            <set picURL="https://api.scryfall.com/cards/195b7790-7d01-48f4-a3d9-84ea94fc79ef?format=image">ONC</set>
+            <set picURL="https://api.scryfall.com/cards/eb47cd56-8f1f-49c9-8f19-8b1507063a9a?format=image">NEC</set>
+            <set picURL="https://api.scryfall.com/cards/a4ca03f7-3442-4256-a830-fc2cbcd356db?format=image">C21</set>
+            <set picURL="https://api.scryfall.com/cards/d57daa4d-c6d2-4d36-bb7b-2cc705d1a659?format=image">2XM</set>
+            <set picURL="https://api.scryfall.com/cards/323e26b2-1f7d-4a30-a0ef-1aa91e91d551?format=image">MH1</set>
+            <set picURL="https://api.scryfall.com/cards/e9c49fa9-6f8b-4d3a-9b11-edbf4c8b8baa?format=image">C18</set>
+            <set picURL="https://api.scryfall.com/cards/f32ad93f-3fd5-465c-ac6a-6f8fb57c19bd?format=image">BBD</set>
+            <set picURL="https://api.scryfall.com/cards/799070d9-2e04-49a0-ba2d-fe149f23fa4a?format=image">C16</set>
+            <set picURL="https://api.scryfall.com/cards/c1a8c1a6-a88a-4b23-bd80-95769ea4917c?format=image">MM2</set>
+            <set picURL="https://api.scryfall.com/cards/dbad9b20-0b13-41b9-a84a-06b691ee6c71?format=image">C14</set>
+            <set picURL="https://api.scryfall.com/cards/182308b3-86e0-46d8-9104-95576a3d3921?format=image">SOM</set>
+            <set picURL="https://api.scryfall.com/cards/187cf6d5-c352-48f2-b8bf-fe1bf946e2ac?format=image">MRD</set>
             <reverse-related>Genesis Chamber</reverse-related>
             <reverse-related count="2">Master's Call</reverse-related>
             <reverse-related>Mirrodin Besieged</reverse-related>
@@ -6152,7 +6152,7 @@ A card with morph can be turned face up any time for its morph cost.)</text>
                 <cmc>0</cmc>
                 <pt>2/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/4/542b3490-1247-4f47-98b6-c67cabae53cb.jpg?1663530074">40K</set>
+            <set picURL="https://api.scryfall.com/cards/542b3490-1247-4f47-98b6-c67cabae53cb?format=image">40K</set>
             <reverse-related>Biotransference</reverse-related>
             <reverse-related count="2">Imotekh the Stormlord</reverse-related>
             <reverse-related count="x=2" exclude="exclude">Imotekh the Stormlord</reverse-related>
@@ -6172,7 +6172,7 @@ A card with morph can be turned face up any time for its morph cost.)</text>
                 <cmc>0</cmc>
                 <pt>*/*</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/4/d/4d33b752-c806-4932-ae0a-46f00ed937de.jpg?1562702042">DOM</set>
+            <set picURL="https://api.scryfall.com/cards/4d33b752-c806-4932-ae0a-46f00ed937de?format=image">DOM</set>
             <reverse-related>Chainer's Torment</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -6187,7 +6187,7 @@ A card with morph can be turned face up any time for its morph cost.)</text>
                 <maintype>Creature</maintype>
                 <pt>2/3</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/5/c528581f-f671-45ae-8d7a-ae26a4e62ceb.jpg?1581902128">THB</set>
+            <set picURL="https://api.scryfall.com/cards/c528581f-f671-45ae-8d7a-ae26a4e62ceb?format=image">THB</set>
             <reverse-related>Ashiok, Nightmare Muse</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -6202,7 +6202,7 @@ A card with morph can be turned face up any time for its morph cost.)</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/4/14eb629e-f09f-4deb-b434-7615a3010a4d.jpg?1644542606">NEO</set>
+            <set picURL="https://api.scryfall.com/cards/14eb629e-f09f-4deb-b434-7615a3010a4d?format=image">NEO</set>
             <reverse-related>Kaito Shizuki</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -6216,7 +6216,7 @@ A card with morph can be turned face up any time for its morph cost.)</text>
                 <cmc>0</cmc>
                 <pt>8/8</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/9/19ac0a35-fae7-49f9-ae96-4406df992dc9.jpg">BFZ</set>
+            <set picURL="https://api.scryfall.com/cards/19ac0a35-fae7-49f9-ae96-4406df992dc9?format=image">BFZ</set>
             <reverse-related>Crush of Tentacles</reverse-related>
             <reverse-related count="3">Kiora, Master of the Depths</reverse-related>
             <token>1</token>
@@ -6231,9 +6231,9 @@ A card with morph can be turned face up any time for its morph cost.)</text>
                 <cmc>0</cmc>
                 <pt>3/3</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/e/3/e3d725a8-daff-4458-aab0-06803ae33be3.jpg?1654172405">CLB</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/6/7/6722527e-883e-49cc-9eab-daee962a740f.jpg?1562915853">C16</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/9/a99c10f3-9f11-42f1-9007-c0320a1929e0.jpg">WWK</set>
+            <set picURL="https://api.scryfall.com/cards/e3d725a8-daff-4458-aab0-06803ae33be3?format=image">CLB</set>
+            <set picURL="https://api.scryfall.com/cards/6722527e-883e-49cc-9eab-daee962a740f?format=image">C16</set>
+            <set picURL="https://api.scryfall.com/cards/a99c10f3-9f11-42f1-9007-c0320a1929e0?format=image">WWK</set>
             <reverse-related>Kazuul, Tyrant of the Cliffs</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -6247,7 +6247,7 @@ A card with morph can be turned face up any time for its morph cost.)</text>
                 <cmc>0</cmc>
                 <pt>4/4</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/e/f/efaa37e5-302e-4b4b-bb2d-6a0f9f80cd3f.jpg">CNS</set>
+            <set picURL="https://api.scryfall.com/cards/efaa37e5-302e-4b4b-bb2d-6a0f9f80cd3f?format=image">CNS</set>
             <reverse-related>Grenzo's Rebuttal</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -6261,7 +6261,7 @@ A card with morph can be turned face up any time for its morph cost.)</text>
                 <cmc>0</cmc>
                 <pt>4/3</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/3/c/3ca43425-d007-4181-9182-18dc01ad7e90.jpg?1650819822">SNC</set>
+            <set picURL="https://api.scryfall.com/cards/3ca43425-d007-4181-9182-18dc01ad7e90?format=image">SNC</set>
             <reverse-related>Join the Maestros</reverse-related>
             <reverse-related count="2" exclude="exclude">Join the Maestros</reverse-related>
             <token>1</token>
@@ -6277,7 +6277,7 @@ A card with morph can be turned face up any time for its morph cost.)</text>
                 <cmc>0</cmc>
                 <pt>3/3</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/a/aa5fedcd-e5d5-4250-b64e-a04772cb9025.jpg">AKH</set>
+            <set picURL="https://api.scryfall.com/cards/aa5fedcd-e5d5-4250-b64e-a04772cb9025?format=image">AKH</set>
             <reverse-related>Oketra's Attendant</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -6291,13 +6291,13 @@ A card with morph can be turned face up any time for its morph cost.)</text>
                 <cmc>0</cmc>
                 <pt>*/*</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/5/155e76d6-d8d5-410b-9b00-088c039b668f.jpg?1598311725">2XM</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/9/c/9c918e38-7151-407f-bf3b-44a11f92fb15.jpg?1552078540">GK2</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/2/d299e48d-fb74-49a1-b94a-29975056378a.jpg?1547509348">UMA</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/2/a/2a9cea73-9421-4f91-b8f9-1a8081b3811a.jpg?1562840738">MM3</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/6/a686e51d-e8c3-4ed6-8357-c3d38d56dd09.jpg">RTR</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/4/d49e91df-0647-4c9f-9c3e-fb8c77c4886c.jpg">ROE</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/3/9/39a4b6d1-c5f5-4a2d-a00c-97f6395c941b.jpg">ALA</set>
+            <set picURL="https://api.scryfall.com/cards/155e76d6-d8d5-410b-9b00-088c039b668f?format=image">2XM</set>
+            <set picURL="https://api.scryfall.com/cards/9c918e38-7151-407f-bf3b-44a11f92fb15?format=image">GK2</set>
+            <set picURL="https://api.scryfall.com/cards/d299e48d-fb74-49a1-b94a-29975056378a?format=image">UMA</set>
+            <set picURL="https://api.scryfall.com/cards/2a9cea73-9421-4f91-b8f9-1a8081b3811a?format=image">MM3</set>
+            <set picURL="https://api.scryfall.com/cards/a686e51d-e8c3-4ed6-8357-c3d38d56dd09?format=image">RTR</set>
+            <set picURL="https://api.scryfall.com/cards/d49e91df-0647-4c9f-9c3e-fb8c77c4886c?format=image">ROE</set>
+            <set picURL="https://api.scryfall.com/cards/39a4b6d1-c5f5-4a2d-a00c-97f6395c941b?format=image">ALA</set>
             <reverse-related count="x">Gelatinous Genesis</reverse-related>
             <reverse-related>Miming Slime</reverse-related>
             <reverse-related>Mystic Genesis</reverse-related>
@@ -6317,7 +6317,7 @@ A card with morph can be turned face up any time for its morph cost.)</text>
                 <cmc>0</cmc>
                 <pt>*/*</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/f/1f22cfdb-15af-46b9-b5c9-d0c76d5b15d6.jpg?1658401140">ISD</set>
+            <set picURL="https://api.scryfall.com/cards/1f22cfdb-15af-46b9-b5c9-d0c76d5b15d6?format=image">ISD</set>
             <reverse-related>Gutter Grime</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -6332,7 +6332,7 @@ A card with morph can be turned face up any time for its morph cost.)</text>
                 <cmc>0</cmc>
                 <pt>2/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/8/e/8ea26341-372c-4657-8910-08e0131fe0fc.jpg">M11</set>
+            <set picURL="https://api.scryfall.com/cards/8ea26341-372c-4657-8910-08e0131fe0fc?format=image">M11</set>
             <related count="2">Ooze Token   </related>
             <reverse-related count="2">Mitotic Slime</reverse-related>
             <token>1</token>
@@ -6347,7 +6347,7 @@ A card with morph can be turned face up any time for its morph cost.)</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/2/4/24edd312-ef8e-48a0-8532-13e072daa00f.jpg">M11</set>
+            <set picURL="https://api.scryfall.com/cards/24edd312-ef8e-48a0-8532-13e072daa00f?format=image">M11</set>
             <token>1</token>
             <tablerow>2</tablerow>
         </card>
@@ -6360,7 +6360,7 @@ A card with morph can be turned face up any time for its morph cost.)</text>
                 <cmc>0</cmc>
                 <pt>3/3</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/6/2/623a7905-3a10-4d23-96fa-4960cac8f4e3.jpg?1562086871">SOI</set>
+            <set picURL="https://api.scryfall.com/cards/623a7905-3a10-4d23-96fa-4960cac8f4e3?format=image">SOI</set>
             <reverse-related>Inexorable Blob</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -6374,7 +6374,7 @@ A card with morph can be turned face up any time for its morph cost.)</text>
                 <cmc>0</cmc>
                 <pt>2/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/2/0260e0ae-bf09-430a-a449-c16219d84b63.jpg?1572892523">RNA</set>
+            <set picURL="https://api.scryfall.com/cards/0260e0ae-bf09-430a-a449-c16219d84b63?format=image">RNA</set>
             <reverse-related count="x=1">Biogenic Ooze</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -6389,7 +6389,7 @@ A card with morph can be turned face up any time for its morph cost.)</text>
                 <cmc>0</cmc>
                 <pt>*/*+1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/f/a/faa10292-f358-48c1-a516-9a1eecf62b1d.jpg?1641305871">MID</set>
+            <set picURL="https://api.scryfall.com/cards/faa10292-f358-48c1-a516-9a1eecf62b1d?format=image">MID</set>
             <reverse-related>Consuming Blob</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -6418,7 +6418,7 @@ A card with morph can be turned face up any time for its morph cost.)</text>
                 <cmc>0</cmc>
                 <pt>0/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/6/a63d3174-75af-4dfa-b2f9-c4330c755af1.jpg?1661549794">DMU</set>
+            <set picURL="https://api.scryfall.com/cards/a63d3174-75af-4dfa-b2f9-c4330c755af1?format=image">DMU</set>
             <reverse-related>Yotia Declares War</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -6432,7 +6432,7 @@ A card with morph can be turned face up any time for its morph cost.)</text>
                 <cmc>0</cmc>
                 <pt>2/4</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/8/f/8f1d69f9-d9d7-47a9-9236-351f81ffa9ae.jpg">M19</set>
+            <set picURL="https://api.scryfall.com/cards/8f1d69f9-d9d7-47a9-9236-351f81ffa9ae?format=image">M19</set>
             <reverse-related>Transmogrifying Wand</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -6446,7 +6446,7 @@ A card with morph can be turned face up any time for its morph cost.)</text>
                 <cmc>0</cmc>
                 <pt>4/4</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/6/6/6655f22c-963f-42d6-b45c-8ea5fb256785.jpg?1654171598">CLB</set>
+            <set picURL="https://api.scryfall.com/cards/6655f22c-963f-42d6-b45c-8ea5fb256785?format=image">CLB</set>
             <reverse-related exclude="exclude">Contraband Livestock</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -6461,10 +6461,10 @@ A card with morph can be turned face up any time for its morph cost.)</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/d/dd1b0ed9-a4c0-4c58-978a-918ca266c699.jpg?1654171274">CLB</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/f/1/f1e1d6b9-e1a2-4c26-981a-507bc895be8e.jpg?1572370471">C19</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/e/1e77b5dd-af53-4229-bd7f-9b961ebde8f7.jpg">C14</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/b/c/bc944579-b6d8-40f7-8c46-146513960d61.jpg?1561757940">UGL</set>
+            <set picURL="https://api.scryfall.com/cards/dd1b0ed9-a4c0-4c58-978a-918ca266c699?format=image">CLB</set>
+            <set picURL="https://api.scryfall.com/cards/f1e1d6b9-e1a2-4c26-981a-507bc895be8e?format=image">C19</set>
+            <set picURL="https://api.scryfall.com/cards/1e77b5dd-af53-4229-bd7f-9b961ebde8f7?format=image">C14</set>
+            <set picURL="https://api.scryfall.com/cards/bc944579-b6d8-40f7-8c46-146513960d61?format=image">UGL</set>
             <reverse-related>Pegasus Guardian // Rescue the Foal</reverse-related>
             <reverse-related>Pegasus Refuge</reverse-related>
             <reverse-related>Pegasus Stampede</reverse-related>
@@ -6483,7 +6483,7 @@ A card with morph can be turned face up any time for its morph cost.)</text>
                 <cmc>0</cmc>
                 <pt>2/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/e/dee1c2ee-d92e-409a-995a-b4c91620c918.jpg?1581901969">THB</set>
+            <set picURL="https://api.scryfall.com/cards/dee1c2ee-d92e-409a-995a-b4c91620c918?format=image">THB</set>
             <reverse-related>Archon of Sun's Grace</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -6497,9 +6497,9 @@ A card with morph can be turned face up any time for its morph cost.)</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/a/0a9a25fd-1a4c-4d63-bbfa-296ef53feb8b.jpg">C14</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/1/a1f88c3e-3532-489a-8f31-e07e8040f28e.jpg">M12</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/4/f/4fbb0dc6-2f9e-4389-8a90-531e94009bfb.jpg">MRD</set>
+            <set picURL="https://api.scryfall.com/cards/0a9a25fd-1a4c-4d63-bbfa-296ef53feb8b?format=image">C14</set>
+            <set picURL="https://api.scryfall.com/cards/a1f88c3e-3532-489a-8f31-e07e8040f28e?format=image">M12</set>
+            <set picURL="https://api.scryfall.com/cards/4fbb0dc6-2f9e-4389-8a90-531e94009bfb?format=image">MRD</set>
             <reverse-related>Pentavus</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -6527,7 +6527,7 @@ A card with morph can be turned face up any time for its morph cost.)</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/0/d0ddbe3e-4a66-494d-9304-7471232549bf.jpg?1641306156">STX</set>
+            <set picURL="https://api.scryfall.com/cards/d0ddbe3e-4a66-494d-9304-7471232549bf?format=image">STX</set>
             <reverse-related>Beledros Witherbloom</reverse-related>
             <reverse-related count="x">Blight Mound</reverse-related>
             <reverse-related>Callous Bloodmage</reverse-related>
@@ -6552,8 +6552,8 @@ A card with morph can be turned face up any time for its morph cost.)</text>
                 <cmc>0</cmc>
                 <pt>4/4</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/6/5/65f64d14-c203-4401-a379-c6227d1cbac2.jpg?1654172085">CLB</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/6/06b5e4d2-7eac-4ee9-82aa-80a668705679.jpg?1641306088">C21</set>
+            <set picURL="https://api.scryfall.com/cards/65f64d14-c203-4401-a379-c6227d1cbac2?format=image">CLB</set>
+            <set picURL="https://api.scryfall.com/cards/06b5e4d2-7eac-4ee9-82aa-80a668705679?format=image">C21</set>
             <reverse-related count="x">Ezuri's Predation</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -6568,7 +6568,7 @@ A card with morph can be turned face up any time for its morph cost.)</text>
                 <cmc>0</cmc>
                 <pt>3/3</pt>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/9/1/919381b0-2d23-4794-b4ff-923c23e18196.jpg?1675095680">ONE</set>
+            <set picURL="https://api.scryfall.com/cards/919381b0-2d23-4794-b4ff-923c23e18196?format=image">ONE</set>
             <related>Poison Counter</related>
             <reverse-related count="2">Goliath Hatchery</reverse-related>
             <reverse-related>Lukka, Bound to Ruin</reverse-related>
@@ -6585,15 +6585,15 @@ A card with morph can be turned face up any time for its morph cost.)</text>
                 <cmc>0</cmc>
                 <pt>0/0</pt>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/1/1/113959ba-be71-47ce-93e2-b81157034822.jpg?1676028695">ONC</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/7/d/7dfd481c-94ad-4a2e-a396-3d4a10bacc33.jpg?1644543591">NEC</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/b/5/b53e0681-603e-4180-bc86-3dadf214e61a.jpg?1641306175">MH2</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/9/e/9ecc467e-b345-446c-b9b7-5f164e6651a4.jpg?1598311624">2XM</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/1/d197efaf-4c60-460a-81d2-651e2914b82b.jpg?1562937128">C16</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/5/d573bb59-5167-4578-8674-355f38d0b7be.jpg?1562857285">C15</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/4/4/4414f9fa-dfda-4714-9f87-cb5e8914b07a.jpg">MM2</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/e/e/eede5cf7-1c41-4523-ad27-9c232e1f2bb5.jpg">C14</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/7/6/760dcba4-c0f1-4843-9c39-393c629aae8e.jpg">MBS</set>
+            <set picURL="https://api.scryfall.com/cards/113959ba-be71-47ce-93e2-b81157034822?format=image">ONC</set>
+            <set picURL="https://api.scryfall.com/cards/7dfd481c-94ad-4a2e-a396-3d4a10bacc33?format=image">NEC</set>
+            <set picURL="https://api.scryfall.com/cards/b53e0681-603e-4180-bc86-3dadf214e61a?format=image">MH2</set>
+            <set picURL="https://api.scryfall.com/cards/9ecc467e-b345-446c-b9b7-5f164e6651a4?format=image">2XM</set>
+            <set picURL="https://api.scryfall.com/cards/d197efaf-4c60-460a-81d2-651e2914b82b?format=image">C16</set>
+            <set picURL="https://api.scryfall.com/cards/d573bb59-5167-4578-8674-355f38d0b7be?format=image">C15</set>
+            <set picURL="https://api.scryfall.com/cards/4414f9fa-dfda-4714-9f87-cb5e8914b07a?format=image">MM2</set>
+            <set picURL="https://api.scryfall.com/cards/eede5cf7-1c41-4523-ad27-9c232e1f2bb5?format=image">C14</set>
+            <set picURL="https://api.scryfall.com/cards/760dcba4-c0f1-4843-9c39-393c629aae8e?format=image">MBS</set>
             <reverse-related attach="attach">Batterbone</reverse-related>
             <reverse-related attach="attach">Batterskull</reverse-related>
             <reverse-related attach="attach">Bonehoard</reverse-related>
@@ -6621,7 +6621,7 @@ A card with morph can be turned face up any time for its morph cost.)</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/3/6/3663e79b-2bf9-44af-a638-c0ad9067d8d4.jpg?1675095429">ONE</set>
+            <set picURL="https://api.scryfall.com/cards/3663e79b-2bf9-44af-a638-c0ad9067d8d4?format=image">ONE</set>
             <reverse-related>Chancellor of the Forge</reverse-related>
             <reverse-related count="x">Chancellor of the Forge</reverse-related>
             <reverse-related>Charforger</reverse-related>
@@ -6640,11 +6640,11 @@ A card with morph can be turned face up any time for its morph cost.)</text>
                 <cmc>0</cmc>
                 <pt>3/3</pt>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/6/3/63ace2fa-8cfb-4641-a05c-d12830378e03.jpg?1675095914">ONE</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/f/af7c6e4c-4980-4b1b-8156-fd17dd6f47c9.jpg?1608908566">CMR</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/c/dc77b308-9d0c-492f-b3fe-e00d60470767.jpg?1563073222">MH1</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/0/509be7b3-490d-4229-ba10-999921a6b977.jpg?1562841177">MM3</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/f/e/fe9e8d3b-ebc0-448b-bd14-a9f418e196e7.jpg">NPH</set>
+            <set picURL="https://api.scryfall.com/cards/63ace2fa-8cfb-4641-a05c-d12830378e03?format=image">ONE</set>
+            <set picURL="https://api.scryfall.com/cards/af7c6e4c-4980-4b1b-8156-fd17dd6f47c9?format=image">CMR</set>
+            <set picURL="https://api.scryfall.com/cards/dc77b308-9d0c-492f-b3fe-e00d60470767?format=image">MH1</set>
+            <set picURL="https://api.scryfall.com/cards/509be7b3-490d-4229-ba10-999921a6b977?format=image">MM3</set>
+            <set picURL="https://api.scryfall.com/cards/fe9e8d3b-ebc0-448b-bd14-a9f418e196e7?format=image">NPH</set>
             <reverse-related>Blade Splicer</reverse-related>
             <reverse-related>Conversion Chamber</reverse-related>
             <reverse-related>Ich-Tekik, Salvage Splicer</reverse-related>
@@ -6668,12 +6668,12 @@ A card with morph can be turned face up any time for its morph cost.)</text>
                 <cmc>0</cmc>
                 <pt>*/*</pt>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/6/6/661297e0-f8cb-402c-be33-67d3d218ce98.jpg?1675905880">ONC</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/7/d/7db68985-a1d5-4bd5-bfc6-c7208689d7df.jpg?1608908587">CMR</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/6/1/6188c0f0-0346-46d4-8a45-ae2749bf246f.jpg?1572370790">C19</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/e/ae98a532-2e83-46bc-b391-cc0ab20ea0da.jpg?1592710130">C18</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/2/4/248ae300-40cc-4e6f-8fa6-2bd6ab85fee6.jpg?1562902339">C16</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/a/5a4c5954-da2b-498a-9e86-eb4d6dc95cb8.jpg">MBS</set>
+            <set picURL="https://api.scryfall.com/cards/661297e0-f8cb-402c-be33-67d3d218ce98?format=image">ONC</set>
+            <set picURL="https://api.scryfall.com/cards/7db68985-a1d5-4bd5-bfc6-c7208689d7df?format=image">CMR</set>
+            <set picURL="https://api.scryfall.com/cards/6188c0f0-0346-46d4-8a45-ae2749bf246f?format=image">C19</set>
+            <set picURL="https://api.scryfall.com/cards/ae98a532-2e83-46bc-b391-cc0ab20ea0da?format=image">C18</set>
+            <set picURL="https://api.scryfall.com/cards/248ae300-40cc-4e6f-8fa6-2bd6ab85fee6?format=image">C16</set>
+            <set picURL="https://api.scryfall.com/cards/5a4c5954-da2b-498a-9e86-eb4d6dc95cb8?format=image">MBS</set>
             <reverse-related>Phyrexian Rebirth</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -6687,7 +6687,7 @@ A card with morph can be turned face up any time for its morph cost.)</text>
                 <cmc>0</cmc>
                 <pt>*/*</pt>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/1/f/1f5fc2cb-a172-418a-a0f3-1a63a5f1aa2c.jpg?1675095716">ONE</set>
+            <set picURL="https://api.scryfall.com/cards/1f5fc2cb-a172-418a-a0f3-1a63a5f1aa2c?format=image">ONE</set>
             <reverse-related>Nissa, Ascended Animist</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -6702,7 +6702,7 @@ A card with morph can be turned face up any time for its morph cost.)</text>
                 <cmc>0</cmc>
                 <pt>*/1</pt>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/d/a/da13c90f-9ed2-4262-88e2-17daa294537b.jpg?1675095539">ONE</set>
+            <set picURL="https://api.scryfall.com/cards/da13c90f-9ed2-4262-88e2-17daa294537b?format=image">ONE</set>
             <reverse-related>Urabrask's Forge</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -6717,8 +6717,8 @@ A card with morph can be turned face up any time for its morph cost.)</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/5/a/5a90e8ab-5a76-4834-9cd6-186af939ea41.jpg?1675905873">ONC</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/8/5/85f9e977-f718-41b2-b30b-77a9a17e9733.jpg">SOM</set>
+            <set picURL="https://api.scryfall.com/cards/5a90e8ab-5a76-4834-9cd6-186af939ea41?format=image">ONC</set>
+            <set picURL="https://api.scryfall.com/cards/85f9e977-f718-41b2-b30b-77a9a17e9733?format=image">SOM</set>
             <related>Poison Counter</related>
             <reverse-related count="2">Carrion Call</reverse-related>
             <reverse-related count="x">Phyrexian Swarmlord</reverse-related>
@@ -6735,7 +6735,7 @@ A card with morph can be turned face up any time for its morph cost.)</text>
                 <cmc>0</cmc>
                 <pt>*/*</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/9/a9930d11-4772-4fc2-abbd-9af0a9b23a3e.jpg">DDE</set>
+            <set picURL="https://api.scryfall.com/cards/a9930d11-4772-4fc2-abbd-9af0a9b23a3e?format=image">DDE</set>
             <reverse-related>Phyrexian Processor</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -6750,7 +6750,7 @@ This creature can't block.</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/9/6/96ec91a9-659a-455f-98e0-cd30b6c6c2a4.jpg?1675095978">ONE</set>
+            <set picURL="https://api.scryfall.com/cards/96ec91a9-659a-455f-98e0-cd30b6c6c2a4?format=image">ONE</set>
             <related>Poison Counter</related>
             <reverse-related count="2">Basilica Shepherd</reverse-related>
             <reverse-related count="2">Charge of the Mites</reverse-related>
@@ -6775,8 +6775,8 @@ This creature can't block.</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/f/dfe197cf-6f36-424e-a544-cbe7a56f8a32.jpg">MD1</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/c/5c087beb-99c0-403e-bb44-33cfc549a831.jpg">NPH</set>
+            <set picURL="https://api.scryfall.com/cards/dfe197cf-6f36-424e-a544-cbe7a56f8a32?format=image">MD1</set>
+            <set picURL="https://api.scryfall.com/cards/5c087beb-99c0-403e-bb44-33cfc549a831?format=image">NPH</set>
             <reverse-related>Myr Sire</reverse-related>
             <reverse-related>Parasitic Implant</reverse-related>
             <reverse-related count="x">Shrine of Loyal Legions</reverse-related>
@@ -6792,8 +6792,8 @@ This creature can't block.</text>
                 <cmc>0</cmc>
                 <pt>2/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/4/8/483c8cd6-288c-49d7-ac28-642132f85259.jpg?1598311565">2XM</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/6/5/656af066-f9b3-4c23-b6c4-3ff55776858f.jpg?1592710019">C18</set>
+            <set picURL="https://api.scryfall.com/cards/483c8cd6-288c-49d7-ac28-642132f85259?format=image">2XM</set>
+            <set picURL="https://api.scryfall.com/cards/656af066-f9b3-4c23-b6c4-3ff55776858f?format=image">C18</set>
             <reverse-related>Brudiclad, Telchor Engineer</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -6807,7 +6807,7 @@ This creature can't block.</text>
                 <cmc>0</cmc>
                 <pt>2/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/b/a/ba2a7b17-a65a-4c37-bc2b-8be5ff8ce692.jpg?1661549355">DMU</set>
+            <set picURL="https://api.scryfall.com/cards/ba2a7b17-a65a-4c37-bc2b-8be5ff8ce692?format=image">DMU</set>
             <reverse-related count="x">The Phasing of Zhalfir</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -6821,9 +6821,9 @@ This creature can't block.</text>
                 <cmc>0</cmc>
                 <pt>3/3</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/6/a6ee0db9-ac89-4ab6-ac2e-8a7527d9ecbd.jpg?1598312477">2XM</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/2/c20607b9-4f4a-4dbc-a09f-250ba2d53f80.jpg">C14</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/e/e/ee53b9a0-8e07-404d-87ae-ff8397a0ba29.jpg">SOM</set>
+            <set picURL="https://api.scryfall.com/cards/a6ee0db9-ac89-4ab6-ac2e-8a7527d9ecbd?format=image">2XM</set>
+            <set picURL="https://api.scryfall.com/cards/c20607b9-4f4a-4dbc-a09f-250ba2d53f80?format=image">C14</set>
+            <set picURL="https://api.scryfall.com/cards/ee53b9a0-8e07-404d-87ae-ff8397a0ba29?format=image">SOM</set>
             <reverse-related>Wurmcoil Engine</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -6837,9 +6837,9 @@ This creature can't block.</text>
                 <cmc>0</cmc>
                 <pt>3/3</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/b/6/b68e816f-f9ac-435b-ad0b-ceedbe72447a.jpg?1598312203">2XM</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/f/1f27a3e2-bfd6-4d01-aef1-0bdb09e41ee0.jpg">C14</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/3/e/3e46e703-2157-41e5-9c21-c17af43e0d3f.jpg">SOM</set>
+            <set picURL="https://api.scryfall.com/cards/b68e816f-f9ac-435b-ad0b-ceedbe72447a?format=image">2XM</set>
+            <set picURL="https://api.scryfall.com/cards/1f27a3e2-bfd6-4d01-aef1-0bdb09e41ee0?format=image">C14</set>
+            <set picURL="https://api.scryfall.com/cards/3e46e703-2157-41e5-9c21-c17af43e0d3f?format=image">SOM</set>
             <reverse-related>Wurmcoil Engine</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -6855,7 +6855,7 @@ Toxic 1 (Players dealt combat damage by this creature also get a poison counter.
                 <cmc>0</cmc>
                 <pt>*/*</pt>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/5/9/594c55d3-d435-4dec-bc92-011442a43684.jpg?1675905874">ONC</set>
+            <set picURL="https://api.scryfall.com/cards/594c55d3-d435-4dec-bc92-011442a43684?format=image">ONC</set>
             <related>Poison Counter</related>
             <reverse-related>Wurmquake</reverse-related>
             <reverse-related count="x" exclude="exclude">Wurmquake</reverse-related>
@@ -6871,7 +6871,7 @@ Toxic 1 (Players dealt combat damage by this creature also get a poison counter.
                 <cmc>0</cmc>
                 <pt>2/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/4/6/46769d11-a7ae-43ac-8c00-e1681955949b.jpg">MBS</set>
+            <set picURL="https://api.scryfall.com/cards/46769d11-a7ae-43ac-8c00-e1681955949b?format=image">MBS</set>
             <reverse-related>Nested Ghoul</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -6885,7 +6885,7 @@ Toxic 1 (Players dealt combat damage by this creature also get a poison counter.
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/b/e/be84f259-2809-48c9-9c70-861437f08c23.jpg?1644542924">NEO</set>
+            <set picURL="https://api.scryfall.com/cards/be84f259-2809-48c9-9c70-861437f08c23?format=image">NEO</set>
             <reverse-related count="2">Born to Drive</reverse-related>
             <reverse-related>Prodigy's Prototype</reverse-related>
             <reverse-related>Reckoner Bankbuster</reverse-related>
@@ -6916,7 +6916,7 @@ Toxic 1 (Players dealt combat damage by this creature also get a poison counter.
                 <cmc>0</cmc>
                 <pt>2/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/2/d/2d7fc721-6b5b-4920-86fa-0fbfd90adaf5.jpg?1562539764">XLN</set>
+            <set picURL="https://api.scryfall.com/cards/2d7fc721-6b5b-4920-86fa-0fbfd90adaf5?format=image">XLN</set>
             <reverse-related>Fathom Fleet Captain</reverse-related>
             <reverse-related>Vraska, Relic Seeker</reverse-related>
             <token>1</token>
@@ -6933,8 +6933,8 @@ Creatures you control attack each combat if able.</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/4/2/42248cea-29e8-4ebe-ad64-e87e216b55d6.jpg?1654172420">CLB</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/a/da3002d9-7754-4c7f-a051-382cd7a86e80.jpg?1594733620">M21</set>
+            <set picURL="https://api.scryfall.com/cards/42248cea-29e8-4ebe-ad64-e87e216b55d6?format=image">CLB</set>
+            <set picURL="https://api.scryfall.com/cards/da3002d9-7754-4c7f-a051-382cd7a86e80?format=image">M21</set>
             <reverse-related>Pursued Whale</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -6948,7 +6948,7 @@ Creatures you control attack each combat if able.</text>
                 <cmc>0</cmc>
                 <pt>1/3</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/b/1/b19d2866-87e7-40ab-9684-0593caeb223e.jpg?1663529881">40K</set>
+            <set picURL="https://api.scryfall.com/cards/b19d2866-87e7-40ab-9684-0593caeb223e?format=image">40K</set>
             <reverse-related count="x">Great Unclean One</reverse-related>
             <reverse-related>Nurgle's Rot</reverse-related>
             <token>1</token>
@@ -6963,13 +6963,13 @@ Creatures you control attack each combat if able.</text>
                 <cmc>0</cmc>
                 <pt>0/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/d/0dfac8bc-2b81-4577-a69c-8edbdbcc84aa.jpg?1644543501">NEC</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/e/6/e67a2d72-595e-4212-837b-07445a2175bf.jpg?1623022282">CMR</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/0/d03d87f5-0ac6-45ca-a54b-6a36132a8eae.jpg?1604194870">ZNR</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/b/1/b1d05bfc-c447-474a-9ec9-9f4772821bfb.jpg?1598311749">2XM</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/8/4/84fcc620-a467-47ce-bbbe-387bad7619ab.jpg?1592710089">C18</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/8/5/8501a910-e181-4f85-ad34-d2a099257148.jpg">OGW</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/1/c1424e8d-1f96-44af-9382-c337b6695ddf.jpg">WWK</set>
+            <set picURL="https://api.scryfall.com/cards/0dfac8bc-2b81-4577-a69c-8edbdbcc84aa?format=image">NEC</set>
+            <set picURL="https://api.scryfall.com/cards/e67a2d72-595e-4212-837b-07445a2175bf?format=image">CMR</set>
+            <set picURL="https://api.scryfall.com/cards/d03d87f5-0ac6-45ca-a54b-6a36132a8eae?format=image">ZNR</set>
+            <set picURL="https://api.scryfall.com/cards/b1d05bfc-c447-474a-9ec9-9f4772821bfb?format=image">2XM</set>
+            <set picURL="https://api.scryfall.com/cards/84fcc620-a467-47ce-bbbe-387bad7619ab?format=image">C18</set>
+            <set picURL="https://api.scryfall.com/cards/8501a910-e181-4f85-ad34-d2a099257148?format=image">OGW</set>
+            <set picURL="https://api.scryfall.com/cards/c1424e8d-1f96-44af-9382-c337b6695ddf?format=image">WWK</set>
             <reverse-related count="x">Avenger of Zendikar</reverse-related>
             <reverse-related count="7">Evil Comes to Fruition</reverse-related>
             <reverse-related>Khalni Garden</reverse-related>
@@ -6989,8 +6989,8 @@ Creatures you control attack each combat if able.</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/4/d4b6b06c-6ce7-405c-acc1-a2626fcde8ad.jpg?1572370744">C19</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/0/10a63c10-9bf9-4e0f-831c-830d7994a62a.jpg">BFZ</set>
+            <set picURL="https://api.scryfall.com/cards/d4b6b06c-6ce7-405c-acc1-a2626fcde8ad?format=image">C19</set>
+            <set picURL="https://api.scryfall.com/cards/10a63c10-9bf9-4e0f-831c-830d7994a62a?format=image">BFZ</set>
             <reverse-related>Grismold, the Dreadsower</reverse-related>
             <reverse-related>Grovetender Druids</reverse-related>
             <token>1</token>
@@ -7006,7 +7006,7 @@ Creatures you control attack each combat if able.</text>
                 <cmc>0</cmc>
                 <pt>0/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/6/4/642d1d93-22d0-43f9-8691-6790876185a0.jpg?1562539777">XLN</set>
+            <set picURL="https://api.scryfall.com/cards/642d1d93-22d0-43f9-8691-6790876185a0?format=image">XLN</set>
             <reverse-related count="2">Dowsing Dagger</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -7019,8 +7019,8 @@ Creatures you control attack each combat if able.</text>
                 <maintype>Artifact</maintype>
                 <cmc>0</cmc>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/d/4/d45fe4b6-aeaf-4f84-b660-c7b482ed8512.jpg?1667886993">BRO</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/4/4/447af615-1e59-471f-886b-bf46007a938d.jpg?1661549831">DMU</set>
+            <set picURL="https://api.scryfall.com/cards/d45fe4b6-aeaf-4f84-b660-c7b482ed8512?format=image">BRO</set>
+            <set picURL="https://api.scryfall.com/cards/447af615-1e59-471f-886b-bf46007a938d?format=image">DMU</set>
             <reverse-related>Arbalest Engineers</reverse-related>
             <reverse-related>Argothian Opportunist</reverse-related>
             <reverse-related>Ashnod, Flesh Mechanist</reverse-related>
@@ -7080,7 +7080,7 @@ Creatures you control attack each combat if able.</text>
                 <cmc>0</cmc>
                 <pt>4/4</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/7/c/7c9d8aac-c032-4e0d-a8ef-99a7c53c7a19.jpg">HOU</set>
+            <set picURL="https://api.scryfall.com/cards/7c9d8aac-c032-4e0d-a8ef-99a7c53c7a19?format=image">HOU</set>
             <reverse-related>Proven Combatant</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -7094,7 +7094,7 @@ Creatures you control attack each combat if able.</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/2/2/22ca55e0-d269-4178-bc90-920a12066e4f.jpg?1654171228">CLB</set>
+            <set picURL="https://api.scryfall.com/cards/22ca55e0-d269-4178-bc90-920a12066e4f?format=image">CLB</set>
             <reverse-related count="x">Cadira, Caller of the Small</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -7108,8 +7108,8 @@ Creatures you control attack each combat if able.</text>
                 <maintype>Creature</maintype>
                 <pt>2/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/c/5cd9a145-86cc-4591-b64b-c003eaa926eb.jpg?1662663407">DMU</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/e/1ebc91a9-23e0-4ca1-bc6d-e710ad2efb31.jpg">AER</set>
+            <set picURL="https://api.scryfall.com/cards/5cd9a145-86cc-4591-b64b-c003eaa926eb?format=image">DMU</set>
+            <set picURL="https://api.scryfall.com/cards/1ebc91a9-23e0-4ca1-bc6d-e710ad2efb31?format=image">AER</set>
             <reverse-related>Kari Zev, Skyship Raider</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -7124,7 +7124,7 @@ Creatures you control attack each combat if able.</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/6/9/695f72ea-13e6-40ab-afc7-55657701c82d.jpg?1644542644">NEO</set>
+            <set picURL="https://api.scryfall.com/cards/695f72ea-13e6-40ab-afc7-55657701c82d?format=image">NEO</set>
             <reverse-related>Tribute to Horobi</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -7138,9 +7138,9 @@ Creatures you control attack each combat if able.</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/e/4/e43a205e-43ea-4b3e-92ab-c2ee2172a50a.jpg?1572489150">ELD</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/f/1/f1fb8ca6-7351-457a-b2a4-48f57ec3c64a.jpg">GTC</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/a/1a85fe9d-ef18-46c4-88b0-cf2e222e30e4.jpg">SHM</set>
+            <set picURL="https://api.scryfall.com/cards/e43a205e-43ea-4b3e-92ab-c2ee2172a50a?format=image">ELD</set>
+            <set picURL="https://api.scryfall.com/cards/f1fb8ca6-7351-457a-b2a4-48f57ec3c64a?format=image">GTC</set>
+            <set picURL="https://api.scryfall.com/cards/1a85fe9d-ef18-46c4-88b0-cf2e222e30e4?format=image">SHM</set>
             <reverse-related count="x">Chittering Witch</reverse-related>
             <reverse-related>Lab Rats</reverse-related>
             <reverse-related count="2">Mad Ratter</reverse-related>
@@ -7161,7 +7161,7 @@ Creatures you control attack each combat if able.</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/1/c1788d4c-31b8-4f73-8275-5470316e7ad4.jpg">C17</set>
+            <set picURL="https://api.scryfall.com/cards/c1788d4c-31b8-4f73-8275-5470316e7ad4?format=image">C17</set>
             <reverse-related>Hungry Lynx</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -7176,7 +7176,7 @@ Creatures you control attack each combat if able.</text>
                 <cmc>0</cmc>
                 <pt>3/3</pt>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/b/3/b3170b92-b4eb-4826-92ed-85deba4c4c88.jpg?1666063013">BOT</set>
+            <set picURL="https://api.scryfall.com/cards/b3170b92-b4eb-4826-92ed-85deba4c4c88?format=image">BOT</set>
             <reverse-related exclude="exclude">Soundwave, Superior Captain</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -7190,7 +7190,7 @@ Creatures you control attack each combat if able.</text>
                 <cmc>0</cmc>
                 <pt>2/2</pt>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/a/4/a41eb9df-d8b4-4697-a759-886faf16754d.jpg?1675095630">ONE</set>
+            <set picURL="https://api.scryfall.com/cards/a41eb9df-d8b4-4697-a759-886faf16754d?format=image">ONE</set>
             <reverse-related>Barbed Batterfist</reverse-related>
             <reverse-related>Blade of Shared Souls</reverse-related>
             <reverse-related>Bladehold War-Whip</reverse-related>
@@ -7246,7 +7246,7 @@ Creatures you control attack each combat if able.</text>
                 <maintype>Creature</maintype>
                 <pt>3/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/b/ab1c23b2-ac39-46b1-aa2b-7d6cbedba767.jpg?1581901994">THB</set>
+            <set picURL="https://api.scryfall.com/cards/ab1c23b2-ac39-46b1-aa2b-7d6cbedba767?format=image">THB</set>
             <reverse-related>Alirios, Enraptured</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -7259,7 +7259,7 @@ Creatures you control attack each combat if able.</text>
                 <maintype>Artifact</maintype>
                 <cmc>0</cmc>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/b/3/b3ce1236-ec2f-4cd1-9701-ba6ead74c220.jpg?1615686843">KHM</set>
+            <set picURL="https://api.scryfall.com/cards/b3ce1236-ec2f-4cd1-9701-ba6ead74c220?format=image">KHM</set>
             <reverse-related count="8">Replicating Ring</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -7274,7 +7274,7 @@ Creatures you control attack each combat if able.</text>
                 <cmc>0</cmc>
                 <pt>4/4</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/1/c1326c5d-b5a5-4942-b15d-37830ac62c7d.jpg">HOU</set>
+            <set picURL="https://api.scryfall.com/cards/c1326c5d-b5a5-4942-b15d-37830ac62c7d?format=image">HOU</set>
             <reverse-related>Resilient Khenra</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -7289,9 +7289,9 @@ Creatures you control attack each combat if able.</text>
                 <cmc>0</cmc>
                 <pt>4/4</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/2/1/214a48bc-4a1c-44e3-9415-a73af3d4fd95.jpg?1568003482">C19</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/0/007c828b-5854-41ac-9c18-f9d41c69ed33.jpg?1563073152">MH1</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/3/1331008a-ae86-4640-b823-a73be766ac16.jpg">RTR</set>
+            <set picURL="https://api.scryfall.com/cards/214a48bc-4a1c-44e3-9415-a73af3d4fd95?format=image">C19</set>
+            <set picURL="https://api.scryfall.com/cards/007c828b-5854-41ac-9c18-f9d41c69ed33?format=image">MH1</set>
+            <set picURL="https://api.scryfall.com/cards/1331008a-ae86-4640-b823-a73be766ac16?format=image">RTR</set>
             <reverse-related count="2">Crashing Footfalls</reverse-related>
             <reverse-related>Ghired, Conclave Exile</reverse-related>
             <reverse-related>Horncaller's Chant</reverse-related>
@@ -7308,7 +7308,7 @@ Creatures you control attack each combat if able.</text>
                 <cmc>0</cmc>
                 <pt>4/4</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/2/3/230419f9-a9f7-441d-bad7-0ed867326aa1.jpg?1650820041">SNC</set>
+            <set picURL="https://api.scryfall.com/cards/230419f9-a9f7-441d-bad7-0ed867326aa1?format=image">SNC</set>
             <reverse-related count="x">Crash the Party</reverse-related>
             <reverse-related exclude="exclude">Killer Service</reverse-related>
             <reverse-related>Titan of Industry</reverse-related>
@@ -7326,7 +7326,7 @@ Creatures you control attack each combat if able.</text>
                 <cmc>0</cmc>
                 <pt>4/4</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/3/1/319aaaae-1efb-412c-8839-c575a2694485.jpg?1663566486">40K</set>
+            <set picURL="https://api.scryfall.com/cards/319aaaae-1efb-412c-8839-c575a2694485?format=image">40K</set>
             <reverse-related>Cybernetica Datasmith</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -7340,7 +7340,7 @@ Equip {1}</text>
                 <maintype>Artifact</maintype>
                 <cmc>0</cmc>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/6/6/661cbde4-9444-4259-b2cf-7c8f9814a071.jpg?1608908618">CMR</set>
+            <set picURL="https://api.scryfall.com/cards/661cbde4-9444-4259-b2cf-7c8f9814a071?format=image">CMR</set>
             <reverse-related>Toggo, Goblin Weaponsmith</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -7354,7 +7354,7 @@ Equip {1}</text>
                 <cmc>0</cmc>
                 <pt>2/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/6/06e503b9-a822-4c42-b478-1f598bc5941d.jpg?1650819906">SNC</set>
+            <set picURL="https://api.scryfall.com/cards/06e503b9-a822-4c42-b478-1f598bc5941d?format=image">SNC</set>
             <reverse-related>Currency Converter</reverse-related>
             <reverse-related>Girder Goons</reverse-related>
             <reverse-related>Misfortune Teller</reverse-related>
@@ -7371,7 +7371,7 @@ Equip {1}</text>
                 <maintype>Creature</maintype>
                 <pt>2/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/4/b/4b633d7b-6d61-4b1a-8d65-6e1f3d5ffba7.jpg?1562908763">UST</set>
+            <set picURL="https://api.scryfall.com/cards/4b633d7b-6d61-4b1a-8d65-6e1f3d5ffba7?format=image">UST</set>
             <reverse-related>Dispatch Dispensary</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -7386,7 +7386,7 @@ Equip {1}</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/6/56ea5f68-3818-43d3-9b7b-c344305a8423.jpg">AKH</set>
+            <set picURL="https://api.scryfall.com/cards/56ea5f68-3818-43d3-9b7b-c344305a8423?format=image">AKH</set>
             <reverse-related>Sacred Cat</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -7400,7 +7400,7 @@ Equip {1}</text>
                 <cmc>0</cmc>
                 <pt>4/3</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/4/c/4c0a6832-677f-4226-bd8d-f93eeeffd02d.jpg?1608908469">CMR</set>
+            <set picURL="https://api.scryfall.com/cards/4c0a6832-677f-4226-bd8d-f93eeeffd02d?format=image">CMR</set>
             <reverse-related>Amphin Mutineer</reverse-related>
             <reverse-related>Gor Muldrak, Amphinologist</reverse-related>
             <token>1</token>
@@ -7416,7 +7416,7 @@ Equip {1}</text>
                 <cmc>0</cmc>
                 <pt>2/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/f/6/f68e5337-6e44-4f8f-a102-2f97b433beea.jpg?1644542564">NEO</set>
+            <set picURL="https://api.scryfall.com/cards/f68e5337-6e44-4f8f-a102-2f97b433beea?format=image">NEO</set>
             <reverse-related>Banishing Slash</reverse-related>
             <reverse-related count="x">Eiganjo Uprising</reverse-related>
             <reverse-related>Experimental Synthesizer</reverse-related>
@@ -7436,7 +7436,7 @@ Equip {1}</text>
                 <cmc>0</cmc>
                 <pt>2/2</pt>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/7/0/70750c90-3856-4d6d-923b-2ab91b1d7049.jpg?1675095377">ONE</set>
+            <set picURL="https://api.scryfall.com/cards/70750c90-3856-4d6d-923b-2ab91b1d7049?format=image">ONE</set>
             <reverse-related>The Eternal Wanderer</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -7463,7 +7463,7 @@ Equip {1}</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/2/124ea959-742a-4914-9bca-1075ccd0cb22.jpg?1662835181">DMU</set>
+            <set picURL="https://api.scryfall.com/cards/124ea959-742a-4914-9bca-1075ccd0cb22?format=image">DMU</set>
             <reverse-related count="x">Hazezon Tamar</reverse-related>
             <reverse-related count="2">Hazezon, Shaper of Sand</reverse-related>
             <reverse-related count="x=2" exclude="exclude">Hazezon, Shaper of Sand</reverse-related>
@@ -7479,41 +7479,41 @@ Equip {1}</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/c/7/c7bb00e4-7eb0-4f7d-b2c3-8995959a6e6a.jpg?1674397413">DMR</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/5/d5a07153-9eb6-4366-aa09-ebe9b4868e7f.jpg?1661549652">DMU</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/f/7/f7cbc9fc-42d2-4d1a-b6c0-29a35cfd1588.jpg?1654171619">CLB</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/9/8/98966946-de7a-4a96-b8c5-875f6e453f94.jpg?1644543523">NEC</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/1/113dbefc-14da-4826-87c1-543b53827c24.jpg?1641306102">C21</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/e/d/ed58cd8c-b11a-4109-b789-0eb92eaf0184.jpg?1641306045">TSR</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/8/08074778-ce6d-4a49-a1fc-1391d55e89be.jpg?1620573860">CMR</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/9/5/95483574-95b7-42a3-b700-616189163b0a.jpg?1598312392">2XM</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/7/d71a5aa4-a960-4c42-b8ac-7003f6e83e95.jpg?1594733634">M21</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/e/1e584eb2-fa22-4d75-b612-e25ecf827918.jpg?1591319226">C20</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/f/8/f8e4cbaa-95bc-424c-ac80-9e3e6d41d273.jpg?1572370767">C19</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/3/5/3543a88a-ed81-4dec-a616-43f9367516de.jpg?1552078539">GK2</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/0/c06bcc5b-4ccd-452d-8579-beee6c5cbe98.jpg?1654766742">GK1</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/c/cc77373d-34d1-475b-ade9-f49bb64bff9c.jpg?1541007432">GK1</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/3/5371de1b-db33-4db4-a518-e35c71aa72b7.jpg?1562702067">DOM</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/4/a49da8fe-559f-4c34-b904-c285188fb98d.jpg?1562702234">DOM</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/b/0b425bdc-b3d5-4825-9f97-a00e2d932438.jpg?1562701895">DOM</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/9/2/925715e5-bb94-406b-82b1-93b4d51f0cc2.jpg?1561757588">RIX</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/back/8/c/8ce60642-e207-46e6-b198-d803ff3b47f4.jpg?1571508385">UST</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/e/0e78d072-183d-4272-9d9f-6801dced729d.jpg?1562840732">MM3</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/3/0302fa7d-2e34-4f4a-a84e-7a78febc77f5.jpg?1562895593">C16</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/4/3/43b42383-6055-4c85-9555-d95aaa3078d1.jpg?1562908655">C16</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/b/f/bf6cf1cf-3efa-409f-84ec-783621566000.jpg?1562857281">C15</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/3/a/3aa39099-1ce8-4d59-bc2e-6bb99d10e97c.jpg">MM2</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/f/afd66b96-eccb-44ce-9125-063d34af2ff8.jpg">M14</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/5/15854c49-14fd-4947-8444-c5ab614cb416.jpg">MMA</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/e/6/e6544989-91b4-4db7-ad44-f1355f1d6e6b.jpg">RTR</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/0/006c118e-b5c7-4726-acee-59132f23e4fc.jpg">DDJ</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/d/dd67de8a-3879-4d03-a716-6e907d597b25.jpg">M13</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/4/f/4fb8f4f1-6372-41ea-802c-4b952a78a08b.jpg">DDH</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/a/ca2df53f-060d-464a-9c97-908e49e2dc2c.jpg">M12</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/b/d/bdd91d97-2f28-4116-a64c-407cf94a4fac.jpg">DDE</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/6/2/622759a9-e68b-48c1-8e03-beaab0a52556.jpg">ALA</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/6/9/698d48fa-d6c1-44b9-8aa2-bb03e0e53788.jpg">10E</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/6/1/61587ac5-0cfe-4e5d-baa2-c9a458e40474.jpg">INV</set>
+            <set picURL="https://api.scryfall.com/cards/c7bb00e4-7eb0-4f7d-b2c3-8995959a6e6a?format=image">DMR</set>
+            <set picURL="https://api.scryfall.com/cards/d5a07153-9eb6-4366-aa09-ebe9b4868e7f?format=image">DMU</set>
+            <set picURL="https://api.scryfall.com/cards/f7cbc9fc-42d2-4d1a-b6c0-29a35cfd1588?format=image">CLB</set>
+            <set picURL="https://api.scryfall.com/cards/98966946-de7a-4a96-b8c5-875f6e453f94?format=image">NEC</set>
+            <set picURL="https://api.scryfall.com/cards/113dbefc-14da-4826-87c1-543b53827c24?format=image">C21</set>
+            <set picURL="https://api.scryfall.com/cards/ed58cd8c-b11a-4109-b789-0eb92eaf0184?format=image">TSR</set>
+            <set picURL="https://api.scryfall.com/cards/08074778-ce6d-4a49-a1fc-1391d55e89be?format=image">CMR</set>
+            <set picURL="https://api.scryfall.com/cards/95483574-95b7-42a3-b700-616189163b0a?format=image">2XM</set>
+            <set picURL="https://api.scryfall.com/cards/d71a5aa4-a960-4c42-b8ac-7003f6e83e95?format=image">M21</set>
+            <set picURL="https://api.scryfall.com/cards/1e584eb2-fa22-4d75-b612-e25ecf827918?format=image">C20</set>
+            <set picURL="https://api.scryfall.com/cards/f8e4cbaa-95bc-424c-ac80-9e3e6d41d273?format=image">C19</set>
+            <set picURL="https://api.scryfall.com/cards/3543a88a-ed81-4dec-a616-43f9367516de?format=image">GK2</set>
+            <set picURL="https://api.scryfall.com/cards/c06bcc5b-4ccd-452d-8579-beee6c5cbe98?format=image">GK1</set>
+            <set picURL="https://api.scryfall.com/cards/cc77373d-34d1-475b-ade9-f49bb64bff9c?format=image">GK1</set>
+            <set picURL="https://api.scryfall.com/cards/5371de1b-db33-4db4-a518-e35c71aa72b7?format=image">DOM</set>
+            <set picURL="https://api.scryfall.com/cards/a49da8fe-559f-4c34-b904-c285188fb98d?format=image">DOM</set>
+            <set picURL="https://api.scryfall.com/cards/0b425bdc-b3d5-4825-9f97-a00e2d932438?format=image">DOM</set>
+            <set picURL="https://api.scryfall.com/cards/925715e5-bb94-406b-82b1-93b4d51f0cc2?format=image">RIX</set>
+            <set picURL="https://api.scryfall.com/cards/8ce60642-e207-46e6-b198-d803ff3b47f4?format=image&amp;face=back">UST</set>
+            <set picURL="https://api.scryfall.com/cards/0e78d072-183d-4272-9d9f-6801dced729d?format=image">MM3</set>
+            <set picURL="https://api.scryfall.com/cards/0302fa7d-2e34-4f4a-a84e-7a78febc77f5?format=image">C16</set>
+            <set picURL="https://api.scryfall.com/cards/43b42383-6055-4c85-9555-d95aaa3078d1?format=image">C16</set>
+            <set picURL="https://api.scryfall.com/cards/bf6cf1cf-3efa-409f-84ec-783621566000?format=image">C15</set>
+            <set picURL="https://api.scryfall.com/cards/3aa39099-1ce8-4d59-bc2e-6bb99d10e97c?format=image">MM2</set>
+            <set picURL="https://api.scryfall.com/cards/afd66b96-eccb-44ce-9125-063d34af2ff8?format=image">M14</set>
+            <set picURL="https://api.scryfall.com/cards/15854c49-14fd-4947-8444-c5ab614cb416?format=image">MMA</set>
+            <set picURL="https://api.scryfall.com/cards/e6544989-91b4-4db7-ad44-f1355f1d6e6b?format=image">RTR</set>
+            <set picURL="https://api.scryfall.com/cards/006c118e-b5c7-4726-acee-59132f23e4fc?format=image">DDJ</set>
+            <set picURL="https://api.scryfall.com/cards/dd67de8a-3879-4d03-a716-6e907d597b25?format=image">M13</set>
+            <set picURL="https://api.scryfall.com/cards/4fb8f4f1-6372-41ea-802c-4b952a78a08b?format=image">DDH</set>
+            <set picURL="https://api.scryfall.com/cards/ca2df53f-060d-464a-9c97-908e49e2dc2c?format=image">M12</set>
+            <set picURL="https://api.scryfall.com/cards/bdd91d97-2f28-4116-a64c-407cf94a4fac?format=image">DDE</set>
+            <set picURL="https://api.scryfall.com/cards/622759a9-e68b-48c1-8e03-beaab0a52556?format=image">ALA</set>
+            <set picURL="https://api.scryfall.com/cards/698d48fa-d6c1-44b9-8aa2-bb03e0e53788?format=image">10E</set>
+            <set picURL="https://api.scryfall.com/cards/61587ac5-0cfe-4e5d-baa2-c9a458e40474?format=image">INV</set>
             <reverse-related count="x">Aether Mutation</reverse-related>
             <reverse-related count="x">Artifact Mutation</reverse-related>
             <reverse-related count="x">Aura Mutation</reverse-related>
@@ -7623,8 +7623,8 @@ Equip {1}</text>
                 <cmc>0</cmc>
                 <pt>2/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/8/3/831fbc86-e328-4c26-a8b2-35feb24f6430.jpg?1654172019">CLB</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/b/a/baa93038-2849-4c26-ab4f-1d50d276659f.jpg">THS</set>
+            <set picURL="https://api.scryfall.com/cards/831fbc86-e328-4c26-a8b2-35feb24f6430?format=image">CLB</set>
+            <set picURL="https://api.scryfall.com/cards/baa93038-2849-4c26-ab4f-1d50d276659f?format=image">THS</set>
             <reverse-related count="4">Revel of the Fallen God</reverse-related>
             <reverse-related>Xenagos, the Reveler</reverse-related>
             <token>1</token>
@@ -7640,7 +7640,7 @@ Equip {1}</text>
                 <maintype>Creature</maintype>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/9/0/903e30f3-580e-4a14-989b-ae0632363407.jpg?1581902165">THB</set>
+            <set picURL="https://api.scryfall.com/cards/903e30f3-580e-4a14-989b-ae0632363407?format=image">THB</set>
             <reverse-related count="x=1">Anax, Hardened in the Forge</reverse-related>
             <reverse-related>Heroes of the Revel</reverse-related>
             <reverse-related>Satyr's Cunning</reverse-related>
@@ -7656,7 +7656,7 @@ Equip {1}</text>
                 <maintype>Creature</maintype>
                 <pt>*/*</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/7/7/7711a586-37f9-4560-b25d-4fb339d9cd55.jpg?1568003539">C19</set>
+            <set picURL="https://api.scryfall.com/cards/7711a586-37f9-4560-b25d-4fb339d9cd55?format=image">C19</set>
             <reverse-related>Doomed Artisan</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -7670,7 +7670,7 @@ Equip {1}</text>
                 <cmc>0</cmc>
                 <pt>0/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/9/c98dbedd-b1f1-4a9c-af37-8ce2ae07a247.jpg?1562702324">EMA</set>
+            <set picURL="https://api.scryfall.com/cards/c98dbedd-b1f1-4a9c-af37-8ce2ae07a247?format=image">EMA</set>
             <reverse-related count="3">Sengir Autocrat</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -7683,12 +7683,12 @@ Equip {1}</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/e/ae8e32b9-431c-43d9-a0df-d73f4ff4fbc2.jpg?1601138298">2XM</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/7/6/761507d5-d36a-4123-a074-95d7f6ffb4c5.jpg?1557575991">WAR</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/6/e/6ec42fab-86b8-4479-90f2-a1690318d6d4.jpg?1592710143">C18</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/e/1/e1980809-4c81-4080-92cd-31776962a4e1.jpg?1562640093">KLD</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/6/0/60842b1a-6ae7-4b3b-a23f-0d94a3d89884.jpg?1562639827">KLD</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/7/d79e2bf1-d26d-4be3-a5ad-a43346ed445a.jpg?1562640071">KLD</set>
+            <set picURL="https://api.scryfall.com/cards/ae8e32b9-431c-43d9-a0df-d73f4ff4fbc2?format=image">2XM</set>
+            <set picURL="https://api.scryfall.com/cards/761507d5-d36a-4123-a074-95d7f6ffb4c5?format=image">WAR</set>
+            <set picURL="https://api.scryfall.com/cards/6ec42fab-86b8-4479-90f2-a1690318d6d4?format=image">C18</set>
+            <set picURL="https://api.scryfall.com/cards/e1980809-4c81-4080-92cd-31776962a4e1?format=image">KLD</set>
+            <set picURL="https://api.scryfall.com/cards/60842b1a-6ae7-4b3b-a23f-0d94a3d89884?format=image">KLD</set>
+            <set picURL="https://api.scryfall.com/cards/d79e2bf1-d26d-4be3-a5ad-a43346ed445a?format=image">KLD</set>
             <reverse-related>Accomplished Automaton</reverse-related>
             <reverse-related>Aether Chaser</reverse-related>
             <reverse-related>Aether Herder</reverse-related>
@@ -7734,11 +7734,11 @@ Equip {1}</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/6/c6bde9bf-fffc-4b86-9698-d5620b21d6b8.jpg?1654172807">CLB</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/7/9/798cef87-237b-4e4a-b7ed-78d15c720391.jpg?1598311416">2XM</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/0/d01a5225-4a61-4fa3-b38b-452606140781.jpg?1592709979">C18</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/7/57753582-85bc-4485-b924-eaab563678d6.jpg?1562857266">C15</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/a/1a7d89ca-8611-4bda-b5c8-0350ce091102.jpg">LRW</set>
+            <set picURL="https://api.scryfall.com/cards/c6bde9bf-fffc-4b86-9698-d5620b21d6b8?format=image">CLB</set>
+            <set picURL="https://api.scryfall.com/cards/798cef87-237b-4e4a-b7ed-78d15c720391?format=image">2XM</set>
+            <set picURL="https://api.scryfall.com/cards/d01a5225-4a61-4fa3-b38b-452606140781?format=image">C18</set>
+            <set picURL="https://api.scryfall.com/cards/57753582-85bc-4485-b924-eaab563678d6?format=image">C15</set>
+            <set picURL="https://api.scryfall.com/cards/1a7d89ca-8611-4bda-b5c8-0350ce091102?format=image">LRW</set>
             <reverse-related>Crib Swap</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -7752,8 +7752,8 @@ Equip {1}</text>
                 <maintype>Creature</maintype>
                 <pt>2/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/d/cd65e932-8ed6-424b-958f-d8edad2aa2f4.jpg?1654172718">CLB</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/3/a33fda72-e61d-478f-bc33-ff1a23b5f45b.jpg?1563072987">MH1</set>
+            <set picURL="https://api.scryfall.com/cards/cd65e932-8ed6-424b-958f-d8edad2aa2f4?format=image">CLB</set>
+            <set picURL="https://api.scryfall.com/cards/a33fda72-e61d-478f-bc33-ff1a23b5f45b?format=image">MH1</set>
             <reverse-related>Birthing Boughs</reverse-related>
             <reverse-related>Irregular Cohort</reverse-related>
             <token>1</token>
@@ -7769,8 +7769,8 @@ Equip {1}</text>
                 <cmc>0</cmc>
                 <pt>2/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/e/ce94fb42-cde4-4637-b938-13f17793bf1f.jpg?1654172786">CLB</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/e/f/ef775ad0-b1a9-4254-ab6f-304558bb77a1.jpg?1615686300">KHM</set>
+            <set picURL="https://api.scryfall.com/cards/ce94fb42-cde4-4637-b938-13f17793bf1f?format=image">CLB</set>
+            <set picURL="https://api.scryfall.com/cards/ef775ad0-b1a9-4254-ab6f-304558bb77a1?format=image">KHM</set>
             <reverse-related>Maskwood Nexus</reverse-related>
             <reverse-related>The Bears of Littjara</reverse-related>
             <token>1</token>
@@ -7785,7 +7785,7 @@ Equip {1}</text>
                 <cmc>0</cmc>
                 <pt>3/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/1/1186b536-e6c8-433d-a906-b29f334d619c.jpg?1654172769">CLB</set>
+            <set picURL="https://api.scryfall.com/cards/1186b536-e6c8-433d-a906-b29f334d619c?format=image">CLB</set>
             <reverse-related exclude="exclude">Black Market Connections</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -7798,7 +7798,7 @@ Equip {1}</text>
                 <maintype>Enchantment</maintype>
                 <cmc>0</cmc>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/f/df826c7d-5508-4e21-848c-91bc3e3f447a.jpg?1615686110">KHM</set>
+            <set picURL="https://api.scryfall.com/cards/df826c7d-5508-4e21-848c-91bc3e3f447a?format=image">KHM</set>
             <reverse-related count="x">Niko Aris</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -7813,7 +7813,7 @@ Equip {1}</text>
                 <cmc>0</cmc>
                 <pt>*/*</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/3/0/30d12226-6417-4b98-beb5-89a36c774141.jpg?1591225585">IKO</set>
+            <set picURL="https://api.scryfall.com/cards/30d12226-6417-4b98-beb5-89a36c774141?format=image">IKO</set>
             <reverse-related>Shark Typhoon</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -7827,7 +7827,7 @@ Equip {1}</text>
                 <cmc>0</cmc>
                 <pt>0/1</pt>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/3/a/3acb4442-e7e5-482b-9ce8-f1af8069114e.jpg?1674397416">DMR</set>
+            <set picURL="https://api.scryfall.com/cards/3acb4442-e7e5-482b-9ce8-f1af8069114e?format=image">DMR</set>
             <set picURL="https://cdn.staticneo.com/w/mtg/5/57/Sheep1.jpg">TSB</set>
             <reverse-related>Ovinomancer</reverse-related>
             <token>1</token>
@@ -7841,7 +7841,7 @@ Equip {1}</text>
                 <maintype>Creature</maintype>
                 <pt>2/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/2/8/281d2c14-2343-44c9-a589-7f4da37978a2.jpg?1561756815">UGL</set>
+            <set picURL="https://api.scryfall.com/cards/281d2c14-2343-44c9-a589-7f4da37978a2?format=image">UGL</set>
             <reverse-related count="x">Flock of Rabid Sheep</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -7854,7 +7854,7 @@ Equip {1}</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/9/0/900340a5-7517-4ec4-a51e-762e15a29470.jpg?1643937786">NEC</set>
+            <set picURL="https://api.scryfall.com/cards/900340a5-7517-4ec4-a51e-762e15a29470?format=image">NEC</set>
             <reverse-related>Go-Shintai of Life's Origin</reverse-related>
             <reverse-related count="x" exclude="exclude">Go-Shintai of Life's Origin</reverse-related>
             <token>1</token>
@@ -7870,7 +7870,7 @@ Equip {1}</text>
                 <cmc>0</cmc>
                 <pt>1/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/8/58784a4f-8190-4751-b42c-fff188ad3ce5.jpg?1663566505">40K</set>
+            <set picURL="https://api.scryfall.com/cards/58784a4f-8190-4751-b42c-fff188ad3ce5?format=image">40K</set>
             <reverse-related count="x">Sicarian Infiltrator</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -7885,7 +7885,7 @@ Equip {1}</text>
                 <cmc>0</cmc>
                 <pt>4/4</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/1/513f2ce9-0127-4479-b37a-a835fbada8f8.jpg">HOU</set>
+            <set picURL="https://api.scryfall.com/cards/513f2ce9-0127-4479-b37a-a835fbada8f8?format=image">HOU</set>
             <reverse-related>Sinuous Striker</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -7900,8 +7900,8 @@ Equip {1}</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/a/1abb1ab0-f8f4-44e8-b8a7-df37a8782e76.jpg?1562701922">A25</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/6/8/6894192e-782b-49ef-b9fc-28b76e2268ab.jpg">ALA</set>
+            <set picURL="https://api.scryfall.com/cards/1abb1ab0-f8f4-44e8-b8a7-df37a8782e76?format=image">A25</set>
+            <set picURL="https://api.scryfall.com/cards/6894192e-782b-49ef-b9fc-28b76e2268ab?format=image">ALA</set>
             <reverse-related>Drudge Spell</reverse-related>
             <reverse-related>Skeletonize</reverse-related>
             <token>1</token>
@@ -7916,7 +7916,7 @@ Equip {1}</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/f/a/fa6fdb57-82f3-4695-b1fa-1f301ea4ef83.jpg?1626139846">AFR</set>
+            <set picURL="https://api.scryfall.com/cards/fa6fdb57-82f3-4695-b1fa-1f301ea4ef83?format=image">AFR</set>
             <reverse-related>Death-Priest of Myrkul</reverse-related>
             <reverse-related>Skeletal Swarming</reverse-related>
             <reverse-related count="2" exclude="exclude">Skeletal Swarming</reverse-related>
@@ -7933,7 +7933,7 @@ Equip {1}</text>
                 <cmc>0</cmc>
                 <pt>4/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/f/cf4c245f-af2f-46a7-81f3-670a04940901.jpg?1654171461">CLB</set>
+            <set picURL="https://api.scryfall.com/cards/cf4c245f-af2f-46a7-81f3-670a04940901?format=image">CLB</set>
             <reverse-related>Altar of Bhaal // Bone Offering</reverse-related>
             <reverse-related>Gut, True Soul Zealot</reverse-related>
             <token>1</token>
@@ -7961,10 +7961,10 @@ Equip {1}</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/e/dec96e95-5580-4110-86ec-561007ab0f1e.jpg?1562640084">M15</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/6/8/68353af0-9cd0-43c0-9b39-8f904c618e3a.jpg">M14</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/0/50c4f43e-ed03-43de-8ff1-2d4431c1684a.jpg">L13</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/f/3/f3b8ae33-f0c3-4fe7-8121-41307d13bb4a.jpg">P03</set>
+            <set picURL="https://api.scryfall.com/cards/dec96e95-5580-4110-86ec-561007ab0f1e?format=image">M15</set>
+            <set picURL="https://api.scryfall.com/cards/68353af0-9cd0-43c0-9b39-8f904c618e3a?format=image">M14</set>
+            <set picURL="https://api.scryfall.com/cards/50c4f43e-ed03-43de-8ff1-2d4431c1684a?format=image">L13</set>
+            <set picURL="https://api.scryfall.com/cards/f3b8ae33-f0c3-4fe7-8121-41307d13bb4a?format=image">P03</set>
             <reverse-related>Brood Sliver</reverse-related>
             <reverse-related count="2">Hive Stirrings</reverse-related>
             <reverse-related>Sliver Hive</reverse-related>
@@ -7981,7 +7981,7 @@ Equip {1}</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/6/e/6e2ae34f-4558-46e0-95c5-e00d813fa355.jpg?1636629936">VOW</set>
+            <set picURL="https://api.scryfall.com/cards/6e2ae34f-4558-46e0-95c5-e00d813fa355?format=image">VOW</set>
             <reverse-related>Toxrill, the Corrosive</reverse-related>
             <reverse-related count="x" exclude="exclude">Toxrill, the Corrosive</reverse-related>
             <token>1</token>
@@ -7996,7 +7996,7 @@ Equip {1}</text>
                 <maintype>Creature</maintype>
                 <cmc>0</cmc>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/e/5eb01bef-8989-4b38-a303-0aafab1b33e5.jpg?1644543390">NEC</set>
+            <set picURL="https://api.scryfall.com/cards/5eb01bef-8989-4b38-a303-0aafab1b33e5?format=image">NEC</set>
             <related>Treasure Token</related>
             <reverse-related count="x">Smoke Spirits' Aid</reverse-related>
             <token>1</token>
@@ -8011,13 +8011,13 @@ Equip {1}</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/e/5e7de554-9d1b-4ab0-abee-1a11d105db81.jpg?1662663504">DMC</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/e/0e0f26b2-eaeb-4ea3-8305-1d65d4402d1a.jpg?1591319233">C20</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/6/169dfab7-ff75-47df-8a20-7b4a729feafe.jpg?1572370781">C19</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/f/2/f29ed172-10e9-430d-977f-7f48da2b65de.jpg?1562857291">C15</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/2/a/2a452235-cebd-4e8f-b217-9b55fc1c3830.jpg">MM2</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/3/032e9f9d-b1e5-4724-9b80-e51500d12d5b.jpg">KTK</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/8/3/83a6a142-f065-4a74-9a73-8105be29bc94.jpg">ZEN</set>
+            <set picURL="https://api.scryfall.com/cards/5e7de554-9d1b-4ab0-abee-1a11d105db81?format=image">DMC</set>
+            <set picURL="https://api.scryfall.com/cards/0e0f26b2-eaeb-4ea3-8305-1d65d4402d1a?format=image">C20</set>
+            <set picURL="https://api.scryfall.com/cards/169dfab7-ff75-47df-8a20-7b4a729feafe?format=image">C19</set>
+            <set picURL="https://api.scryfall.com/cards/f29ed172-10e9-430d-977f-7f48da2b65de?format=image">C15</set>
+            <set picURL="https://api.scryfall.com/cards/2a452235-cebd-4e8f-b217-9b55fc1c3830?format=image">MM2</set>
+            <set picURL="https://api.scryfall.com/cards/032e9f9d-b1e5-4724-9b80-e51500d12d5b?format=image">KTK</set>
+            <set picURL="https://api.scryfall.com/cards/83a6a142-f065-4a74-9a73-8105be29bc94?format=image">ZEN</set>
             <reverse-related>Bestial Menace</reverse-related>
             <reverse-related count="4">Cobra Trap</reverse-related>
             <reverse-related count="x">Endless Swarm</reverse-related>
@@ -8057,7 +8057,7 @@ Equip {1}</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/5/153f01ac-8601-488f-8da7-72f392c0a3c6.jpg?1562857260">C15</set>
+            <set picURL="https://api.scryfall.com/cards/153f01ac-8601-488f-8da7-72f392c0a3c6?format=image">C15</set>
             <reverse-related count="2">Patagia Viper</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -8072,7 +8072,7 @@ Equip {1}</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/9/5910a7f2-71a7-4e85-8feb-4a0da228eb15.jpg">JOU</set>
+            <set picURL="https://api.scryfall.com/cards/5910a7f2-71a7-4e85-8feb-4a0da228eb15?format=image">JOU</set>
             <reverse-related>Pharika, God of Affliction</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -8087,7 +8087,7 @@ Equip {1}</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/3/13e4832d-8530-4b85-b738-51d0c18f28ec.jpg?1630007268">CC2</set>
+            <set picURL="https://api.scryfall.com/cards/13e4832d-8530-4b85-b738-51d0c18f28ec?format=image">CC2</set>
             <reverse-related>Ophiomancer</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -8102,7 +8102,7 @@ Equip {1}</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/6/a/6aaa8539-8d21-4da1-8410-d4354078390f.jpg?1562844799">AKH</set>
+            <set picURL="https://api.scryfall.com/cards/6aaa8539-8d21-4da1-8410-d4354078390f?format=image">AKH</set>
             <reverse-related>Hapatra, Vizier of Poisons</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -8116,7 +8116,7 @@ Equip {1}</text>
                 <cmc>0</cmc>
                 <pt>5/4</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/7/57708b3d-ddfb-4924-b5c9-123aa9e967ad.jpg">HOU</set>
+            <set picURL="https://api.scryfall.com/cards/57708b3d-ddfb-4924-b5c9-123aa9e967ad?format=image">HOU</set>
             <reverse-related>Rhonas's Last Stand</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -8130,7 +8130,7 @@ Equip {1}</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/5/05abf2df-833f-4172-af74-6533b022dfa9.jpg">WWK</set>
+            <set picURL="https://api.scryfall.com/cards/05abf2df-833f-4172-af74-6533b022dfa9?format=image">WWK</set>
             <reverse-related count="2">Join the Ranks</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -8144,44 +8144,44 @@ Equip {1}</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/4/6/461532a6-ef9c-4a9b-9815-3b5158ada976.jpg?1675905862">ONC</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/c/5c9295e9-222f-4e7d-91c3-84479d5ec568.jpg?1663530197">40K</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/8/c/8c4b0257-2ca5-4015-9d63-d7cf6e87ab9d.jpg?1661539690">DMU</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/b/5/b5000cf8-2104-4d85-95df-29efa92256f6.jpg?1654171358">CLB</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/6/d6090f44-034f-4069-a328-5c81ab774cea.jpg?1641306022">TSR</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/2/3/23b4c4d7-5b53-417a-a61b-df56eec4a274.jpg?1620573766">CMR</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/a/1aa14443-d02e-41db-942a-498857e6b83c.jpg?1598311535">2XM</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/b/1bdb2914-bba2-4cb6-802e-af2aeef46de8.jpg?1594733526">M21</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/d/1dee8c94-cdc8-42b2-a393-0c0c8e439125.jpg?1591319146">C20</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/4/a491d9da-a58d-4423-b565-c5a99ef63132.jpg?1592515941">M20</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/6/c61b83cf-791a-48bf-81c8-c6c940b89d83.jpg?1563073033">MH1</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/3/a3ef007f-d90f-4835-a5c0-35fb33c63719.jpg?1592710011">C18</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/7/07929ced-5c81-4b05-82e1-522fec1cf5c0.jpg">M19</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/f/9/f9b56129-17a2-4512-a4d6-34779224473f.jpg?1562702454">DOM</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/2/2/227a4e23-ff87-486b-aba1-32f1d8c33592.jpg?1562701943">A25</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/3/b/3b7ed2fe-4f78-4a09-8d2c-342dcf92eae4.jpg">E01</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/b/e/be2c0e6f-44a9-410f-a501-b95c1def9d88.jpg?1562841189">MM3</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/a/0a47f751-52f1-4042-85dd-ea222e5d969d.jpg?1562896993">C16</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/3/6/36d229e4-2a21-4d56-be82-5f812659f8e6.jpg?1561897121">CN2</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/9/c9c807dc-9c4f-4e87-9263-4dc9864e78ed.jpg?1562702326">EMA</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/e/3/e33426f5-59bf-456c-8fff-0ca27eacdef9.jpg">ORI</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/4/d480a351-cb9d-4bcc-b5c4-cd197ae98d43.jpg">MM2</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/9/a9ef7318-b46c-4463-9a30-3937f57d9c71.jpg">C14</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/f/a/faf83070-573c-4a06-9a2d-1263d7600b66.jpg?1562640146">M15</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/5/05e8f775-02bd-46dc-a618-07a9a127fa69.jpg">MD1</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/6/8/688c8e63-1462-4ad6-8872-216384160b58.jpg">THS</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/3/1/31f320f4-baae-46cb-840e-421f010a0a20.jpg">THS</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/3/c3317ef0-5104-41de-9e7a-2629ad658ae7.jpg">MMA</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/9/4/944a40e8-5469-4d8b-b044-67ff3382ec92.jpg">RTR</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/8/6/86272c08-c5f2-413f-87ea-b135aca2d9c5.jpg">M13</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/7/c/7c2a26d0-2687-41f6-99b9-6ed4e5e8a5e4.jpg">M12</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/7/a/7a563df7-7b9d-4692-ab1b-578be1887b62.jpg">SOM</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/8/c848b20e-a99c-445e-bf27-45a8e65a50d2.jpg">DDF</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/6/d/6dccd622-264e-4867-b34b-324c94861241.jpg">M10</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/9/2/927580e6-353a-46bb-ac05-52a5fa78a959.jpg">ALA</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/8/c8ae31d1-9a6e-43f3-9b04-bd15699f73d6.jpg">10E</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/b/5b953ca2-5be4-4c6a-a0fd-b53219ca6341.jpg">ONS</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/b/1/b159b57d-bc52-4cef-ac7a-e364e40c3d03.jpg?1561757834">UGL</set>
+            <set picURL="https://api.scryfall.com/cards/461532a6-ef9c-4a9b-9815-3b5158ada976?format=image">ONC</set>
+            <set picURL="https://api.scryfall.com/cards/5c9295e9-222f-4e7d-91c3-84479d5ec568?format=image">40K</set>
+            <set picURL="https://api.scryfall.com/cards/8c4b0257-2ca5-4015-9d63-d7cf6e87ab9d?format=image">DMU</set>
+            <set picURL="https://api.scryfall.com/cards/b5000cf8-2104-4d85-95df-29efa92256f6?format=image">CLB</set>
+            <set picURL="https://api.scryfall.com/cards/d6090f44-034f-4069-a328-5c81ab774cea?format=image">TSR</set>
+            <set picURL="https://api.scryfall.com/cards/23b4c4d7-5b53-417a-a61b-df56eec4a274?format=image">CMR</set>
+            <set picURL="https://api.scryfall.com/cards/1aa14443-d02e-41db-942a-498857e6b83c?format=image">2XM</set>
+            <set picURL="https://api.scryfall.com/cards/1bdb2914-bba2-4cb6-802e-af2aeef46de8?format=image">M21</set>
+            <set picURL="https://api.scryfall.com/cards/1dee8c94-cdc8-42b2-a393-0c0c8e439125?format=image">C20</set>
+            <set picURL="https://api.scryfall.com/cards/a491d9da-a58d-4423-b565-c5a99ef63132?format=image">M20</set>
+            <set picURL="https://api.scryfall.com/cards/c61b83cf-791a-48bf-81c8-c6c940b89d83?format=image">MH1</set>
+            <set picURL="https://api.scryfall.com/cards/a3ef007f-d90f-4835-a5c0-35fb33c63719?format=image">C18</set>
+            <set picURL="https://api.scryfall.com/cards/07929ced-5c81-4b05-82e1-522fec1cf5c0?format=image">M19</set>
+            <set picURL="https://api.scryfall.com/cards/f9b56129-17a2-4512-a4d6-34779224473f?format=image">DOM</set>
+            <set picURL="https://api.scryfall.com/cards/227a4e23-ff87-486b-aba1-32f1d8c33592?format=image">A25</set>
+            <set picURL="https://api.scryfall.com/cards/3b7ed2fe-4f78-4a09-8d2c-342dcf92eae4?format=image">E01</set>
+            <set picURL="https://api.scryfall.com/cards/be2c0e6f-44a9-410f-a501-b95c1def9d88?format=image">MM3</set>
+            <set picURL="https://api.scryfall.com/cards/0a47f751-52f1-4042-85dd-ea222e5d969d?format=image">C16</set>
+            <set picURL="https://api.scryfall.com/cards/36d229e4-2a21-4d56-be82-5f812659f8e6?format=image">CN2</set>
+            <set picURL="https://api.scryfall.com/cards/c9c807dc-9c4f-4e87-9263-4dc9864e78ed?format=image">EMA</set>
+            <set picURL="https://api.scryfall.com/cards/e33426f5-59bf-456c-8fff-0ca27eacdef9?format=image">ORI</set>
+            <set picURL="https://api.scryfall.com/cards/d480a351-cb9d-4bcc-b5c4-cd197ae98d43?format=image">MM2</set>
+            <set picURL="https://api.scryfall.com/cards/a9ef7318-b46c-4463-9a30-3937f57d9c71?format=image">C14</set>
+            <set picURL="https://api.scryfall.com/cards/faf83070-573c-4a06-9a2d-1263d7600b66?format=image">M15</set>
+            <set picURL="https://api.scryfall.com/cards/05e8f775-02bd-46dc-a618-07a9a127fa69?format=image">MD1</set>
+            <set picURL="https://api.scryfall.com/cards/688c8e63-1462-4ad6-8872-216384160b58?format=image">THS</set>
+            <set picURL="https://api.scryfall.com/cards/31f320f4-baae-46cb-840e-421f010a0a20?format=image">THS</set>
+            <set picURL="https://api.scryfall.com/cards/c3317ef0-5104-41de-9e7a-2629ad658ae7?format=image">MMA</set>
+            <set picURL="https://api.scryfall.com/cards/944a40e8-5469-4d8b-b044-67ff3382ec92?format=image">RTR</set>
+            <set picURL="https://api.scryfall.com/cards/86272c08-c5f2-413f-87ea-b135aca2d9c5?format=image">M13</set>
+            <set picURL="https://api.scryfall.com/cards/7c2a26d0-2687-41f6-99b9-6ed4e5e8a5e4?format=image">M12</set>
+            <set picURL="https://api.scryfall.com/cards/7a563df7-7b9d-4692-ab1b-578be1887b62?format=image">SOM</set>
+            <set picURL="https://api.scryfall.com/cards/c848b20e-a99c-445e-bf27-45a8e65a50d2?format=image">DDF</set>
+            <set picURL="https://api.scryfall.com/cards/6dccd622-264e-4867-b34b-324c94861241?format=image">M10</set>
+            <set picURL="https://api.scryfall.com/cards/927580e6-353a-46bb-ac05-52a5fa78a959?format=image">ALA</set>
+            <set picURL="https://api.scryfall.com/cards/c8ae31d1-9a6e-43f3-9b04-bd15699f73d6?format=image">10E</set>
+            <set picURL="https://api.scryfall.com/cards/5b953ca2-5be4-4c6a-a0fd-b53219ca6341?format=image">ONS</set>
+            <set picURL="https://api.scryfall.com/cards/b159b57d-bc52-4cef-ac7a-e364e40c3d03?format=image">UGL</set>
             <reverse-related count="x">Abdel Adrian, Gorion's Ward</reverse-related>
             <reverse-related>Akroan Horse</reverse-related>
             <reverse-related count="x">Alliance of Arms</reverse-related>
@@ -8262,10 +8262,10 @@ Equip {1}</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/a/7/a772cfa9-39e3-4057-bccf-4d82f49982bd.jpg?1675905875">ONC</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/f/7/f78c0976-83c4-4694-a93f-13046902cdd9.jpg?1541007771">GK1</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/6/d/6d49a56f-2a5e-4d42-b75c-f3f3735829d3.jpg?1562841181">MM3</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/8/a8a5a5a5-a8ae-41ed-9af5-b99d80ce0b35.jpg">GTC</set>
+            <set picURL="https://api.scryfall.com/cards/a772cfa9-39e3-4057-bccf-4d82f49982bd?format=image">ONC</set>
+            <set picURL="https://api.scryfall.com/cards/f78c0976-83c4-4694-a93f-13046902cdd9?format=image">GK1</set>
+            <set picURL="https://api.scryfall.com/cards/6d49a56f-2a5e-4d42-b75c-f3f3735829d3?format=image">MM3</set>
+            <set picURL="https://api.scryfall.com/cards/a8a5a5a5-a8ae-41ed-9af5-b99d80ce0b35?format=image">GTC</set>
             <reverse-related count="x">Assemble the Legion</reverse-related>
             <reverse-related count="2">Blaze Commando</reverse-related>
             <reverse-related>Sunhome Guildmage</reverse-related>
@@ -8282,7 +8282,7 @@ Equip {1}</text>
                 <cmc>0</cmc>
                 <pt>1/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/3/d/3d5c2f87-f0c9-4188-9b20-1c2a1d3c4f45.jpg?1561897495">CN2</set>
+            <set picURL="https://api.scryfall.com/cards/3d5c2f87-f0c9-4188-9b20-1c2a1d3c4f45?format=image">CN2</set>
             <reverse-related>Hold the Perimeter</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -8297,8 +8297,8 @@ Equip {1}</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/back/6/4/64f4dc68-060b-4c63-8f43-00f53c52a251.jpg?1541007299">GK1</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/4/5/45907b16-af17-4237-ab38-9d7537fd30e8.jpg?1572892483">GRN</set>
+            <set picURL="https://api.scryfall.com/cards/64f4dc68-060b-4c63-8f43-00f53c52a251?format=image&amp;face=back">GK1</set>
+            <set picURL="https://api.scryfall.com/cards/45907b16-af17-4237-ab38-9d7537fd30e8?format=image">GRN</set>
             <reverse-related>Dawn of Hope</reverse-related>
             <reverse-related>Emmara, Soul of the Accord</reverse-related>
             <reverse-related>Haazda Marshal</reverse-related>
@@ -8319,8 +8319,8 @@ Equip {1}</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/3/039b8e44-b435-4e05-b94c-02c4dda11943.jpg?1547509318">UMA</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/0/509e44d4-72c1-4d68-b942-c3e8de6ed7a8.jpg">THS</set>
+            <set picURL="https://api.scryfall.com/cards/039b8e44-b435-4e05-b94c-02c4dda11943?format=image">UMA</set>
+            <set picURL="https://api.scryfall.com/cards/509e44d4-72c1-4d68-b942-c3e8de6ed7a8?format=image">THS</set>
             <reverse-related>Akroan Crusader</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -8334,7 +8334,7 @@ Equip {1}</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/6/6/66f90245-fa63-48b2-a20a-8a6f00dd5853.jpg">BNG</set>
+            <set picURL="https://api.scryfall.com/cards/66f90245-fa63-48b2-a20a-8a6f00dd5853?format=image">BNG</set>
             <reverse-related count="2">God-Favored General</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -8349,8 +8349,8 @@ Equip {1}</text>
                 <cmc>0</cmc>
                 <pt>2/2</pt>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/f/1/f1684175-6e03-4934-92e3-e2a32725f7f9.jpg?1675905863">ONC</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/a/ca11c711-93fe-45ca-b393-3851148defc4.jpg?1557575877">WAR</set>
+            <set picURL="https://api.scryfall.com/cards/f1684175-6e03-4934-92e3-e2a32725f7f9?format=image">ONC</set>
+            <set picURL="https://api.scryfall.com/cards/ca11c711-93fe-45ca-b393-3851148defc4?format=image">WAR</set>
             <reverse-related count="x">Finale of Glory</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -8363,7 +8363,7 @@ Equip {1}</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/3/7/37da5b54-ec55-46e3-9f0b-565cbbe1ac7a.jpg?1667887016">BRO</set>
+            <set picURL="https://api.scryfall.com/cards/37da5b54-ec55-46e3-9f0b-565cbbe1ac7a?format=image">BRO</set>
             <reverse-related>Conscripted Infantry</reverse-related>
             <reverse-related>Emergency Weld</reverse-related>
             <reverse-related count="4">Mass Production</reverse-related>
@@ -8389,7 +8389,7 @@ Equip {1}</text>
                 <cmc>0</cmc>
                 <pt>3/3</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/a/aa796e45-1d95-44f7-927d-0cdd2f67da78.jpg?1663569745">40K</set>
+            <set picURL="https://api.scryfall.com/cards/aa796e45-1d95-44f7-927d-0cdd2f67da78?format=image">40K</set>
             <reverse-related count="x">Space Marine Devastator</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -8405,7 +8405,7 @@ At the beginning of the end step, sacrifice Spark Elemental.</text>
                 <cmc>0</cmc>
                 <pt>3/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/b/1/b1270173-72fc-489a-beef-85e2d8096bd7.jpg?1552832795">UMA</set>
+            <set picURL="https://api.scryfall.com/cards/b1270173-72fc-489a-beef-85e2d8096bd7?format=image">UMA</set>
             <reverse-related>Sparkspitter</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -8432,7 +8432,7 @@ At the beginning of the end step, sacrifice Spark Elemental.</text>
                 <cmc>0</cmc>
                 <pt>3/3</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/b/c/bc938f2e-2d6e-4afd-9a88-34eeaf0b51e3.jpg?1663529982">40K</set>
+            <set picURL="https://api.scryfall.com/cards/bc938f2e-2d6e-4afd-9a88-34eeaf0b51e3?format=image">40K</set>
             <reverse-related>Magnus the Red</reverse-related>
             <reverse-related>The Lost and the Damned</reverse-related>
             <reverse-related count="x" exclude="exclude">The Lost and the Damned</reverse-related>
@@ -8449,7 +8449,7 @@ At the beginning of the end step, sacrifice Spark Elemental.</text>
                 <cmc>0</cmc>
                 <pt>4/4</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/b/7/b74f1983-e9ac-47f0-836d-843a53c054cc.jpg">JOU</set>
+            <set picURL="https://api.scryfall.com/cards/b74f1983-e9ac-47f0-836d-843a53c054cc?format=image">JOU</set>
             <reverse-related count="x">Hour of Need</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -8464,7 +8464,7 @@ At the beginning of the end step, sacrifice Spark Elemental.</text>
                 <cmc>0</cmc>
                 <pt>4/4</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/f/8/f82ba894-7b10-45ae-9322-60ef85a2869d.jpg?1572892536">RNA</set>
+            <set picURL="https://api.scryfall.com/cards/f82ba894-7b10-45ae-9322-60ef85a2869d?format=image">RNA</set>
             <reverse-related>Warrant // Warden</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -8479,15 +8479,15 @@ At the beginning of the end step, sacrifice Spark Elemental.</text>
                 <cmc>0</cmc>
                 <pt>1/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/d/1dab34a7-0d18-4a6c-ac40-3b9901ff841b.jpg?1654171975">CLB</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/4/1/41bee18a-46d6-4f60-9e19-5fc670a20a4d.jpg?1653273222">MID</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/6/56f28541-9711-42cd-9c83-993a81af96b6.jpg?1581902167">THB</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/1/01591603-d903-419d-9957-cf0ae7f79240.jpg?1563073166">MH1</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/5/c5ede910-a0cb-4cf1-82f4-69fce0076c4d.jpg?1547509357">UMA</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/e/ce90c48f-74fb-4e87-9e46-7f8c3d79cbb0.jpg?1562636904">EMN</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/e/8/e8efa0fc-e710-44f8-8128-485c2d43cc9e.jpg?1562857289">C15</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/7/1/71031ff1-17dc-46b7-a72b-3297137a83bb.jpg">ISD</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/7/d/7df0de51-8d05-475a-832e-de8a0f60849e.jpg">SHM</set>
+            <set picURL="https://api.scryfall.com/cards/1dab34a7-0d18-4a6c-ac40-3b9901ff841b?format=image">CLB</set>
+            <set picURL="https://api.scryfall.com/cards/41bee18a-46d6-4f60-9e19-5fc670a20a4d?format=image">MID</set>
+            <set picURL="https://api.scryfall.com/cards/56f28541-9711-42cd-9c83-993a81af96b6?format=image">THB</set>
+            <set picURL="https://api.scryfall.com/cards/01591603-d903-419d-9957-cf0ae7f79240?format=image">MH1</set>
+            <set picURL="https://api.scryfall.com/cards/c5ede910-a0cb-4cf1-82f4-69fce0076c4d?format=image">UMA</set>
+            <set picURL="https://api.scryfall.com/cards/ce90c48f-74fb-4e87-9e46-7f8c3d79cbb0?format=image">EMN</set>
+            <set picURL="https://api.scryfall.com/cards/e8efa0fc-e710-44f8-8128-485c2d43cc9e?format=image">C15</set>
+            <set picURL="https://api.scryfall.com/cards/71031ff1-17dc-46b7-a72b-3297137a83bb?format=image">ISD</set>
+            <set picURL="https://api.scryfall.com/cards/7df0de51-8d05-475a-832e-de8a0f60849e?format=image">SHM</set>
             <reverse-related count="x">Arachnogenesis</reverse-related>
             <reverse-related>Arasta of the Endless Web</reverse-related>
             <reverse-related>Brood Weaver</reverse-related>
@@ -8511,9 +8511,9 @@ At the beginning of the end step, sacrifice Spark Elemental.</text>
                 <cmc>0</cmc>
                 <pt>2/4</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/9/6/96e8f429-5a66-4bcd-8a1f-69f9b79c0f5b.jpg?1641306030">TSR</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/4/c/4cbd8800-affa-4e64-825f-2a3b4516ed0f.jpg?1562841175">MM3</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/2/d/2d833298-a270-4b89-987c-5b6432bbc311.jpg">MMA</set>
+            <set picURL="https://api.scryfall.com/cards/96e8f429-5a66-4bcd-8a1f-69f9b79c0f5b?format=image">TSR</set>
+            <set picURL="https://api.scryfall.com/cards/4cbd8800-affa-4e64-825f-2a3b4516ed0f?format=image">MM3</set>
+            <set picURL="https://api.scryfall.com/cards/2d833298-a270-4b89-987c-5b6432bbc311?format=image">MMA</set>
             <reverse-related>Penumbra Spider</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -8528,7 +8528,7 @@ At the beginning of the end step, sacrifice Spark Elemental.</text>
                 <cmc>0</cmc>
                 <pt>1/3</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/7/a/7a0275af-708d-4c43-b226-c88cb9a8054c.jpg">JOU</set>
+            <set picURL="https://api.scryfall.com/cards/7a0275af-708d-4c43-b226-c88cb9a8054c?format=image">JOU</set>
             <reverse-related>Renowned Weaver</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -8543,7 +8543,7 @@ At the beginning of the end step, sacrifice Spark Elemental.</text>
                 <cmc>0</cmc>
                 <pt>2/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/2/124e0b03-d9fb-44f1-9e3c-3462aabdd42e.jpg?1626139115">AFR</set>
+            <set picURL="https://api.scryfall.com/cards/124e0b03-d9fb-44f1-9e3c-3462aabdd42e?format=image">AFR</set>
             <reverse-related>Drider</reverse-related>
             <reverse-related count="2">Lolth, Spider Queen</reverse-related>
             <token>1</token>
@@ -8573,7 +8573,7 @@ At the beginning of the end step, sacrifice Spark Elemental.</text>
                 <cmc>0</cmc>
                 <pt>*/*</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/2/5212bae5-d768-45ab-aba8-94c4f9fabc79.jpg?1636629861">VOW</set>
+            <set picURL="https://api.scryfall.com/cards/5212bae5-d768-45ab-aba8-94c4f9fabc79?format=image">VOW</set>
             <reverse-related>Hallowed Haunting</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -8588,38 +8588,38 @@ At the beginning of the end step, sacrifice Spark Elemental.</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/a/1/a171254d-7616-42c4-bd78-b2787fb973aa.jpg?1675905865">ONC</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/6/b/6bee4081-5d74-4cc2-ba2f-887bc8799513.jpg?1636629868">MID</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/8/c865bc02-0562-408c-b18e-0e66da906fc6.jpg?1653273226">MID</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/9/5/95694c03-2b3b-455c-8361-0799c078bf04.jpg?1615686192">KHM</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/2/1/21e580cb-6092-48b7-ba3e-d64ec28860da.jpg?1608908446">CMR</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/9/8/9858cbdb-cf4a-4d72-b1c1-a151f6a3e794.jpg?1591319157">C20</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/1/d1ac09a7-239b-43af-ac7a-8c79618dc9e3.jpg?1572370476">C19</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/7/9/79b17be6-2ee7-4f3b-88df-f298bb058f46.jpg?1592515948">M20</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/e/1/e11d6572-0398-490d-8790-7d2b7e9fbca5.jpg?1552078541">GK2</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/3/1/31830977-e096-4736-bb30-1d70008d7488.jpg?1547509203">UMA</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/b/3/b3c9a097-219b-4aaf-831f-cc0cddbcfaae.jpg?1561757870">BBD</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/7/070b2ce3-33a7-42a5-b4c2-6b0ed2bf926a.jpg?1562701881">A25</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/back/4/1/41fc8b22-f6fe-4853-b80a-64ab70a41f1d.jpg?1571508521">UST</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/b/5b2c2f3d-9489-4e7b-85e3-db1f2ee0f601.jpg">E01</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/2/9/2933a376-399c-4071-b44b-95605edd8fdb.jpg?1562840737">MM3</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/4/b/4b3c4b73-9a95-4caa-9a91-b4777f85b6f8.jpg?1562910249">C16</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/f/8/f89b99b9-9720-4177-b664-aac310fc1bea.jpg?1561897511">CN2</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/f/4/f4b36a9a-7456-4c72-a7b2-478461d886a4.jpg?1562702446">EMA</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/3/a/3a53a7c6-6b32-4491-8c96-e564abea8880.jpg?1562086864">SOI</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/0/0000a54c-a511-4925-92dc-01b937f9afad.jpg">MM2</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/2/52e32ad7-d59e-4cd8-ab88-3c7c0c083357.jpg">FRF</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/6/6/66c51c7f-b2d2-4a8a-84c6-57382e06fe7b.jpg">C14</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/7/0/7071930c-689a-44b9-b52d-45027fd14446.jpg">KTK</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/4/1/41dbf439-793a-4fe6-9d4e-0333f482e364.jpg?1562639767">M15</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/9/595c4665-48e1-492e-9e62-a49ec443e161.jpg">CNS</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/2/e/2e16c19f-ef44-4ebc-aa1d-f95646ae312b.jpg">MD1</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/8/58be6a05-8021-4fca-8e9f-0ebb4769c635.jpg">DDK</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/9/59e79ba0-33c8-46c8-8694-8bf854345fe7.jpg">AVR</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/d/0dbede5b-8e61-4ed8-bccb-8b54f69cccee.jpg">ISD</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/4/b/4b9a934b-dbd2-4691-8c96-a2f25ca18db0.jpg">DDC</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/b/cba50f25-ad8c-4244-8dc1-f8656f4c8c0b.jpg">SHM</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/4/14ef4815-3dfe-47b3-ad81-1506925280d3.jpg">PLS</set>
+            <set picURL="https://api.scryfall.com/cards/a171254d-7616-42c4-bd78-b2787fb973aa?format=image">ONC</set>
+            <set picURL="https://api.scryfall.com/cards/6bee4081-5d74-4cc2-ba2f-887bc8799513?format=image">MID</set>
+            <set picURL="https://api.scryfall.com/cards/c865bc02-0562-408c-b18e-0e66da906fc6?format=image">MID</set>
+            <set picURL="https://api.scryfall.com/cards/95694c03-2b3b-455c-8361-0799c078bf04?format=image">KHM</set>
+            <set picURL="https://api.scryfall.com/cards/21e580cb-6092-48b7-ba3e-d64ec28860da?format=image">CMR</set>
+            <set picURL="https://api.scryfall.com/cards/9858cbdb-cf4a-4d72-b1c1-a151f6a3e794?format=image">C20</set>
+            <set picURL="https://api.scryfall.com/cards/d1ac09a7-239b-43af-ac7a-8c79618dc9e3?format=image">C19</set>
+            <set picURL="https://api.scryfall.com/cards/79b17be6-2ee7-4f3b-88df-f298bb058f46?format=image">M20</set>
+            <set picURL="https://api.scryfall.com/cards/e11d6572-0398-490d-8790-7d2b7e9fbca5?format=image">GK2</set>
+            <set picURL="https://api.scryfall.com/cards/31830977-e096-4736-bb30-1d70008d7488?format=image">UMA</set>
+            <set picURL="https://api.scryfall.com/cards/b3c9a097-219b-4aaf-831f-cc0cddbcfaae?format=image">BBD</set>
+            <set picURL="https://api.scryfall.com/cards/070b2ce3-33a7-42a5-b4c2-6b0ed2bf926a?format=image">A25</set>
+            <set picURL="https://api.scryfall.com/cards/41fc8b22-f6fe-4853-b80a-64ab70a41f1d?format=image&amp;face=back">UST</set>
+            <set picURL="https://api.scryfall.com/cards/5b2c2f3d-9489-4e7b-85e3-db1f2ee0f601?format=image">E01</set>
+            <set picURL="https://api.scryfall.com/cards/2933a376-399c-4071-b44b-95605edd8fdb?format=image">MM3</set>
+            <set picURL="https://api.scryfall.com/cards/4b3c4b73-9a95-4caa-9a91-b4777f85b6f8?format=image">C16</set>
+            <set picURL="https://api.scryfall.com/cards/f89b99b9-9720-4177-b664-aac310fc1bea?format=image">CN2</set>
+            <set picURL="https://api.scryfall.com/cards/f4b36a9a-7456-4c72-a7b2-478461d886a4?format=image">EMA</set>
+            <set picURL="https://api.scryfall.com/cards/3a53a7c6-6b32-4491-8c96-e564abea8880?format=image">SOI</set>
+            <set picURL="https://api.scryfall.com/cards/0000a54c-a511-4925-92dc-01b937f9afad?format=image">MM2</set>
+            <set picURL="https://api.scryfall.com/cards/52e32ad7-d59e-4cd8-ab88-3c7c0c083357?format=image">FRF</set>
+            <set picURL="https://api.scryfall.com/cards/66c51c7f-b2d2-4a8a-84c6-57382e06fe7b?format=image">C14</set>
+            <set picURL="https://api.scryfall.com/cards/7071930c-689a-44b9-b52d-45027fd14446?format=image">KTK</set>
+            <set picURL="https://api.scryfall.com/cards/41dbf439-793a-4fe6-9d4e-0333f482e364?format=image">M15</set>
+            <set picURL="https://api.scryfall.com/cards/595c4665-48e1-492e-9e62-a49ec443e161?format=image">CNS</set>
+            <set picURL="https://api.scryfall.com/cards/2e16c19f-ef44-4ebc-aa1d-f95646ae312b?format=image">MD1</set>
+            <set picURL="https://api.scryfall.com/cards/58be6a05-8021-4fca-8e9f-0ebb4769c635?format=image">DDK</set>
+            <set picURL="https://api.scryfall.com/cards/59e79ba0-33c8-46c8-8694-8bf854345fe7?format=image">AVR</set>
+            <set picURL="https://api.scryfall.com/cards/0dbede5b-8e61-4ed8-bccb-8b54f69cccee?format=image">ISD</set>
+            <set picURL="https://api.scryfall.com/cards/4b9a934b-dbd2-4691-8c96-a2f25ca18db0?format=image">DDC</set>
+            <set picURL="https://api.scryfall.com/cards/cba50f25-ad8c-4244-8dc1-f8656f4c8c0b?format=image">SHM</set>
+            <set picURL="https://api.scryfall.com/cards/14ef4815-3dfe-47b3-ad81-1506925280d3?format=image">PLS</set>
             <reverse-related>Abzan Ascendancy</reverse-related>
             <reverse-related>Afterlife</reverse-related>
             <reverse-related>Alharu, Solemn Ritualist</reverse-related>
@@ -8700,7 +8700,7 @@ At the beginning of the end step, sacrifice Spark Elemental.</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/4/4/44c14591-f807-40cf-9c00-4c94b85fff44.jpg">AVR</set>
+            <set picURL="https://api.scryfall.com/cards/44c14591-f807-40cf-9c00-4c94b85fff44?format=image">AVR</set>
             <reverse-related>Geist Snatch</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -8715,13 +8715,13 @@ At the beginning of the end step, sacrifice Spark Elemental.</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/8/d/8dc14fc0-5c53-4381-ae55-1fb22d0f4148.jpg?1641306109">C21</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/f/cf24e9fa-7d7f-4693-a9ed-b8e725d0ad5c.jpg?1563073193">MH1</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/4/5/45b3bdd7-b093-4bfd-8a9a-965e72bfefb3.jpg?1572892542">RNA</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/9/c9a306c6-57e9-4c99-b2a9-ee27a557d69b.jpg?1547509367">UMA</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/9/e/9e50a908-0adb-4149-b8cf-2cfb56eab2cb.jpg?1562857279">C15</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/9/1/91f3a4b0-0992-4245-b245-033ad1083a93.jpg">GTC</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/4/c48d8e99-a530-4eec-a938-254c98073975.jpg">EVE</set>
+            <set picURL="https://api.scryfall.com/cards/8dc14fc0-5c53-4381-ae55-1fb22d0f4148?format=image">C21</set>
+            <set picURL="https://api.scryfall.com/cards/cf24e9fa-7d7f-4693-a9ed-b8e725d0ad5c?format=image">MH1</set>
+            <set picURL="https://api.scryfall.com/cards/45b3bdd7-b093-4bfd-8a9a-965e72bfefb3?format=image">RNA</set>
+            <set picURL="https://api.scryfall.com/cards/c9a306c6-57e9-4c99-b2a9-ee27a557d69b?format=image">UMA</set>
+            <set picURL="https://api.scryfall.com/cards/9e50a908-0adb-4149-b8cf-2cfb56eab2cb?format=image">C15</set>
+            <set picURL="https://api.scryfall.com/cards/91f3a4b0-0992-4245-b245-033ad1083a93?format=image">GTC</set>
+            <set picURL="https://api.scryfall.com/cards/c48d8e99-a530-4eec-a938-254c98073975?format=image">EVE</set>
             <reverse-related>Beckon Apparition</reverse-related>
             <reverse-related count="2">Debtors' Transport</reverse-related>
             <reverse-related count="x">Ethereal Absolution</reverse-related>
@@ -8747,12 +8747,12 @@ At the beginning of the end step, sacrifice Spark Elemental.</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/a/ca20548f-6324-4858-adbe-87303ff1ca52.jpg?1644542803">NEO</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/8/3/83497714-97ae-4846-8096-f7f1524f0e09.jpg?1641599803">VOC</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/e/f/ef264a95-afe4-4b8c-9648-e8f95bfaed2a.jpg?1562702434">A25</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/0/5009729f-6365-42ca-979f-d854a10e463b.jpg?1562911219">C16</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/8/082c3bad-3fea-4c3f-8263-4b16139bb32a.jpg?1562701890">EMA</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/4/6/46b60d95-b9bc-40f8-b986-bfa8e3eb74f3.jpg">CHK</set>
+            <set picURL="https://api.scryfall.com/cards/ca20548f-6324-4858-adbe-87303ff1ca52?format=image">NEO</set>
+            <set picURL="https://api.scryfall.com/cards/83497714-97ae-4846-8096-f7f1524f0e09?format=image">VOC</set>
+            <set picURL="https://api.scryfall.com/cards/ef264a95-afe4-4b8c-9648-e8f95bfaed2a?format=image">A25</set>
+            <set picURL="https://api.scryfall.com/cards/5009729f-6365-42ca-979f-d854a10e463b?format=image">C16</set>
+            <set picURL="https://api.scryfall.com/cards/082c3bad-3fea-4c3f-8263-4b16139bb32a?format=image">EMA</set>
+            <set picURL="https://api.scryfall.com/cards/46b60d95-b9bc-40f8-b986-bfa8e3eb74f3?format=image">CHK</set>
             <reverse-related>Akki Ember-Keeper</reverse-related>
             <reverse-related count="x" exclude="exclude">Akki Ember-Keeper</reverse-related>
             <reverse-related>Architect of Restoration</reverse-related>
@@ -8800,7 +8800,7 @@ At the beginning of the end step, sacrifice Spark Elemental.</text>
                 <cmc>0</cmc>
                 <pt>3/3</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/e/6/e6e361f5-a662-495f-a8e5-e4a647833af5.jpg?1641599867">VOC</set>
+            <set picURL="https://api.scryfall.com/cards/e6e361f5-a662-495f-a8e5-e4a647833af5?format=image">VOC</set>
             <reverse-related>Oyobi, Who Split the Heavens</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -8815,7 +8815,7 @@ At the beginning of the end step, sacrifice Spark Elemental.</text>
                 <cmc>0</cmc>
                 <pt>*/*</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/3/03553980-53fa-4256-b478-c7e0e73e2b5b.jpg?1563132220">C15</set>
+            <set picURL="https://api.scryfall.com/cards/03553980-53fa-4256-b478-c7e0e73e2b5b?format=image">C15</set>
             <reverse-related>Daxos the Returned</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -8828,7 +8828,7 @@ At the beginning of the end step, sacrifice Spark Elemental.</text>
                 <cmc>0</cmc>
                 <pt>2/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/2/4/243d7514-35a9-446b-be0d-a5b6b4001291.jpg?1557575859">WAR</set>
+            <set picURL="https://api.scryfall.com/cards/243d7514-35a9-446b-be0d-a5b6b4001291?format=image">WAR</set>
             <reverse-related>Ugin, the Ineffable</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -8842,7 +8842,7 @@ At the beginning of the end step, sacrifice Spark Elemental.</text>
                 <cmc>0</cmc>
                 <pt>3/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/f/9/f98c0167-7434-4607-87c4-315fa8b6972e.jpg?1641306157">STX</set>
+            <set picURL="https://api.scryfall.com/cards/f98c0167-7434-4607-87c4-315fa8b6972e?format=image">STX</set>
             <reverse-related>Illuminate History</reverse-related>
             <reverse-related>Illustrious Historian</reverse-related>
             <reverse-related>Lorehold Command</reverse-related>
@@ -8865,7 +8865,7 @@ At the beginning of the end step, sacrifice Spark Elemental.</text>
                 <cmc>0</cmc>
                 <pt>4/4</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/b/6/b61e7f44-c112-4501-8850-0565fc857397.jpg?1636629873">VOW</set>
+            <set picURL="https://api.scryfall.com/cards/b61e7f44-c112-4501-8850-0565fc857397?format=image">VOW</set>
             <reverse-related>Dorothea's Retribution</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -8880,7 +8880,7 @@ At the beginning of the end step, sacrifice Spark Elemental.</text>
                 <cmc>0</cmc>
                 <pt>2/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/2/c20e427c-efa5-476c-aa33-e3149648d207.jpg?1644542690">NEO</set>
+            <set picURL="https://api.scryfall.com/cards/c20e427c-efa5-476c-aa33-e3149648d207?format=image">NEO</set>
             <reverse-related>Chishiro, the Shattered Blade</reverse-related>
             <reverse-related>Gift of Wrath</reverse-related>
             <token>1</token>
@@ -8895,7 +8895,7 @@ At the beginning of the end step, sacrifice Spark Elemental.</text>
                 <cmc>0</cmc>
                 <pt>4/5</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/f/0f48aaab-dd6e-4bcc-a8fb-d31dd4a098ba.jpg?1644542872">NEO</set>
+            <set picURL="https://api.scryfall.com/cards/0f48aaab-dd6e-4bcc-a8fb-d31dd4a098ba?format=image">NEO</set>
             <reverse-related count="2">Invoke the Ancients</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -8909,7 +8909,7 @@ At the beginning of the end step, sacrifice Spark Elemental.</text>
                 <cmc>0</cmc>
                 <pt>*/*</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/2/d237377d-b79b-4f27-a142-e2c1756e0d94.jpg?1644542987">NEO</set>
+            <set picURL="https://api.scryfall.com/cards/d237377d-b79b-4f27-a142-e2c1756e0d94?format=image">NEO</set>
             <reverse-related>Kura, the Boundless Sky</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -8924,7 +8924,7 @@ At the beginning of the end step, sacrifice Spark Elemental.</text>
                 <cmc>0</cmc>
                 <pt>2/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/a/0a7a7f7c-29e3-4b98-ad2f-2d585ec7610e.jpg?1650819739">SNC</set>
+            <set picURL="https://api.scryfall.com/cards/0a7a7f7c-29e3-4b98-ad2f-2d585ec7610e?format=image">SNC</set>
             <reverse-related>Obscura Ascendancy</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -8939,7 +8939,7 @@ Whenever you draw a card, put a +1/+1 counter on this creature.</text>
                 <maintype>Creature</maintype>
                 <cmc>0</cmc>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/3/4/349e3241-8f9d-4c52-9848-e01b575fd372.jpg?1667886797">BRO</set>
+            <set picURL="https://api.scryfall.com/cards/349e3241-8f9d-4c52-9848-e01b575fd372?format=image">BRO</set>
             <reverse-related>Teferi, Temporal Pilgrim</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -8953,7 +8953,7 @@ Whenever you draw a card, put a +1/+1 counter on this creature.</text>
                 <cmc>0</cmc>
                 <pt>*/*</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/f/e/febc7ce0-387f-413c-a387-2952b990ff3f.jpg">KTK</set>
+            <set picURL="https://api.scryfall.com/cards/febc7ce0-387f-413c-a387-2952b990ff3f?format=image">KTK</set>
             <reverse-related>Kin-Tree Invocation</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -8984,9 +8984,9 @@ Cumulative upkeep {G}</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/7/4/743688fa-ca30-4a4b-92ec-6708af8692db.jpg?1654172611">CLB</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/b/2/b247ed9c-f5d4-43a7-bf9b-3a42878de840.jpg?1562930891">C16</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/8/c/8c366546-6da9-4daa-b0c3-1401ace5568c.jpg?1562639916">M15</set>
+            <set picURL="https://api.scryfall.com/cards/743688fa-ca30-4a4b-92ec-6708af8692db?format=image">CLB</set>
+            <set picURL="https://api.scryfall.com/cards/b247ed9c-f5d4-43a7-bf9b-3a42878de840?format=image">C16</set>
+            <set picURL="https://api.scryfall.com/cards/8c366546-6da9-4daa-b0c3-1401ace5568c?format=image">M15</set>
             <reverse-related count="x">Chasm Skulker</reverse-related>
             <reverse-related>Coral Barrier</reverse-related>
             <token>1</token>
@@ -9001,17 +9001,17 @@ Cumulative upkeep {G}</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/2/7/27f8ccb9-32b2-4562-a60f-843e82795984.jpg?1674397420">DMR</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/b/0b4170e0-c899-481a-8076-cae9f3effc37.jpg?1664344137">UNF</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/3/8/380330b4-2d01-4042-97ac-41d9c60c982d.jpg?1654171629">CLB</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/9/7/977ddd05-1aae-46fc-95ce-866710d1c5c6.jpg?1641306196">MH2</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/a/aa846cf5-c618-4304-bb92-5df936ebca9b.jpg?1598312396">2XM</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/6/6/66c6d816-d9b2-4b11-b0e1-ab00be74cbda.jpg?1584741599">UND</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/7/b/7b997fe7-69f3-4ccd-b3a7-ef5e0cb7db46.jpg?1563073181">MH1</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/3/53500f0f-ef65-4534-a8db-80ce73030bc1.jpg?1562910261">UST</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/3/a/3af9733f-192f-4028-8ad6-aa1187dd15e7.jpg">CNS</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/f/af7c2def-d20d-4670-8950-7042e9380844.jpg">ODY</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/b/abf24a09-0a54-4e1d-a515-ed5ae99294be.jpg?1561757804">UGL</set>
+            <set picURL="https://api.scryfall.com/cards/27f8ccb9-32b2-4562-a60f-843e82795984?format=image">DMR</set>
+            <set picURL="https://api.scryfall.com/cards/0b4170e0-c899-481a-8076-cae9f3effc37?format=image">UNF</set>
+            <set picURL="https://api.scryfall.com/cards/380330b4-2d01-4042-97ac-41d9c60c982d?format=image">CLB</set>
+            <set picURL="https://api.scryfall.com/cards/977ddd05-1aae-46fc-95ce-866710d1c5c6?format=image">MH2</set>
+            <set picURL="https://api.scryfall.com/cards/aa846cf5-c618-4304-bb92-5df936ebca9b?format=image">2XM</set>
+            <set picURL="https://api.scryfall.com/cards/66c6d816-d9b2-4b11-b0e1-ab00be74cbda?format=image">UND</set>
+            <set picURL="https://api.scryfall.com/cards/7b997fe7-69f3-4ccd-b3a7-ef5e0cb7db46?format=image">MH1</set>
+            <set picURL="https://api.scryfall.com/cards/53500f0f-ef65-4534-a8db-80ce73030bc1?format=image">UST</set>
+            <set picURL="https://api.scryfall.com/cards/3af9733f-192f-4028-8ad6-aa1187dd15e7?format=image">CNS</set>
+            <set picURL="https://api.scryfall.com/cards/af7c2def-d20d-4670-8950-7042e9380844?format=image">ODY</set>
+            <set picURL="https://api.scryfall.com/cards/abf24a09-0a54-4e1d-a515-ed5ae99294be?format=image">UGL</set>
             <reverse-related>Acorn Catapult</reverse-related>
             <reverse-related count="2">Acorn Harvest</reverse-related>
             <reverse-related>Chatter of the Squirrel</reverse-related>
@@ -9053,8 +9053,8 @@ Cumulative upkeep {G}</text>
                 <cmc>0</cmc>
                 <pt>3/4</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/e/d/edc84f49-86e9-43a2-b98c-a59b1e0c72ed.jpg?1662835186">DMU</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/e/b/eba90d37-d7ac-4097-a04d-1f27e4c9e5de.jpg?1562702416">A25</set>
+            <set picURL="https://api.scryfall.com/cards/edc84f49-86e9-43a2-b98c-a59b1e0c72ed?format=image">DMU</set>
+            <set picURL="https://api.scryfall.com/cards/eba90d37-d7ac-4097-a04d-1f27e4c9e5de?format=image">A25</set>
             <reverse-related>Stangg</reverse-related>
             <reverse-related>Stangg, Echo Warrior</reverse-related>
             <token>1</token>
@@ -9084,7 +9084,7 @@ Cumulative upkeep {G}</text>
                 <cmc>0</cmc>
                 <pt>4/4</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/8/7/872694ba-0666-43c1-8884-47a2e92a127c.jpg">HOU</set>
+            <set picURL="https://api.scryfall.com/cards/872694ba-0666-43c1-8884-47a2e92a127c?format=image">HOU</set>
             <reverse-related>Steadfast Sentinel</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -9099,7 +9099,7 @@ Equip {0}</text>
                 <maintype>Artifact</maintype>
                 <cmc>0</cmc>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/9/59a00cac-53ae-46ad-8468-e6d1db40b266.jpg">C14</set>
+            <set picURL="https://api.scryfall.com/cards/59a00cac-53ae-46ad-8468-e6d1db40b266?format=image">C14</set>
             <reverse-related exclude="exclude">Nahiri, the Lithomancer</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -9113,8 +9113,8 @@ Equip {0}</text>
                 <maintype>Creature</maintype>
                 <pt>1/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/3/2/32c73960-1dd9-4f11-81b3-2ae4d3a5e283.jpg?1664344074">UNF</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/8/0/80165be4-c6c8-4b22-b259-c64eb4b7fc95.jpg?1562918744">UST</set>
+            <set picURL="https://api.scryfall.com/cards/32c73960-1dd9-4f11-81b3-2ae4d3a5e283?format=image">UNF</set>
+            <set picURL="https://api.scryfall.com/cards/80165be4-c6c8-4b22-b259-c64eb4b7fc95?format=image">UST</set>
             <reverse-related count="x">Attempted Murder</reverse-related>
             <reverse-related>Crow Storm</reverse-related>
             <token>1</token>
@@ -9130,7 +9130,7 @@ Equip {0}</text>
                 <cmc>0</cmc>
                 <pt>4/4</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/2/8/289a9593-151e-47d0-b0de-5eb9f061515a.jpg">HOU</set>
+            <set picURL="https://api.scryfall.com/cards/289a9593-151e-47d0-b0de-5eb9f061515a?format=image">HOU</set>
             <reverse-related>Sunscourge Champion</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -9144,7 +9144,7 @@ Equip {0}</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/f/4/f4478979-19b6-4524-bbbd-519594c38f5a.jpg?1592710055">C18</set>
+            <set picURL="https://api.scryfall.com/cards/f4478979-19b6-4524-bbbd-519594c38f5a?format=image">C18</set>
             <reverse-related count="x">Varchild's War-Riders</reverse-related>
             <reverse-related count="x=3">Varchild, Betrayer of Kjeldor</reverse-related>
             <token>1</token>
@@ -9159,7 +9159,7 @@ Equip {0}</text>
                 <cmc>0</cmc>
                 <pt>2/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/6/c/6c2e835c-0f39-4fd1-a839-125bee0c9dbc.jpg">AKH</set>
+            <set picURL="https://api.scryfall.com/cards/6c2e835c-0f39-4fd1-a839-125bee0c9dbc?format=image">AKH</set>
             <reverse-related>Tah-Crop Skirmisher</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -9173,7 +9173,7 @@ Equip {0}</text>
                 <maintype>Artifact</maintype>
                 <cmc>0</cmc>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/9/9/992cb1e0-e846-4710-b49e-a748e4ebffa5.jpg?1644543067">NEO</set>
+            <set picURL="https://api.scryfall.com/cards/992cb1e0-e846-4710-b49e-a748e4ebffa5?format=image">NEO</set>
             <reverse-related>Tamiyo, Compleated Sage</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -9187,7 +9187,7 @@ Equip {0}</text>
                 <cmc>0</cmc>
                 <pt>2/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/4/a/4aef57de-7b99-47f3-af44-3c0bc546bbac.jpg?1664344170">UNF</set>
+            <set picURL="https://api.scryfall.com/cards/4aef57de-7b99-47f3-af44-3c0bc546bbac?format=image">UNF</set>
             <reverse-related count="2">Dart Throw</reverse-related>
             <reverse-related exclude="exclude">Gift Shop</reverse-related>
             <reverse-related>Push Your Luck</reverse-related>
@@ -9204,7 +9204,7 @@ Equip {0}</text>
                 <cmc>0</cmc>
                 <pt>2/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/a/5a6201e6-7dcd-40b1-97aa-fd9c860cea97.jpg">AKH</set>
+            <set picURL="https://api.scryfall.com/cards/5a6201e6-7dcd-40b1-97aa-fd9c860cea97?format=image">AKH</set>
             <reverse-related>Temmet, Vizier of Naktamun</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -9218,7 +9218,7 @@ Equip {0}</text>
                 <maintype>Creature</maintype>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/7/b/7b9f04f7-587e-4774-8aaa-09e8520efacb.jpg?1581901996">THB</set>
+            <set picURL="https://api.scryfall.com/cards/7b9f04f7-587e-4774-8aaa-09e8520efacb?format=image">THB</set>
             <reverse-related>Nadir Kraken</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -9248,7 +9248,7 @@ This creature can't be enchanted.</text>
                 <cmc>0</cmc>
                 <pt>4/4</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/6/5/65f8e40f-fb5e-4ab8-add3-a8b87e7bcdd9.jpg?1626139916">AFR</set>
+            <set picURL="https://api.scryfall.com/cards/65f8e40f-fb5e-4ab8-add3-a8b87e7bcdd9?format=image">AFR</set>
             <!-- this token is created by another token only -->
             <token>1</token>
             <tablerow>2</tablerow>
@@ -9261,7 +9261,7 @@ This creature can't be enchanted.</text>
                 <cmc>0</cmc>
                 <pt>3/3</pt>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/5/4/54e0cbfa-a7f9-49a6-9bca-4a08f5b8da93.jpg?1675095839">ONE</set>
+            <set picURL="https://api.scryfall.com/cards/54e0cbfa-a7f9-49a6-9bca-4a08f5b8da93?format=image">ONE</set>
             <reverse-related>Venser, Corpse Puppet</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -9275,23 +9275,23 @@ This creature can't be enchanted.</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/4/e/4e076b7f-14f3-4ce2-83f9-a18ccb2b755f.jpg?1675905881">ONC</set>
-            <set picURL="https://cards.scryfall.io/large/front/4/5/4501d15d-d306-4372-9516-bd63cf788f45.jpg?1667887063">BRO</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/6/5/65dd4252-09d0-4666-8d80-10432265ae4a.jpg?1644543340">NEC</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/a/ca51da85-15ed-4f65-8ffa-8868ef779cd2.jpg?1641599947">VOC</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/e/1e542094-8d95-463c-ae6c-8f2cd56434b2.jpg?1641306208">MH2</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/f/2/f22c9a2e-e4da-4ca0-a035-abeccf719bcc.jpg?1641306124">C21</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/7/5/75602e25-a0ab-430e-b610-5e12c1cab3d8.jpg?1601138573">2XM</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/8/d/8dd768c3-f278-41f8-b329-8403391d6326.jpg?1572892549">RNA</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/8/d/8d502061-ca95-4067-a61f-bc5294c274dd.jpg?1592710157">C18</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/6/2/62cafc0a-cd02-4265-aa1f-b8a6cb7cc8db.jpg?1592710150">C18</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/0/d0044cd9-2136-423e-aa2a-829e8f007535.jpg">M19</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/9/c/9c9a3d08-040a-4fec-b86d-c41a074f925c.jpg?1562639947">KLD</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/f/d/fd03a2b9-bfd7-4e1d-b660-e9f945699b78.jpg?1562640153">KLD</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/7/d/7d39524b-a4af-44ed-8f04-50680628c28f.jpg?1562639880">KLD</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/b/f/bfa49655-6ce7-404b-ad12-33ec1cd7c0d3.jpg">ORI</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/7/5/75fa5fab-1076-443b-ba27-46d10770883d.jpg">ORI</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/8/f/8f4e230e-f604-4803-9cbd-fd08d2863db4.jpg">MBS</set>
+            <set picURL="https://api.scryfall.com/cards/4e076b7f-14f3-4ce2-83f9-a18ccb2b755f?format=image">ONC</set>
+            <set picURL="https://api.scryfall.com/cards/4501d15d-d306-4372-9516-bd63cf788f45?format=image">BRO</set>
+            <set picURL="https://api.scryfall.com/cards/65dd4252-09d0-4666-8d80-10432265ae4a?format=image">NEC</set>
+            <set picURL="https://api.scryfall.com/cards/ca51da85-15ed-4f65-8ffa-8868ef779cd2?format=image">VOC</set>
+            <set picURL="https://api.scryfall.com/cards/1e542094-8d95-463c-ae6c-8f2cd56434b2?format=image">MH2</set>
+            <set picURL="https://api.scryfall.com/cards/f22c9a2e-e4da-4ca0-a035-abeccf719bcc?format=image">C21</set>
+            <set picURL="https://api.scryfall.com/cards/75602e25-a0ab-430e-b610-5e12c1cab3d8?format=image">2XM</set>
+            <set picURL="https://api.scryfall.com/cards/8dd768c3-f278-41f8-b329-8403391d6326?format=image">RNA</set>
+            <set picURL="https://api.scryfall.com/cards/8d502061-ca95-4067-a61f-bc5294c274dd?format=image">C18</set>
+            <set picURL="https://api.scryfall.com/cards/62cafc0a-cd02-4265-aa1f-b8a6cb7cc8db?format=image">C18</set>
+            <set picURL="https://api.scryfall.com/cards/d0044cd9-2136-423e-aa2a-829e8f007535?format=image">M19</set>
+            <set picURL="https://api.scryfall.com/cards/9c9a3d08-040a-4fec-b86d-c41a074f925c?format=image">KLD</set>
+            <set picURL="https://api.scryfall.com/cards/fd03a2b9-bfd7-4e1d-b660-e9f945699b78?format=image">KLD</set>
+            <set picURL="https://api.scryfall.com/cards/7d39524b-a4af-44ed-8f04-50680628c28f?format=image">KLD</set>
+            <set picURL="https://api.scryfall.com/cards/bfa49655-6ce7-404b-ad12-33ec1cd7c0d3?format=image">ORI</set>
+            <set picURL="https://api.scryfall.com/cards/75fa5fab-1076-443b-ba27-46d10770883d?format=image">ORI</set>
+            <set picURL="https://api.scryfall.com/cards/8f4e230e-f604-4803-9cbd-fd08d2863db4?format=image">MBS</set>
             <reverse-related count="x">Access Denied</reverse-related>
             <reverse-related>Aspiring Aeronaut</reverse-related>
             <reverse-related>Aviation Pioneer</reverse-related>
@@ -9339,11 +9339,11 @@ This creature can't be enchanted.</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/e/e/eef8b4fc-238f-4c1f-ad98-a1769fd44eab.jpg?1598311587">2XM</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/3/a3506ee6-a168-49a4-9814-2858194be60e.jpg?1592710025">C18</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/back/2/d/2d844ee2-20a0-4071-bc2c-4a58ab1dc07f.jpg?1571508393">UST</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/6/c/6c9a9020-2bf0-4bdd-94a2-545304226a53.jpg?1562916799">C16</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/2/52510a8b-a5a2-421b-a8b4-5ab60c848628.jpg">ALA</set>
+            <set picURL="https://api.scryfall.com/cards/eef8b4fc-238f-4c1f-ad98-a1769fd44eab?format=image">2XM</set>
+            <set picURL="https://api.scryfall.com/cards/a3506ee6-a168-49a4-9814-2858194be60e?format=image">C18</set>
+            <set picURL="https://api.scryfall.com/cards/2d844ee2-20a0-4071-bc2c-4a58ab1dc07f?format=image&amp;face=back">UST</set>
+            <set picURL="https://api.scryfall.com/cards/6c9a9020-2bf0-4bdd-94a2-545304226a53?format=image">C16</set>
+            <set picURL="https://api.scryfall.com/cards/52510a8b-a5a2-421b-a8b4-5ab60c848628?format=image">ALA</set>
             <reverse-related count="2">Breya, Etherium Shaper</reverse-related>
             <reverse-related>Sharding Sphinx</reverse-related>
             <reverse-related>Thopter Foundry</reverse-related>
@@ -9359,8 +9359,8 @@ This creature can't be enchanted.</text>
                 <cmc>0</cmc>
                 <pt>0/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/b/9/b9f3042b-784c-4006-9bf1-60a323e60c5c.jpg?1608908490">CMR</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/2/7/2795320c-57fc-4140-b306-a92237390353.jpg">DDC</set>
+            <set picURL="https://api.scryfall.com/cards/b9f3042b-784c-4006-9bf1-60a323e60c5c?format=image">CMR</set>
+            <set picURL="https://api.scryfall.com/cards/2795320c-57fc-4140-b306-a92237390353?format=image">DDC</set>
             <reverse-related>Breeding Pit</reverse-related>
             <reverse-related count="x">Szat's Will</reverse-related>
             <reverse-related count="2">Tevesh Szat, Doom of Fools</reverse-related>
@@ -9376,7 +9376,7 @@ This creature can't be enchanted.</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/b/5b9f471a-1822-4981-95a9-8923d83ddcbf.jpg">MM2</set>
+            <set picURL="https://api.scryfall.com/cards/5b9f471a-1822-4981-95a9-8923d83ddcbf?format=image">MM2</set>
             <reverse-related count="x">Endrek Sahr, Master Breeder</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -9391,7 +9391,7 @@ This creature can't be enchanted.</text>
                 <cmc>0</cmc>
                 <pt>4/4</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/f/7/f7ab74f3-897a-4dd9-b460-f31a0f496bb4.jpg?1641306179">MH2</set>
+            <set picURL="https://api.scryfall.com/cards/f7ab74f3-897a-4dd9-b460-f31a0f496bb4?format=image">MH2</set>
             <reverse-related>Timeless Dragon</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -9406,7 +9406,7 @@ This creature can't be enchanted.</text>
                 <cmc>0</cmc>
                 <pt>4/4</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/e/0e466a1b-a120-420a-884f-99c6629dcbc7.jpg?1641306180">MH2</set>
+            <set picURL="https://api.scryfall.com/cards/0e466a1b-a120-420a-884f-99c6629dcbc7?format=image">MH2</set>
             <reverse-related>Timeless Witness</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -9434,32 +9434,32 @@ This creature can't be enchanted.</text>
                 <maintype>Artifact</maintype>
                 <cmc>0</cmc>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/f/a/fab1ec58-5299-4604-8feb-212a6c5e7ffd.jpg?1664344237">UNF</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/5/55c46e7d-a436-4e61-9fea-d725787b43a9.jpg?1662835192">DMU</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/7/7/770b988d-4f31-4746-8c23-4ed8d9a6b393.jpg?1654171665">CLB</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/b/1be23c27-d8b6-4f59-8ab8-9ce80e9e29dd.jpg?1650820123">SNC</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/b/8/b883958b-1d82-4c1a-9f19-ab20fc01d5f4.jpg?1650820135">SNC</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/8/2/825c7dce-a51b-4ce2-9359-a17c577f535d.jpg?1650820212">SNC</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/7/0/70a356a2-c851-41e5-a389-7019575d5ace.jpg?1650820175">SNC</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/9/3/93116d98-2dad-4b80-a3af-9e36e34da6d4.jpg?1650820194">SNC</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/6/9/6911181d-573b-41eb-96a4-799c96e008fc.jpg?1644542893">NEO</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/a/0a89fdcf-0672-4241-834f-5db2c861694d.jpg?1636630296">VOW</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/3/a3a684b7-27e0-4d9e-a064-9e03c6e50c89.jpg?1626139418">AFR</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/0/d0ab4943-3943-4b83-8da3-90a1fb0988b3.jpg?1641306212">MH2</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/a/1a2d027f-8996-4761-a776-47cd428f6779.jpg?1641306162">STX</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/4/a/4ae9f454-4f8c-4123-9886-674bc439dfe7.jpg?1615686815">KHM</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/2/8/284ec798-2725-4741-8748-578c259d0623.jpg?1608908639">CMR</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/7/9/791f5fa0-f972-455e-9802-ff299853607f.jpg?1601138787">2XM</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/4/3/4306be80-d7c9-4bcf-a3de-4bf159475546.jpg?1594733644">M21</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/2/8/2888d3ed-0719-4e1d-9de7-3da6fbde0c48.jpg?1591319265">C20</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/2/e/2e752ca8-5404-4898-8b75-a0848e3850f2.jpg">SLD</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/e/6/e6fa7d35-9a7a-40fc-9b97-b479fc157ab0.jpg?1568003548">C19</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/4/2/42e54aad-ec80-4914-9ba8-91bd53924778.jpg?1592516008">M20</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/5/0559f9f3-eff0-465d-93c1-e875a8afe87f.jpg?1572892555">RNA</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/6/56f06ec6-634d-454b-a46a-dfefe4600d27.jpg?1562539772">XLN</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/2/1/21e89101-f1cf-4bbd-a1d5-c5d48512e0dd.jpg?1562539760">XLN</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/7/2/720f3e68-84c0-462e-a0d1-90236ccc494a.jpg?1562539782">XLN</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/b/b/bbe8bced-9524-47f6-a600-bf4ddc072698.jpg?1562539795">XLN</set>
+            <set picURL="https://api.scryfall.com/cards/fab1ec58-5299-4604-8feb-212a6c5e7ffd?format=image">UNF</set>
+            <set picURL="https://api.scryfall.com/cards/55c46e7d-a436-4e61-9fea-d725787b43a9?format=image">DMU</set>
+            <set picURL="https://api.scryfall.com/cards/770b988d-4f31-4746-8c23-4ed8d9a6b393?format=image">CLB</set>
+            <set picURL="https://api.scryfall.com/cards/1be23c27-d8b6-4f59-8ab8-9ce80e9e29dd?format=image">SNC</set>
+            <set picURL="https://api.scryfall.com/cards/b883958b-1d82-4c1a-9f19-ab20fc01d5f4?format=image">SNC</set>
+            <set picURL="https://api.scryfall.com/cards/825c7dce-a51b-4ce2-9359-a17c577f535d?format=image">SNC</set>
+            <set picURL="https://api.scryfall.com/cards/70a356a2-c851-41e5-a389-7019575d5ace?format=image">SNC</set>
+            <set picURL="https://api.scryfall.com/cards/93116d98-2dad-4b80-a3af-9e36e34da6d4?format=image">SNC</set>
+            <set picURL="https://api.scryfall.com/cards/6911181d-573b-41eb-96a4-799c96e008fc?format=image">NEO</set>
+            <set picURL="https://api.scryfall.com/cards/0a89fdcf-0672-4241-834f-5db2c861694d?format=image">VOW</set>
+            <set picURL="https://api.scryfall.com/cards/a3a684b7-27e0-4d9e-a064-9e03c6e50c89?format=image">AFR</set>
+            <set picURL="https://api.scryfall.com/cards/d0ab4943-3943-4b83-8da3-90a1fb0988b3?format=image">MH2</set>
+            <set picURL="https://api.scryfall.com/cards/1a2d027f-8996-4761-a776-47cd428f6779?format=image">STX</set>
+            <set picURL="https://api.scryfall.com/cards/4ae9f454-4f8c-4123-9886-674bc439dfe7?format=image">KHM</set>
+            <set picURL="https://api.scryfall.com/cards/284ec798-2725-4741-8748-578c259d0623?format=image">CMR</set>
+            <set picURL="https://api.scryfall.com/cards/791f5fa0-f972-455e-9802-ff299853607f?format=image">2XM</set>
+            <set picURL="https://api.scryfall.com/cards/4306be80-d7c9-4bcf-a3de-4bf159475546?format=image">M21</set>
+            <set picURL="https://api.scryfall.com/cards/2888d3ed-0719-4e1d-9de7-3da6fbde0c48?format=image">C20</set>
+            <set picURL="https://api.scryfall.com/cards/2e752ca8-5404-4898-8b75-a0848e3850f2?format=image">SLD</set>
+            <set picURL="https://api.scryfall.com/cards/e6fa7d35-9a7a-40fc-9b97-b479fc157ab0?format=image">C19</set>
+            <set picURL="https://api.scryfall.com/cards/42e54aad-ec80-4914-9ba8-91bd53924778?format=image">M20</set>
+            <set picURL="https://api.scryfall.com/cards/0559f9f3-eff0-465d-93c1-e875a8afe87f?format=image">RNA</set>
+            <set picURL="https://api.scryfall.com/cards/56f06ec6-634d-454b-a46a-dfefe4600d27?format=image">XLN</set>
+            <set picURL="https://api.scryfall.com/cards/21e89101-f1cf-4bbd-a1d5-c5d48512e0dd?format=image">XLN</set>
+            <set picURL="https://api.scryfall.com/cards/720f3e68-84c0-462e-a0d1-90236ccc494a?format=image">XLN</set>
+            <set picURL="https://api.scryfall.com/cards/bbe8bced-9524-47f6-a600-bf4ddc072698?format=image">XLN</set>
             <reverse-related>Academy Manufactor</reverse-related>
             <reverse-related count="2">An Offer You Can't Refuse</reverse-related>
             <reverse-related count="x">Ancient Copper Dragon</reverse-related>
@@ -9656,8 +9656,8 @@ This creature can't be enchanted.</text>
                 <cmc>0</cmc>
                 <pt>2/5</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/7/d75c1ada-2a49-49e8-800d-f11d08263dde.jpg">MMA</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/5/55c82ec9-692e-48eb-9337-c350fe815a3e.jpg">MOR</set>
+            <set picURL="https://api.scryfall.com/cards/d75c1ada-2a49-49e8-800d-f11d08263dde?format=image">MMA</set>
+            <set picURL="https://api.scryfall.com/cards/55c82ec9-692e-48eb-9337-c350fe815a3e?format=image">MOR</set>
             <reverse-related>Reach of Branches</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -9671,7 +9671,7 @@ This creature can't be enchanted.</text>
                 <cmc>0</cmc>
                 <pt>*/*</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/2/a/2a3f0d52-34cd-4095-bfa0-bbf9562a8146.jpg">C14</set>
+            <set picURL="https://api.scryfall.com/cards/2a3f0d52-34cd-4095-bfa0-bbf9562a8146?format=image">C14</set>
             <reverse-related>Sylvan Offering</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -9687,7 +9687,7 @@ This creature's power and toughness are each equal to the number of lands you co
                 <cmc>0</cmc>
                 <pt>*/*</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/9/4/94e4345b-61b1-4026-a01c-c9f2036c5c8a.jpg?1641305874">MID</set>
+            <set picURL="https://api.scryfall.com/cards/94e4345b-61b1-4026-a01c-c9f2036c5c8a?format=image">MID</set>
             <reverse-related>Wrenn and Seven</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -9702,7 +9702,7 @@ This creature's power and toughness are each equal to the number of lands you co
                 <cmc>0</cmc>
                 <pt>*/*</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/2/5/2569593a-d2f2-414c-9e61-2c34e8a5832d.jpg?1562639718">M15</set>
+            <set picURL="https://api.scryfall.com/cards/2569593a-d2f2-414c-9e61-2c34e8a5832d?format=image">M15</set>
             <reverse-related>Kalonian Twingrove</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -9732,7 +9732,7 @@ Sacrifice this creature: This creature deals 1 damage to target creature or play
                 <cmc>0</cmc>
                 <pt>4/4</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/8/8/8869a8cc-d196-417f-bba5-5ed31bae6a18.jpg?1615686760">KHM</set>
+            <set picURL="https://api.scryfall.com/cards/8869a8cc-d196-417f-bba5-5ed31bae6a18?format=image">KHM</set>
             <reverse-related>Gnottvold Slumbermound</reverse-related>
             <reverse-related>Old-Growth Troll</reverse-related>
             <reverse-related count="x">Waking the Trolls</reverse-related>
@@ -9749,7 +9749,7 @@ Sacrifice this creature: This creature deals 1 damage to target creature or play
                 <cmc>0</cmc>
                 <pt>2/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/7/c770d91c-b7d1-44ef-922d-128cb3faef08.jpg">AKH</set>
+            <set picURL="https://api.scryfall.com/cards/c770d91c-b7d1-44ef-922d-128cb3faef08?format=image">AKH</set>
             <reverse-related>Trueheart Duelist</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -9762,9 +9762,9 @@ Sacrifice this creature: This creature deals 1 damage to target creature or play
                 <cmc>0</cmc>
                 <pt>5/5</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/7/c7e7822b-f155-4f3f-b835-ec64f3a71307.jpg?1601138813">2XM</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/2/2/2250038e-4b67-4c44-b446-e78c451e5fbd.jpg">C14</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/1/11f55fa2-bb6f-4609-85ec-72703638fbd9.jpg">ROE</set>
+            <set picURL="https://api.scryfall.com/cards/c7e7822b-f155-4f3f-b835-ec64f3a71307?format=image">2XM</set>
+            <set picURL="https://api.scryfall.com/cards/2250038e-4b67-4c44-b446-e78c451e5fbd?format=image">C14</set>
+            <set picURL="https://api.scryfall.com/cards/11f55fa2-bb6f-4609-85ec-72703638fbd9?format=image">ROE</set>
             <reverse-related>Tuktuk the Explorer</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -9792,7 +9792,7 @@ Sacrifice this creature: This creature deals 1 damage to target creature or play
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/2/0/20171707-0670-42dd-a6c4-f0aa56fc0cd1.jpg?1663289882">40K</set>
+            <set picURL="https://api.scryfall.com/cards/20171707-0670-42dd-a6c4-f0aa56fc0cd1?format=image">40K</set>
             <reverse-related>Gargoyle Flock</reverse-related>
             <reverse-related>Tyranid Harridan</reverse-related>
             <reverse-related count="x" exclude="exclude">Tyranid Harridan</reverse-related>
@@ -9808,7 +9808,7 @@ Sacrifice this creature: This creature deals 1 damage to target creature or play
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/2/1/21e0620b-0498-407f-a609-79c7bc393e76.jpg?1663289760">40K</set>
+            <set picURL="https://api.scryfall.com/cards/21e0620b-0498-407f-a609-79c7bc393e76?format=image">40K</set>
             <reverse-related count="x">Termagant Swarm</reverse-related>
             <reverse-related count="x">Tervigon</reverse-related>
             <token>1</token>
@@ -9823,7 +9823,7 @@ Sacrifice this creature: This creature deals 1 damage to target creature or play
                 <cmc>0</cmc>
                 <pt>5/5</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/2/1/21afb029-9aef-4e6e-a646-3343605b4bb7.jpg?1663289847">40K</set>
+            <set picURL="https://api.scryfall.com/cards/21afb029-9aef-4e6e-a646-3343605b4bb7?format=image">40K</set>
             <reverse-related>Old One Eye</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -9838,7 +9838,7 @@ Sacrifice this creature: This creature deals 1 damage to target creature or play
                 <cmc>0</cmc>
                 <pt>3/3</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/6/9/691979ab-e0d7-4e74-84da-77d09dc038a3.jpg?1663289810">40K</set>
+            <set picURL="https://api.scryfall.com/cards/691979ab-e0d7-4e74-84da-77d09dc038a3?format=image">40K</set>
             <reverse-related>Lictor</reverse-related>
             <reverse-related count="x">Tyranid Invasion</reverse-related>
             <token>1</token>
@@ -9854,7 +9854,7 @@ Sacrifice this creature: This creature deals 1 damage to target creature or play
                 <cmc>0</cmc>
                 <pt>2/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/f/7/f7d6c117-0924-404a-9b06-5c28b830d316.jpg?1663566276">40K</set>
+            <set picURL="https://api.scryfall.com/cards/f7d6c117-0924-404a-9b06-5c28b830d316?format=image">40K</set>
             <reverse-related count="x">Ultramarines Honour Guard</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -9883,7 +9883,7 @@ Sacrifice this creature: This creature deals 1 damage to target creature or play
                 <cmc>0</cmc>
                 <pt>3/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/7/07ab720d-40fc-4315-bc8d-c7073cea588b.jpg">AKH</set>
+            <set picURL="https://api.scryfall.com/cards/07ab720d-40fc-4315-bc8d-c7073cea588b?format=image">AKH</set>
             <reverse-related>Unwavering Initiate</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -9913,7 +9913,7 @@ Sacrifice this creature: This creature deals 1 damage to target creature or play
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/8/9/8989fdb4-723b-4c80-89b4-930ccac13b22.jpg?1562086874">SOI</set>
+            <set picURL="https://api.scryfall.com/cards/8989fdb4-723b-4c80-89b4-930ccac13b22?format=image">SOI</set>
             <reverse-related>Call the Bloodline</reverse-related>
             <reverse-related count="x">Sorin, Grim Nemesis</reverse-related>
             <token>1</token>
@@ -9929,9 +9929,9 @@ Sacrifice this creature: This creature deals 1 damage to target creature or play
                 <cmc>0</cmc>
                 <pt>2/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/back/5/d/5d9e999f-7033-4ccd-933a-eac4105b3edc.jpg?1571508406">UST</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/7/1/71496671-f7ba-4014-a895-d70a27979db7.jpg">KTK</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/f/5f68c2ab-5131-4620-920f-7ba99522ccf0.jpg">ISD</set>
+            <set picURL="https://api.scryfall.com/cards/5d9e999f-7033-4ccd-933a-eac4105b3edc?format=image&amp;face=back">UST</set>
+            <set picURL="https://api.scryfall.com/cards/71496671-f7ba-4014-a895-d70a27979db7?format=image">KTK</set>
+            <set picURL="https://api.scryfall.com/cards/5f68c2ab-5131-4620-920f-7ba99522ccf0?format=image">ISD</set>
             <reverse-related>Bloodline Keeper</reverse-related>
             <reverse-related>Lord of Lineage</reverse-related>
             <reverse-related>Sorin, Solemn Visitor</reverse-related>
@@ -9948,7 +9948,7 @@ Sacrifice this creature: This creature deals 1 damage to target creature or play
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/d/0d6abdaa-7be5-48a1-acc9-b3cba4c10619.jpg">DKA</set>
+            <set picURL="https://api.scryfall.com/cards/0d6abdaa-7be5-48a1-acc9-b3cba4c10619?format=image">DKA</set>
             <reverse-related>Sorin, Lord of Innistrad</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -9962,7 +9962,7 @@ Sacrifice this creature: This creature deals 1 damage to target creature or play
                 <cmc>0</cmc>
                 <pt>*/*</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/9/6/969eff58-d91e-49e2-a1e1-8f32b4598810.jpg">ZEN</set>
+            <set picURL="https://api.scryfall.com/cards/969eff58-d91e-49e2-a1e1-8f32b4598810?format=image">ZEN</set>
             <reverse-related>Kalitas, Bloodchief of Ghet</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -9976,7 +9976,7 @@ Sacrifice this creature: This creature deals 1 damage to target creature or play
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/d/5d328599-b5c8-4cf7-9d62-fe8492e02f48.jpg">C17</set>
+            <set picURL="https://api.scryfall.com/cards/5d328599-b5c8-4cf7-9d62-fe8492e02f48?format=image">C17</set>
             <reverse-related>Edgar Markov</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -9991,7 +9991,7 @@ Sacrifice this creature: This creature deals 1 damage to target creature or play
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/9/09293ae7-0629-417b-9eda-9bd3f6d8e118.jpg?1562539752">XLN</set>
+            <set picURL="https://api.scryfall.com/cards/09293ae7-0629-417b-9eda-9bd3f6d8e118?format=image">XLN</set>
             <reverse-related>Adanto, the First Fort</reverse-related>
             <reverse-related count="3">Call to the Feast</reverse-related>
             <reverse-related count="x">Elenda, the Dusk Rose</reverse-related>
@@ -10014,7 +10014,7 @@ Sacrifice this creature: This creature deals 1 damage to target creature or play
                 <cmc>0</cmc>
                 <pt>3/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/f/0f8fe08d-b469-4471-8a7d-cf75850ba312.jpg?1641305879">MID</set>
+            <set picURL="https://api.scryfall.com/cards/0f8fe08d-b469-4471-8a7d-cf75850ba312?format=image">MID</set>
             <reverse-related>Hungry for More</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -10029,7 +10029,7 @@ Sacrifice this creature: This creature deals 1 damage to target creature or play
                 <cmc>0</cmc>
                 <pt>2/3</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/e/b/ebd12ac1-d1b2-4e22-9a17-8f3964294e35.jpg?1636629974">VOW</set>
+            <set picURL="https://api.scryfall.com/cards/ebd12ac1-d1b2-4e22-9a17-8f3964294e35?format=image">VOW</set>
             <reverse-related>Sorin the Mirthless</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -10044,7 +10044,7 @@ Sacrifice this creature: This creature deals 1 damage to target creature or play
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/7/e/7eee78d3-c65f-4454-bd3c-1c55388422f5.jpg?1636630265">VOW</set>
+            <set picURL="https://api.scryfall.com/cards/7eee78d3-c65f-4454-bd3c-1c55388422f5?format=image">VOW</set>
             <reverse-related>Edgar Markov's Coffin</reverse-related>
             <reverse-related>Glass-Cast Heart</reverse-related>
             <token>1</token>
@@ -10061,7 +10061,7 @@ Whenever Vanguard Suppressor deals combat damage to a player, draw a card.</text
                 <cmc>0</cmc>
                 <pt>3/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/e/5/e5d319cb-4982-4fb9-93d4-1cc846b03c30.jpg?1657122441">40K</set>
+            <set picURL="https://api.scryfall.com/cards/e5d319cb-4982-4fb9-93d4-1cc846b03c30?format=image">40K</set>
             <reverse-related count="x">Vanguard Suppressor</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -10076,7 +10076,7 @@ Whenever Vanguard Suppressor deals combat damage to a player, draw a card.</text
                 <cmc>0</cmc>
                 <pt>8/8</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/8/6/86881c5f-df5e-4f50-b554-e4c49d5316f9.jpg?1625676073">AFR</set>
+            <set picURL="https://api.scryfall.com/cards/86881c5f-df5e-4f50-b554-e4c49d5316f9?format=image">AFR</set>
             <reverse-related>The Book of Vile Darkness</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -10091,7 +10091,7 @@ Whenever Vanguard Suppressor deals combat damage to a player, draw a card.</text
                 <cmc>0</cmc>
                 <pt>0/0</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/3/9/39520c16-1f4b-4f15-aeb4-53c91e8ecfcc.jpg">AKH</set>
+            <set picURL="https://api.scryfall.com/cards/39520c16-1f4b-4f15-aeb4-53c91e8ecfcc?format=image">AKH</set>
             <reverse-related>Vizier of Many Faces</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -10105,7 +10105,7 @@ Whenever Vanguard Suppressor deals combat damage to a player, draw a card.</text
                 <cmc>0</cmc>
                 <pt>2/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/2/8/2879010f-b752-4808-8531-d24e612de0d9.jpg?1541006575">GK1</set>
+            <set picURL="https://api.scryfall.com/cards/2879010f-b752-4808-8531-d24e612de0d9?format=image">GK1</set>
             <reverse-related>Tolsimir Wolfblood</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -10119,7 +10119,7 @@ Whenever Vanguard Suppressor deals combat damage to a player, draw a card.</text
                 <cmc>0</cmc>
                 <pt>3/3</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/3/9/39475e91-1e71-4546-ae4a-47ea66e47536.jpg?1557575985">WAR</set>
+            <set picURL="https://api.scryfall.com/cards/39475e91-1e71-4546-ae4a-47ea66e47536?format=image">WAR</set>
             <reverse-related>Tolsimir, Friend to Wolves</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -10133,7 +10133,7 @@ Whenever you cast a creature spell, note one of its creature types that hasn't b
                 <maintype>Artifact</maintype>
                 <cmc>0</cmc>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/7/f/7f0fe7c9-b0ab-4d48-94d0-99e7bee0c0de.jpg?1654171716">CLB</set>
+            <set picURL="https://api.scryfall.com/cards/7f0fe7c9-b0ab-4d48-94d0-99e7bee0c0de?format=image">CLB</set>
             <reverse-related>Volo, Itinerant Scholar</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -10147,11 +10147,11 @@ Whenever you cast a creature spell, note one of its creature types that hasn't b
                 <cmc>0</cmc>
                 <pt>2/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/4/d/4d03f760-6e5a-404e-beb9-07d78a53364d.jpg?1608349779">SLD</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/b/4/b4c637c4-c1cc-4852-9561-78add390ef52.jpg?1608349788">SLD</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/1/a121c039-ec93-4383-bdb5-bc7acf9e1a05.jpg?1608349797">SLD</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/7/a7940307-6ae3-423e-b752-a72acddb9087.jpg?1616400493">SLD</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/4/b/4b236f7a-62b0-4605-9328-6994ca65909b.jpg?1608349820">SLD</set>
+            <set picURL="https://api.scryfall.com/cards/4d03f760-6e5a-404e-beb9-07d78a53364d?format=image">SLD</set>
+            <set picURL="https://api.scryfall.com/cards/b4c637c4-c1cc-4852-9561-78add390ef52?format=image">SLD</set>
+            <set picURL="https://api.scryfall.com/cards/a121c039-ec93-4383-bdb5-bc7acf9e1a05?format=image">SLD</set>
+            <set picURL="https://api.scryfall.com/cards/a7940307-6ae3-423e-b752-a72acddb9087?format=image">SLD</set>
+            <set picURL="https://api.scryfall.com/cards/4b236f7a-62b0-4605-9328-6994ca65909b?format=image">SLD</set>
             <reverse-related count="3">Daryl, Hunter of Walkers</reverse-related>
             <reverse-related>Lucille</reverse-related>
             <reverse-related count="2">Michonne, Ruthless Survivor</reverse-related>
@@ -10182,7 +10182,7 @@ Whenever you cast a creature spell, note one of its creature types that hasn't b
                 <cmc>0</cmc>
                 <pt>5/5</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/7/f/7f31debf-0b93-44c7-99b6-be441ba4e167.jpg?1562702163">EMA</set>
+            <set picURL="https://api.scryfall.com/cards/7f31debf-0b93-44c7-99b6-be441ba4e167?format=image">EMA</set>
             <reverse-related>Tidal Wave</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -10197,7 +10197,7 @@ Whenever you cast a creature spell, note one of its creature types that hasn't b
                 <cmc>0</cmc>
                 <pt>0/3</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/e/8/e8ae8c31-70cb-44e1-a105-f4d29f1f9356.jpg?1557575887">WAR</set>
+            <set picURL="https://api.scryfall.com/cards/e8ae8c31-70cb-44e1-a105-f4d29f1f9356?format=image">WAR</set>
             <reverse-related>Teyo, the Shieldmage</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -10211,7 +10211,7 @@ Whenever you cast a creature spell, note one of its creature types that hasn't b
                 <maintype>Creature</maintype>
                 <pt>0/4</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/b/dbdd5d53-65e7-42c3-a325-791f11335e62.jpg?1581902169">THB</set>
+            <set picURL="https://api.scryfall.com/cards/dbdd5d53-65e7-42c3-a325-791f11335e62?format=image">THB</set>
             <reverse-related>The Birth of Meletis</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -10239,10 +10239,10 @@ Whenever you cast a creature spell, note one of its creature types that hasn't b
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/3/d36e3c0e-a759-4adc-aa2f-61b13c0f786d.jpg?1561758133">BBD</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/6/7/677a1d9d-86fd-49db-9573-8cd2cbc1a096.jpg">DTK</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/f/af4c9101-85bf-4a4f-a496-ff6db7b531b7.jpg">KTK</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/f/4/f46bcc76-181c-4e06-aa04-590a3e651dc7.jpg">KTK</set>
+            <set picURL="https://api.scryfall.com/cards/d36e3c0e-a759-4adc-aa2f-61b13c0f786d?format=image">BBD</set>
+            <set picURL="https://api.scryfall.com/cards/677a1d9d-86fd-49db-9573-8cd2cbc1a096?format=image">DTK</set>
+            <set picURL="https://api.scryfall.com/cards/af4c9101-85bf-4a4f-a496-ff6db7b531b7?format=image">KTK</set>
+            <set picURL="https://api.scryfall.com/cards/f46bcc76-181c-4e06-aa04-590a3e651dc7?format=image">KTK</set>
             <reverse-related>Blaring Recruiter</reverse-related>
             <reverse-related>Herald of Anafenza</reverse-related>
             <reverse-related count="2">Mardu Charm</reverse-related>
@@ -10263,8 +10263,8 @@ Whenever you cast a creature spell, note one of its creature types that hasn't b
                 <cmc>0</cmc>
                 <pt>2/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/8/8/883ac854-ee35-418a-9d4e-c30ba2a5ade8.jpg?1654172651">CLB</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/3/b/3b5eaba1-a7e1-4bbb-949c-e7f6a9592f50.jpg">FRF</set>
+            <set picURL="https://api.scryfall.com/cards/883ac854-ee35-418a-9d4e-c30ba2a5ade8?format=image">CLB</set>
+            <set picURL="https://api.scryfall.com/cards/3b5eaba1-a7e1-4bbb-949c-e7f6a9592f50?format=image">FRF</set>
             <reverse-related>Mardu Strike Leader</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -10279,8 +10279,8 @@ Whenever you cast a creature spell, note one of its creature types that hasn't b
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/d/1d7b1dfa-14a2-4e4e-baf2-e06672651db1.jpg?1662663372">DMC</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/2/d/2d1446ed-f114-421d-bb60-9aeb655e5adb.jpg">AKH</set>
+            <set picURL="https://api.scryfall.com/cards/1d7b1dfa-14a2-4e4e-baf2-e06672651db1?format=image">DMC</set>
+            <set picURL="https://api.scryfall.com/cards/2d1446ed-f114-421d-bb60-9aeb655e5adb?format=image">AKH</set>
             <reverse-related>Cartouche of Solidarity</reverse-related>
             <reverse-related>Oketra the True</reverse-related>
             <reverse-related>Oketra's Monument</reverse-related>
@@ -10299,7 +10299,7 @@ Whenever you cast a creature spell, note one of its creature types that hasn't b
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/7/c75b81b5-5c84-45d4-832a-20c038372bc6.jpg">10E</set>
+            <set picURL="https://api.scryfall.com/cards/c75b81b5-5c84-45d4-832a-20c038372bc6?format=image">10E</set>
             <reverse-related>The Hive</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -10314,7 +10314,7 @@ Whenever you cast a creature spell, note one of its creature types that hasn't b
                 <cmc>0</cmc>
                 <pt>3/3</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/d/1d34ff67-24e1-4cf5-b032-8be6b83e0819.jpg?1632381617">GK1</set>
+            <set picURL="https://api.scryfall.com/cards/1d34ff67-24e1-4cf5-b032-8be6b83e0819?format=image">GK1</set>
             <reverse-related>Thunderheads</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -10328,7 +10328,7 @@ Whenever you cast a creature spell, note one of its creature types that hasn't b
                 <cmc>0</cmc>
                 <pt>*/*</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/2/a/2a0d9c67-69ee-48c4-af4c-18cc3c2ef3cd.jpg?1594733637">M21</set>
+            <set picURL="https://api.scryfall.com/cards/2a0d9c67-69ee-48c4-af4c-18cc3c2ef3cd?format=image">M21</set>
             <reverse-related>Experimental Overload</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -10343,9 +10343,9 @@ Whenever you cast a creature spell, note one of its creature types that hasn't b
                 <cmc>0</cmc>
                 <pt>6/6</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/8/7/87a6f719-3e2f-48ea-829d-77134a2a8432.jpg?1641306079">C21</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/b/ab3331a0-5840-439d-9553-d4489c343f21.jpg?1562702249">A25</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/c/ccd172b9-377a-4dbf-a11a-e4985da62c72.jpg">C14</set>
+            <set picURL="https://api.scryfall.com/cards/87a6f719-3e2f-48ea-829d-77134a2a8432?format=image">C21</set>
+            <set picURL="https://api.scryfall.com/cards/ab3331a0-5840-439d-9553-d4489c343f21?format=image">A25</set>
+            <set picURL="https://api.scryfall.com/cards/ccd172b9-377a-4dbf-a11a-e4985da62c72?format=image">C14</set>
             <related>Kraken Token</related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -10373,7 +10373,7 @@ Whenever you cast a creature spell, note one of its creature types that hasn't b
                 <cmc>0</cmc>
                 <pt>2/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/7/b/7b0b95ce-4821-4955-a27c-93471240f54b.jpg?1557575896">WAR</set>
+            <set picURL="https://api.scryfall.com/cards/7b0b95ce-4821-4955-a27c-93471240f54b?format=image">WAR</set>
             <reverse-related>Kasmina, Enigmatic Mentor</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -10388,8 +10388,8 @@ Whenever you cast a creature spell, note one of its creature types that hasn't b
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/5/c53eb7d1-9c36-4184-b411-ebe65aa64230.jpg?1654172688">CLB</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/7/f/7f3edaf7-0ebd-4a8b-9954-dd91bb797744.jpg?1650819787">SNC</set>
+            <set picURL="https://api.scryfall.com/cards/c53eb7d1-9c36-4184-b411-ebe65aa64230?format=image">CLB</set>
+            <set picURL="https://api.scryfall.com/cards/7f3edaf7-0ebd-4a8b-9954-dd91bb797744?format=image">SNC</set>
             <reverse-related>Mage's Attendant</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -10403,29 +10403,29 @@ Whenever you cast a creature spell, note one of its creature types that hasn't b
                 <cmc>0</cmc>
                 <pt>2/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/8/1/81605b8d-cf1d-49dc-aebb-a857d6796a77.jpg?1654171951">CLB</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/5/d5f1e139-3054-4273-8a4d-faaaa9c383a8.jpg?1636630176">VOW</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/3/6/364e04d9-9a8a-49df-921c-7a9bf62dc731.jpg?1653273232">MID</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/8/1864d5b9-7151-42f0-8d37-8c319c3ab264.jpg?1626139395">AFR</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/f/cf371056-43dd-41ab-8d05-b16a8bdc8d28.jpg?1598312579">2XM</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/4/1/411f4bf6-7f09-4e24-b483-0068d2f974e5.jpg?1581902126">THB</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/b/d/bd05e304-1a16-436d-a05c-4a38a839759b.jpg?1592515991">M20</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/5/551f3219-3e98-4354-abcd-db22c3253105.jpg?1557575971">WAR</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/4/f/4ff5727c-7001-45db-9e0c-771824e849b0.jpg?1562702060">A25</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/a/0a5ac360-dc47-4bc5-a4cc-ff223abc3ffc.jpg?1562086859">SOI</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/7/d/7dc406c6-c2d7-4771-b916-258f7a35275a.jpg?1562857268">C15</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/7/b/7bdb3368-fee3-4795-a23f-c97555ee7475.jpg">MM2</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/c/dce952a6-a5d2-4fb9-b66b-1852ab698ac6.jpg">C14</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/4/a4cd989d-e274-4058-876f-3c20f28def0d.jpg">CNS</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/8/9/8958b650-c831-4499-813b-5699954ab2f0.jpg">BNG</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/3/0/309f1bd4-78af-4722-9d45-b5f40b001570.jpg">M14</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/back/3/a/3a98c51f-c55c-4bd9-853b-65b8bad5a29f.jpg">F12</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/5/a53f8031-aaa8-424c-929a-5478538a8cc6.jpg">ISD</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/c/5cde8b3e-c006-41fd-a926-8746c794e149.jpg">SOM</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/c/dcc9e4b4-c0fb-4627-92cf-69544e0c875d.jpg">ZEN</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/f/0f63920d-18a0-4267-bb4e-a972ba86067d.jpg">M10</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/9/c/9c138bf9-8be6-4f1a-a82c-a84938ab84f5.jpg">SHM</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/2/02a80dc2-0811-4df0-95f1-dd80ce9e24de.jpg">LRW</set>
+            <set picURL="https://api.scryfall.com/cards/81605b8d-cf1d-49dc-aebb-a857d6796a77?format=image">CLB</set>
+            <set picURL="https://api.scryfall.com/cards/d5f1e139-3054-4273-8a4d-faaaa9c383a8?format=image">VOW</set>
+            <set picURL="https://api.scryfall.com/cards/364e04d9-9a8a-49df-921c-7a9bf62dc731?format=image">MID</set>
+            <set picURL="https://api.scryfall.com/cards/1864d5b9-7151-42f0-8d37-8c319c3ab264?format=image">AFR</set>
+            <set picURL="https://api.scryfall.com/cards/cf371056-43dd-41ab-8d05-b16a8bdc8d28?format=image">2XM</set>
+            <set picURL="https://api.scryfall.com/cards/411f4bf6-7f09-4e24-b483-0068d2f974e5?format=image">THB</set>
+            <set picURL="https://api.scryfall.com/cards/bd05e304-1a16-436d-a05c-4a38a839759b?format=image">M20</set>
+            <set picURL="https://api.scryfall.com/cards/551f3219-3e98-4354-abcd-db22c3253105?format=image">WAR</set>
+            <set picURL="https://api.scryfall.com/cards/4ff5727c-7001-45db-9e0c-771824e849b0?format=image">A25</set>
+            <set picURL="https://api.scryfall.com/cards/0a5ac360-dc47-4bc5-a4cc-ff223abc3ffc?format=image">SOI</set>
+            <set picURL="https://api.scryfall.com/cards/7dc406c6-c2d7-4771-b916-258f7a35275a?format=image">C15</set>
+            <set picURL="https://api.scryfall.com/cards/7bdb3368-fee3-4795-a23f-c97555ee7475?format=image">MM2</set>
+            <set picURL="https://api.scryfall.com/cards/dce952a6-a5d2-4fb9-b66b-1852ab698ac6?format=image">C14</set>
+            <set picURL="https://api.scryfall.com/cards/a4cd989d-e274-4058-876f-3c20f28def0d?format=image">CNS</set>
+            <set picURL="https://api.scryfall.com/cards/8958b650-c831-4499-813b-5699954ab2f0?format=image">BNG</set>
+            <set picURL="https://api.scryfall.com/cards/309f1bd4-78af-4722-9d45-b5f40b001570?format=image">M14</set>
+            <set picURL="https://api.scryfall.com/cards/3a98c51f-c55c-4bd9-853b-65b8bad5a29f?format=image&amp;face=back">F12</set>
+            <set picURL="https://api.scryfall.com/cards/a53f8031-aaa8-424c-929a-5478538a8cc6?format=image">ISD</set>
+            <set picURL="https://api.scryfall.com/cards/5cde8b3e-c006-41fd-a926-8746c794e149?format=image">SOM</set>
+            <set picURL="https://api.scryfall.com/cards/dcc9e4b4-c0fb-4627-92cf-69544e0c875d?format=image">ZEN</set>
+            <set picURL="https://api.scryfall.com/cards/0f63920d-18a0-4267-bb4e-a972ba86067d?format=image">M10</set>
+            <set picURL="https://api.scryfall.com/cards/9c138bf9-8be6-4f1a-a82c-a84938ab84f5?format=image">SHM</set>
+            <set picURL="https://api.scryfall.com/cards/02a80dc2-0811-4df0-95f1-dd80ce9e24de?format=image">LRW</set>
             <reverse-related>Arlinn Kord</reverse-related>
             <reverse-related count="2">Arlinn, the Pack's Hope</reverse-related>
             <reverse-related>Arlinn, Voice of the Pack</reverse-related>
@@ -10481,7 +10481,7 @@ Whenever you cast a creature spell, note one of its creature types that hasn't b
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/7/a/7a49607c-427a-474c-ad77-60cd05844b3c.jpg">ISD</set>
+            <set picURL="https://api.scryfall.com/cards/7a49607c-427a-474c-ad77-60cd05844b3c?format=image">ISD</set>
             <reverse-related>Garruk, the Veil-Cursed</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -10511,7 +10511,7 @@ Whenever you cast a creature spell, note one of its creature types that hasn't b
                 <maintype>Creature</maintype>
                 <pt>2/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/8/8/88452ed7-1065-41c3-94a6-dc41108c45c1.jpg?1596045222">ELD</set>
+            <set picURL="https://api.scryfall.com/cards/88452ed7-1065-41c3-94a6-dc41108c45c1?format=image">ELD</set>
             <reverse-related count="2">Garruk, Cursed Huntsman</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -10525,7 +10525,7 @@ Whenever you cast a creature spell, note one of its creature types that hasn't b
                 <maintype>Creature</maintype>
                 <pt>3/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/0/001cc57e-f3fc-4790-a9e5-171b2e3e8739.jpg?1636630097">VOW</set>
+            <set picURL="https://api.scryfall.com/cards/001cc57e-f3fc-4790-a9e5-171b2e3e8739?format=image">VOW</set>
             <reverse-related>Kessig Wolfrider</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -10569,11 +10569,11 @@ Whenever you cast a creature spell, note one of its creature types that hasn't b
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/7/4/74b0276f-004e-458a-b941-e217216141f6.jpg?1592710098">C18</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/f/b/fb508d76-5e34-45f9-b0bb-9dbbf8caadbf.jpg?1562945714">C16</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/f/1fd82205-5d3e-4a8d-a31b-020efc6303d0.jpg">MM2</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/8/2/828b9eb1-ccdc-4540-9d53-7853539af189.jpg">MMA</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/7/0788f7a4-793a-42f4-a7c9-05e4b4587897.jpg">EVE</set>
+            <set picURL="https://api.scryfall.com/cards/74b0276f-004e-458a-b941-e217216141f6?format=image">C18</set>
+            <set picURL="https://api.scryfall.com/cards/fb508d76-5e34-45f9-b0bb-9dbbf8caadbf?format=image">C16</set>
+            <set picURL="https://api.scryfall.com/cards/1fd82205-5d3e-4a8d-a31b-020efc6303d0?format=image">MM2</set>
+            <set picURL="https://api.scryfall.com/cards/828b9eb1-ccdc-4540-9d53-7853539af189?format=image">MMA</set>
+            <set picURL="https://api.scryfall.com/cards/0788f7a4-793a-42f4-a7c9-05e4b4587897?format=image">EVE</set>
             <reverse-related>Creakwood Liege</reverse-related>
             <reverse-related count="x">Worm Harvest</reverse-related>
             <token>1</token>
@@ -10588,13 +10588,13 @@ Whenever you cast a creature spell, note one of its creature types that hasn't b
                 <cmc>0</cmc>
                 <pt>6/6</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/5/d559711e-7895-46e1-a970-ce5a05ec1ee4.jpg?1641306106">C21</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/2/52df7443-9af7-4cab-a69a-2ffd04b48815.jpg?1572370785">C19</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/f/1f5a1c01-a461-495e-87cc-f2202c3f349a.jpg?1552078543">GK2</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/3/a32175ed-d4f8-43b0-8f31-df529167610b.jpg?1562702232">EMA</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/4/a4d87f38-c342-4186-8768-c3f1aceb680a.jpg">M13</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/8/4/84dc847c-7a37-4c7f-b02c-30b3e4c91fb6.jpg">M12</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/9/f/9fc04b19-e636-4868-8224-a5da75ea01c8.jpg">ODY</set>
+            <set picURL="https://api.scryfall.com/cards/d559711e-7895-46e1-a970-ce5a05ec1ee4?format=image">C21</set>
+            <set picURL="https://api.scryfall.com/cards/52df7443-9af7-4cab-a69a-2ffd04b48815?format=image">C19</set>
+            <set picURL="https://api.scryfall.com/cards/1f5a1c01-a461-495e-87cc-f2202c3f349a?format=image">GK2</set>
+            <set picURL="https://api.scryfall.com/cards/a32175ed-d4f8-43b0-8f31-df529167610b?format=image">EMA</set>
+            <set picURL="https://api.scryfall.com/cards/a4d87f38-c342-4186-8768-c3f1aceb680a?format=image">M13</set>
+            <set picURL="https://api.scryfall.com/cards/84dc847c-7a37-4c7f-b02c-30b3e4c91fb6?format=image">M12</set>
+            <set picURL="https://api.scryfall.com/cards/9fc04b19-e636-4868-8224-a5da75ea01c8?format=image">ODY</set>
             <reverse-related count="3">Crush of Wurms</reverse-related>
             <reverse-related count="x" exclude="exclude">Garruk, Primal Hunter</reverse-related>
             <reverse-related>Roar of the Wurm</reverse-related>
@@ -10612,7 +10612,7 @@ Whenever you cast a creature spell, note one of its creature types that hasn't b
                 <cmc>0</cmc>
                 <pt>6/6</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/3/1/31107acf-5969-42ff-a805-9152f439b7fa.jpg?1547509275">UMA</set>
+            <set picURL="https://api.scryfall.com/cards/31107acf-5969-42ff-a805-9152f439b7fa?format=image">UMA</set>
             <reverse-related>Penumbra Wurm</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -10627,9 +10627,9 @@ Whenever you cast a creature spell, note one of its creature types that hasn't b
                 <cmc>0</cmc>
                 <pt>5/5</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/0/d0c052ed-c761-4f1d-816b-092cdd6cb0fa.jpg?1541007588">GK1</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/3/f/3fd53493-ac85-4dd0-b1db-0ae0130ea2d4.jpg?1562841174">MM3</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/3/3/33ee3f6c-5df6-4271-b2f9-86b9afffab7b.jpg">RTR</set>
+            <set picURL="https://api.scryfall.com/cards/d0c052ed-c761-4f1d-816b-092cdd6cb0fa?format=image">GK1</set>
+            <set picURL="https://api.scryfall.com/cards/3fd53493-ac85-4dd0-b1db-0ae0130ea2d4?format=image">MM3</set>
+            <set picURL="https://api.scryfall.com/cards/33ee3f6c-5df6-4271-b2f9-86b9afffab7b?format=image">RTR</set>
             <reverse-related>Advent of the Wurm</reverse-related>
             <reverse-related>Armada Wurm</reverse-related>
             <reverse-related count="3">Worldspine Wurm</reverse-related>
@@ -10660,8 +10660,8 @@ Whenever you cast a creature spell, note one of its creature types that hasn't b
                 <cmc>0</cmc>
                 <pt>5/5</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/4/54afe5d9-a6b6-46a2-89e9-470ad9e44a06.jpg?1654172101">CLB</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/3/6/366c01a7-6399-496b-a5a3-8be45475ce33.jpg">AKH</set>
+            <set picURL="https://api.scryfall.com/cards/54afe5d9-a6b6-46a2-89e9-470ad9e44a06?format=image">CLB</set>
+            <set picURL="https://api.scryfall.com/cards/366c01a7-6399-496b-a5a3-8be45475ce33?format=image">AKH</set>
             <reverse-related>Sandwurm Convergence</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -10675,7 +10675,7 @@ Whenever you cast a creature spell, note one of its creature types that hasn't b
                 <cmc>0</cmc>
                 <pt>4/4</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/e/d/edcfb468-6389-4e72-80af-d0d4442e6988.jpg?1662835177">DMU</set>
+            <set picURL="https://api.scryfall.com/cards/edcfb468-6389-4e72-80af-d0d4442e6988?format=image">DMU</set>
             <reverse-related>Baru, Wurmspeaker</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -10690,7 +10690,7 @@ Whenever you cast a creature spell, note one of its creature types that hasn't b
                 <cmc>0</cmc>
                 <pt>3/3</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/8/8/88be9551-c8d9-4486-b8f1-810f5dae12c8.jpg?1663530371">40K</set>
+            <set picURL="https://api.scryfall.com/cards/88be9551-c8d9-4486-b8f1-810f5dae12c8?format=image">40K</set>
             <reverse-related count="x">Zephyrim</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -10704,10 +10704,10 @@ Whenever you cast a creature spell, note one of its creature types that hasn't b
                 <cmc>0</cmc>
                 <pt>0/0</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/4/c46d82e0-ef99-473c-a09c-8f552db759bf.jpg?1641306185">MH2</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/2/f/2f4b7c63-8430-4ca4-baee-dc958d5bd22f.jpg?1557575919">WAR</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/3/f/3f3f2ad9-d362-4602-8e49-b44c0659c112.jpg?1557575928">WAR</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/2/12742d1f-eb2e-4262-88e2-403c9ae6c431.jpg?1557575935">WAR</set>
+            <set picURL="https://api.scryfall.com/cards/c46d82e0-ef99-473c-a09c-8f552db759bf?format=image">MH2</set>
+            <set picURL="https://api.scryfall.com/cards/2f4b7c63-8430-4ca4-baee-dc958d5bd22f?format=image">WAR</set>
+            <set picURL="https://api.scryfall.com/cards/3f3f2ad9-d362-4602-8e49-b44c0659c112?format=image">WAR</set>
+            <set picURL="https://api.scryfall.com/cards/12742d1f-eb2e-4262-88e2-403c9ae6c431?format=image">WAR</set>
             <reverse-related>Angrath, Captain of Chaos</reverse-related>
             <reverse-related>Aven Eternal</reverse-related>
             <reverse-related>Bleeding Edge</reverse-related>
@@ -10743,7 +10743,7 @@ Whenever you cast a creature spell, note one of its creature types that hasn't b
                 <cmc>0</cmc>
                 <pt>2/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/e/4/e4bbd379-6728-4c6b-b375-295926fe6b00.jpg?1615686324">KHM</set>
+            <set picURL="https://api.scryfall.com/cards/e4bbd379-6728-4c6b-b375-295926fe6b00?format=image">KHM</set>
             <reverse-related>Deathknell Berserker</reverse-related>
             <reverse-related attach="attach">Draugr's Helm</reverse-related>
             <reverse-related count="x">Rise of the Dread Marn</reverse-related>
@@ -10759,7 +10759,7 @@ Whenever you cast a creature spell, note one of its creature types that hasn't b
                 <cmc>0</cmc>
                 <pt>2/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/6/c6d7d1d3-8989-4c54-9029-c1298c6ff8ca.jpg?1664344098">UNF</set>
+            <set picURL="https://api.scryfall.com/cards/c6d7d1d3-8989-4c54-9029-c1298c6ff8ca?format=image">UNF</set>
             <reverse-related>Night Shift of the Living Dead</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -10773,8 +10773,8 @@ Whenever you cast a creature spell, note one of its creature types that hasn't b
                 <cmc>0</cmc>
                 <pt>5/5</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/b/e/be7e26e1-5db6-49ba-a88e-c79d889cd364.jpg?1561757964">BBD</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/9/1999ff2f-5797-496e-9917-ad19507ecec9.jpg">ZEN</set>
+            <set picURL="https://api.scryfall.com/cards/be7e26e1-5db6-49ba-a88e-c79d889cd364?format=image">BBD</set>
+            <set picURL="https://api.scryfall.com/cards/1999ff2f-5797-496e-9917-ad19507ecec9?format=image">ZEN</set>
             <reverse-related>Quest for the Gravelord</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -10788,7 +10788,7 @@ Whenever you cast a creature spell, note one of its creature types that hasn't b
                 <cmc>0</cmc>
                 <pt>*/*</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/3/533c41ab-d9ee-4817-a982-41d4da6fa9ad.jpg">DTK</set>
+            <set picURL="https://api.scryfall.com/cards/533c41ab-d9ee-4817-a982-41d4da6fa9ad?format=image">DTK</set>
             <reverse-related>Corpseweft</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -10803,8 +10803,8 @@ Whenever you cast a creature spell, note one of its creature types that hasn't b
                 <cmc>0</cmc>
                 <pt>2/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/4/145bd35c-efcb-4aee-8f13-349961979046.jpg?1662663389">DMC</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/b/0b527bcd-0d37-495a-8457-8123388056b9.jpg?1562701899">DOM</set>
+            <set picURL="https://api.scryfall.com/cards/145bd35c-efcb-4aee-8f13-349961979046?format=image">DMC</set>
+            <set picURL="https://api.scryfall.com/cards/0b527bcd-0d37-495a-8457-8123388056b9?format=image">DOM</set>
             <reverse-related count="x">Bladewing, Deathless Tyrant</reverse-related>
             <reverse-related count="8">Josu Vess, Lich Knight</reverse-related>
             <token>1</token>
@@ -10819,58 +10819,58 @@ Whenever you cast a creature spell, note one of its creature types that hasn't b
                 <cmc>0</cmc>
                 <pt>2/2</pt>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/c/7/c700cb99-1cee-455f-9a36-d7d9a79fed06.jpg?1674397371">DMR</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/a/dac26fe3-b44c-4385-ad74-d348c33e151c.jpg?1662835159">DMU</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/back/1/3/13e4832d-8530-4b85-b738-51d0c18f28ec.jpg?1651951882">CC2</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/8/c84e21cd-079d-493f-ab8d-e62f16ec1581.jpg?1636629997">VOW</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/b/0b08d210-01cb-46c5-9150-4dfb47f50ae7.jpg?1626139197">AFR</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/3/0/3031bec1-c6dc-441f-9391-458bb1577c56.jpg?1641306181">MH2</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/f/2/f29c0f8b-0888-4d9f-a554-c4a79d079f54.jpg?1641306085">C21</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/9/d/9d62c8ad-af51-493c-aef1-fe7774156d4b.jpg?1608908509">CMR</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/3/f/3f170f84-6c36-43e2-91e6-3c7a136944b1.jpg?1594733533">M21</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/3/e/3e8a0b96-9add-406a-bf10-bc943141edf5.jpg?1591319184">C20</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/6/b/6b3e6b4d-d798-4c6a-8a09-255be2a6df2c.jpg?1581901997">THB</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/8/e/8e214f84-01ee-49c1-8801-4e550b5ade5d.jpg?1572370688">C19</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/9/59bad855-ff86-4f98-bf18-0982c7aea9c5.jpg?1568003399">C19</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/8/18f0436e-9328-4266-9cf8-80b557a0c17c.jpg?1592515969">M20</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/9/c/9c722fe8-05f1-4da0-a23b-25e20359fcef.jpg?1563073076">MH1</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/9/3/935d1421-0d26-468f-aa86-488b0ba25e77.jpg?1557575912">WAR</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/2/7/27b69e52-f394-4863-943b-239e96b5cc95.jpg?1572892495">RNA</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/9/096e8ff7-3cb7-4ef9-a480-76d664924cff.jpg?1547509286">UMA</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/f/a/faa2e829-fa71-426b-b71f-dfa021786531.jpg?1592710033">C18</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/e/d/ed08aac1-9e82-4049-9926-618f15222024.jpg">M19</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/f/0/f08609b4-f5e0-4e3b-aee3-8ed3e3232074.jpg?1561758393">BBD</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/back/5/a/5a561f84-5696-44a5-8dc1-227af883341d.jpg?1571508505">UST</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/2/d2bd70ba-91a6-4944-92a1-89d561355c25.jpg">C17</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/b/5/b5bd6905-79be-4d2c-a343-f6e6a181b3e6.jpg">AKH</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/2/2/22110a53-493d-4af5-aea5-f6a8b4958a84.jpg?1562840735">MM3</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/6/b/6b0a71ed-f693-4228-9077-93c62d057ef9.jpg?1562916502">C16</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/4/c/4ccc931f-4586-4d7e-a984-dc7142359a85.jpg?1561897498">CN2</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/5/15f1f43a-cbdb-4d1b-a254-dadcb2469784.jpg?1562636743">EMN</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/6/06e7f8df-826e-4ba7-9c6c-8c8eb7a61de8.jpg?1562636730">EMN</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/b/8/b8710a30-8314-49ef-b995-bd05454095be.jpg?1562636876">EMN</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/2/0/207e9b8c-3e5e-4262-8d78-248780600462.jpg?1562701941">EMA</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/e/0/e0a12a72-5cd9-4f1b-997d-7dabb65e9f51.jpg?1562086884">SOI</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/e/0/e0bde78b-98d1-4864-899b-fc2f945ce06b.jpg">OGW</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/8/f/8ffaa67e-32fa-4843-8858-feed2ebb40df.jpg?1562857273">C15</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/e/5/e5ccae95-95c2-4d11-aa68-5c80ecf90fd2.jpg">ORI</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/e/4/e4de662d-374d-4dd7-908f-bcde7bdc5ae9.jpg">DTK</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/3/0397aa00-6d82-47d9-bc30-072b722c8b71.jpg">C14</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/b/a/ba7da3d0-2471-48ab-8e7c-af8046d9e0be.jpg">KTK</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/e/b/eb0a1ebd-a0ac-4a03-8ac2-4678d6fb03fa.jpg?1562640118">M15</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/2/2/22aec1b4-33ec-4cf1-9f41-3e0468a679cd.jpg">CNS</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/7/07d82a8d-4c57-401f-92c3-8fd9ba20174a.jpg">M14</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/7/3/738dce42-9852-4ced-8e9e-4639fad8b79f.jpg">MMA</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/9/1966d7e6-cd4a-47ff-bc3e-f8e0db8a3439.jpg">M13</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/b/8/b877c19d-6022-4377-92e7-4511e24eb98e.jpg">AVR</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/9/c9a85357-3cad-4a1e-805b-ea4146d8b05f.jpg">ISD</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/8/d/8db7e3f4-0153-425a-8edc-2747bbb89638.jpg">M12</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/6/b/6b365694-e056-48b9-aae3-599180c0c29c.jpg">M11</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/d/cd51a6b5-1165-4df6-a30d-d46c729633f7.jpg">M10</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/b/a/ba9b6612-5372-4e6f-841f-20009f71a736.jpg">ALA</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/8/a/8a73e348-5bf1-4465-978b-3f31408bade9.jpg">10E</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/6/5/657fa00d-ddb5-49e6-a01e-82038cccfe30.jpg">ODY</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/8/e/8e7b5995-ee8b-40d1-b157-8df96c02cc5b.jpg?1561757555">UGL</set>
+            <set picURL="https://api.scryfall.com/cards/c700cb99-1cee-455f-9a36-d7d9a79fed06?format=image">DMR</set>
+            <set picURL="https://api.scryfall.com/cards/dac26fe3-b44c-4385-ad74-d348c33e151c?format=image">DMU</set>
+            <set picURL="https://api.scryfall.com/cards/13e4832d-8530-4b85-b738-51d0c18f28ec?format=image&amp;face=back">CC2</set>
+            <set picURL="https://api.scryfall.com/cards/c84e21cd-079d-493f-ab8d-e62f16ec1581?format=image">VOW</set>
+            <set picURL="https://api.scryfall.com/cards/0b08d210-01cb-46c5-9150-4dfb47f50ae7?format=image">AFR</set>
+            <set picURL="https://api.scryfall.com/cards/3031bec1-c6dc-441f-9391-458bb1577c56?format=image">MH2</set>
+            <set picURL="https://api.scryfall.com/cards/f29c0f8b-0888-4d9f-a554-c4a79d079f54?format=image">C21</set>
+            <set picURL="https://api.scryfall.com/cards/9d62c8ad-af51-493c-aef1-fe7774156d4b?format=image">CMR</set>
+            <set picURL="https://api.scryfall.com/cards/3f170f84-6c36-43e2-91e6-3c7a136944b1?format=image">M21</set>
+            <set picURL="https://api.scryfall.com/cards/3e8a0b96-9add-406a-bf10-bc943141edf5?format=image">C20</set>
+            <set picURL="https://api.scryfall.com/cards/6b3e6b4d-d798-4c6a-8a09-255be2a6df2c?format=image">THB</set>
+            <set picURL="https://api.scryfall.com/cards/8e214f84-01ee-49c1-8801-4e550b5ade5d?format=image">C19</set>
+            <set picURL="https://api.scryfall.com/cards/59bad855-ff86-4f98-bf18-0982c7aea9c5?format=image">C19</set>
+            <set picURL="https://api.scryfall.com/cards/18f0436e-9328-4266-9cf8-80b557a0c17c?format=image">M20</set>
+            <set picURL="https://api.scryfall.com/cards/9c722fe8-05f1-4da0-a23b-25e20359fcef?format=image">MH1</set>
+            <set picURL="https://api.scryfall.com/cards/935d1421-0d26-468f-aa86-488b0ba25e77?format=image">WAR</set>
+            <set picURL="https://api.scryfall.com/cards/27b69e52-f394-4863-943b-239e96b5cc95?format=image">RNA</set>
+            <set picURL="https://api.scryfall.com/cards/096e8ff7-3cb7-4ef9-a480-76d664924cff?format=image">UMA</set>
+            <set picURL="https://api.scryfall.com/cards/faa2e829-fa71-426b-b71f-dfa021786531?format=image">C18</set>
+            <set picURL="https://api.scryfall.com/cards/ed08aac1-9e82-4049-9926-618f15222024?format=image">M19</set>
+            <set picURL="https://api.scryfall.com/cards/f08609b4-f5e0-4e3b-aee3-8ed3e3232074?format=image">BBD</set>
+            <set picURL="https://api.scryfall.com/cards/5a561f84-5696-44a5-8dc1-227af883341d?format=image&amp;face=back">UST</set>
+            <set picURL="https://api.scryfall.com/cards/d2bd70ba-91a6-4944-92a1-89d561355c25?format=image">C17</set>
+            <set picURL="https://api.scryfall.com/cards/b5bd6905-79be-4d2c-a343-f6e6a181b3e6?format=image">AKH</set>
+            <set picURL="https://api.scryfall.com/cards/22110a53-493d-4af5-aea5-f6a8b4958a84?format=image">MM3</set>
+            <set picURL="https://api.scryfall.com/cards/6b0a71ed-f693-4228-9077-93c62d057ef9?format=image">C16</set>
+            <set picURL="https://api.scryfall.com/cards/4ccc931f-4586-4d7e-a984-dc7142359a85?format=image">CN2</set>
+            <set picURL="https://api.scryfall.com/cards/15f1f43a-cbdb-4d1b-a254-dadcb2469784?format=image">EMN</set>
+            <set picURL="https://api.scryfall.com/cards/06e7f8df-826e-4ba7-9c6c-8c8eb7a61de8?format=image">EMN</set>
+            <set picURL="https://api.scryfall.com/cards/b8710a30-8314-49ef-b995-bd05454095be?format=image">EMN</set>
+            <set picURL="https://api.scryfall.com/cards/207e9b8c-3e5e-4262-8d78-248780600462?format=image">EMA</set>
+            <set picURL="https://api.scryfall.com/cards/e0a12a72-5cd9-4f1b-997d-7dabb65e9f51?format=image">SOI</set>
+            <set picURL="https://api.scryfall.com/cards/e0bde78b-98d1-4864-899b-fc2f945ce06b?format=image">OGW</set>
+            <set picURL="https://api.scryfall.com/cards/8ffaa67e-32fa-4843-8858-feed2ebb40df?format=image">C15</set>
+            <set picURL="https://api.scryfall.com/cards/e5ccae95-95c2-4d11-aa68-5c80ecf90fd2?format=image">ORI</set>
+            <set picURL="https://api.scryfall.com/cards/e4de662d-374d-4dd7-908f-bcde7bdc5ae9?format=image">DTK</set>
+            <set picURL="https://api.scryfall.com/cards/0397aa00-6d82-47d9-bc30-072b722c8b71?format=image">C14</set>
+            <set picURL="https://api.scryfall.com/cards/ba7da3d0-2471-48ab-8e7c-af8046d9e0be?format=image">KTK</set>
+            <set picURL="https://api.scryfall.com/cards/eb0a1ebd-a0ac-4a03-8ac2-4678d6fb03fa?format=image">M15</set>
+            <set picURL="https://api.scryfall.com/cards/22aec1b4-33ec-4cf1-9f41-3e0468a679cd?format=image">CNS</set>
+            <set picURL="https://api.scryfall.com/cards/07d82a8d-4c57-401f-92c3-8fd9ba20174a?format=image">M14</set>
+            <set picURL="https://api.scryfall.com/cards/738dce42-9852-4ced-8e9e-4639fad8b79f?format=image">MMA</set>
+            <set picURL="https://api.scryfall.com/cards/1966d7e6-cd4a-47ff-bc3e-f8e0db8a3439?format=image">M13</set>
+            <set picURL="https://api.scryfall.com/cards/b877c19d-6022-4377-92e7-4511e24eb98e?format=image">AVR</set>
+            <set picURL="https://api.scryfall.com/cards/c9a85357-3cad-4a1e-805b-ea4146d8b05f?format=image">ISD</set>
+            <set picURL="https://api.scryfall.com/cards/8db7e3f4-0153-425a-8edc-2747bbb89638?format=image">M12</set>
+            <set picURL="https://api.scryfall.com/cards/6b365694-e056-48b9-aae3-599180c0c29c?format=image">M11</set>
+            <set picURL="https://api.scryfall.com/cards/cd51a6b5-1165-4df6-a30d-d46c729633f7?format=image">M10</set>
+            <set picURL="https://api.scryfall.com/cards/ba9b6612-5372-4e6f-841f-20009f71a736?format=image">ALA</set>
+            <set picURL="https://api.scryfall.com/cards/8a73e348-5bf1-4465-978b-3f31408bade9?format=image">10E</set>
+            <set picURL="https://api.scryfall.com/cards/657fa00d-ddb5-49e6-a01e-82038cccfe30?format=image">ODY</set>
+            <set picURL="https://api.scryfall.com/cards/8e7b5995-ee8b-40d1-b157-8df96c02cc5b?format=image">UGL</set>
             <reverse-related count="x">Acererak the Archlich</reverse-related>
             <reverse-related>Aphemia, the Cacophony</reverse-related>
             <reverse-related>Archdemon of Unx</reverse-related>
@@ -10979,7 +10979,7 @@ Whenever you cast a creature spell, note one of its creature types that hasn't b
                 <cmc>0</cmc>
                 <pt>2/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/a/aa525567-24f3-4ad4-b0b2-3b09d87cd106.jpg">BNG</set>
+            <set picURL="https://api.scryfall.com/cards/aa525567-24f3-4ad4-b0b2-3b09d87cd106?format=image">BNG</set>
             <reverse-related>Forlorn Pseudamma</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -10993,8 +10993,8 @@ Whenever you cast a creature spell, note one of its creature types that hasn't b
                 <cmc>0</cmc>
                 <pt>*/*</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/e/4/e44aa879-b63b-497c-9c1b-2333950161fa.jpg?1562636931">EMN</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/9/5/95c59642-575f-4356-ae1a-20b90895545b.jpg">JOU</set>
+            <set picURL="https://api.scryfall.com/cards/e44aa879-b63b-497c-9c1b-2333950161fa?format=image">EMN</set>
+            <set picURL="https://api.scryfall.com/cards/95c59642-575f-4356-ae1a-20b90895545b?format=image">JOU</set>
             <reverse-related>Ritual of the Returned</reverse-related>
             <reverse-related>Soul Separator</reverse-related>
             <token>1</token>
@@ -11009,7 +11009,7 @@ Whenever you cast a creature spell, note one of its creature types that hasn't b
                 <cmc>0</cmc>
                 <pt>*/*</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/7/d791c7af-1ba7-45ab-ad0c-be9ebc9e51f9.jpg">C14</set>
+            <set picURL="https://api.scryfall.com/cards/d791c7af-1ba7-45ab-ad0c-be9ebc9e51f9?format=image">C14</set>
             <reverse-related>Stitcher Geralf</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -11024,7 +11024,7 @@ Whenever you cast a creature spell, note one of its creature types that hasn't b
                 <cmc>0</cmc>
                 <pt>2/2</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/6/a/6adb8607-1066-451d-a719-74ad32358278.jpg?1641305859">MID</set>
+            <set picURL="https://api.scryfall.com/cards/6adb8607-1066-451d-a719-74ad32358278?format=image">MID</set>
             <reverse-related count="x">Crowded Crypt</reverse-related>
             <reverse-related>Curse of the Restless Dead</reverse-related>
             <reverse-related count="x" exclude="exclude">Curse of the Restless Dead</reverse-related>
@@ -11055,7 +11055,7 @@ Whenever you cast a creature spell, note one of its creature types that hasn't b
                 <cmc>0</cmc>
                 <pt>*/*</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/e/b/eb5fb489-6e46-4359-9c3c-ef1702526e5a.jpg?1641305883">MID</set>
+            <set picURL="https://api.scryfall.com/cards/eb5fb489-6e46-4359-9c3c-ef1702526e5a?format=image">MID</set>
             <reverse-related>Corpse Cobble</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -11069,7 +11069,7 @@ Whenever you cast a creature spell, note one of its creature types that hasn't b
                 <cmc>0</cmc>
                 <pt>*/*</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/3/539f4b60-667b-469d-9191-eacaad5c0db1.jpg?1636629909">VOW</set>
+            <set picURL="https://api.scryfall.com/cards/539f4b60-667b-469d-9191-eacaad5c0db1?format=image">VOW</set>
             <reverse-related>Geralf, Visionary Stitcher</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -11082,7 +11082,7 @@ Whenever you cast a creature spell, note one of its creature types that hasn't b
                 <cmc>0</cmc>
                 <pt>3/3</pt>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/f/e/fef47d03-9050-48ed-994f-f72582967dbd.jpg?1667887088">BRO</set>
+            <set picURL="https://api.scryfall.com/cards/fef47d03-9050-48ed-994f-f72582967dbd?format=image">BRO</set>
             <reverse-related exclude="exclude">Ashnod, Flesh Mechanist</reverse-related>
             <reverse-related>Transmogrant Altar</reverse-related>
             <token>1</token>
@@ -11098,7 +11098,7 @@ Whenever you cast a creature spell, note one of its creature types that hasn't b
                 <cmc>0</cmc>
                 <pt>4/4</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/2/e/2e06aa97-1611-4af6-8bad-32051927fcfd.jpg?1557575941">WAR</set>
+            <set picURL="https://api.scryfall.com/cards/2e06aa97-1611-4af6-8bad-32051927fcfd?format=image">WAR</set>
             <reverse-related>God-Eternal Oketra</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -11112,7 +11112,7 @@ Whenever you cast a creature spell, note one of its creature types that hasn't b
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/b/d/bde17901-35fb-4045-8ba5-deab046cd44f.jpg">ARB</set>
+            <set picURL="https://api.scryfall.com/cards/bde17901-35fb-4045-8ba5-deab046cd44f?format=image">ARB</set>
             <reverse-related>Lich Lord of Unx</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -11132,7 +11132,7 @@ Mad Wizard’s Lair — Draw three cards and reveal them. You may cast one of th
                 <type>Dungeon</type>
                 <maintype>Dungeon</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/6/f/6f509dbe-6ec7-4438-ab36-e20be46c9922.jpg?1625106684">AFR</set>
+            <set picURL="https://api.scryfall.com/cards/6f509dbe-6ec7-4438-ab36-e20be46c9922?format=image">AFR</set>
             <related count="2" exclude="exclude">Skeleton Token </related>
             <related exclude="exclude">Treasure Token</related>
             <reverse-related exclude="exclude">Acererak the Archlich</reverse-related>
@@ -11188,7 +11188,7 @@ Temple of Dumathoin — Draw a card.</text>
                 <type>Dungeon</type>
                 <maintype>Dungeon</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/9/59b11ff8-f118-4978-87dd-509dc0c8c932.jpg?1625106709">AFR</set>
+            <set picURL="https://api.scryfall.com/cards/59b11ff8-f118-4978-87dd-509dc0c8c932?format=image">AFR</set>
             <related exclude="exclude">Goblin Token</related>
             <related exclude="exclude">Treasure Token</related>
             <reverse-related exclude="exclude">Acererak the Archlich</reverse-related>
@@ -11242,7 +11242,7 @@ Cradle of the Death God — Create The Atropal, a legendary 4/4 black God Horror
                 <type>Dungeon</type>
                 <maintype>Dungeon</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/7/0/70b284bd-7a8f-4b60-8238-f746bdc5b236.jpg?1626574335">AFR</set>
+            <set picURL="https://api.scryfall.com/cards/70b284bd-7a8f-4b60-8238-f746bdc5b236?format=image">AFR</set>
             <related>The Atropal</related>
             <reverse-related exclude="exclude">Acererak the Archlich</reverse-related>
             <reverse-related exclude="exclude">Bar the Gate</reverse-related>
@@ -11300,7 +11300,7 @@ Throne of the Dead Three — Reveal the top ten cards of your library. Put a cre
                 <type>Dungeon</type>
                 <maintype>Dungeon</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/back/2/c/2c65185b-6cf0-451d-985e-56aa45d9a57d.jpg?1654853128">CLB</set>
+            <set picURL="https://api.scryfall.com/cards/2c65185b-6cf0-451d-985e-56aa45d9a57d?format=image&amp;face=back">CLB</set>
             <related>Skeleton Token  </related>
             <related>Treasure</related>
             <token>1</token>
@@ -11313,7 +11313,7 @@ Throne of the Dead Three — Reveal the top ten cards of your library. Put a cre
                 <type>Emblem</type>
                 <maintype>Emblem</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/e/ae9ee46d-b2f4-4710-bf7d-1d7a5ec0aefe.jpg?1662361835">DMU</set>
+            <set picURL="https://api.scryfall.com/cards/ae9ee46d-b2f4-4710-bf7d-1d7a5ec0aefe?format=image">DMU</set>
             <reverse-related>Ajani, Sleeper Agent</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -11325,7 +11325,7 @@ Throne of the Dead Three — Reveal the top ten cards of your library. Put a cre
                 <type>Emblem — Ajani</type>
                 <maintype>Emblem</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/e/8/e8ec39dd-8ba5-4a92-bfc8-4028a2c4691d.jpg?1562640117">M15</set>
+            <set picURL="https://api.scryfall.com/cards/e8ec39dd-8ba5-4a92-bfc8-4028a2c4691d?format=image">M15</set>
             <reverse-related exclude="exclude">Ajani Steadfast</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -11337,7 +11337,7 @@ Throne of the Dead Three — Reveal the top ten cards of your library. Put a cre
                 <type>Emblem — Ajani</type>
                 <maintype>Emblem</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/c/1c97e5b2-a024-4aa7-a9b8-45f441aad138.jpg">M19</set>
+            <set picURL="https://api.scryfall.com/cards/1c97e5b2-a024-4aa7-a9b8-45f441aad138?format=image">M19</set>
             <related count="3">Cat Token   </related>
             <reverse-related>Ajani, Adversary of Tyrants</reverse-related>
             <token>1</token>
@@ -11350,7 +11350,7 @@ Throne of the Dead Three — Reveal the top ten cards of your library. Put a cre
                 <type>Emblem — Arlinn</type>
                 <maintype>Emblem</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/b/b/bb0686c3-a44a-449d-ab12-eeb9c0c25489.jpg?1562086879">SOI</set>
+            <set picURL="https://api.scryfall.com/cards/bb0686c3-a44a-449d-ab12-eeb9c0c25489?format=image">SOI</set>
             <reverse-related exclude="exclude">Arlinn Kord</reverse-related>
             <reverse-related exclude="exclude">Arlinn, Embraced by the Moon</reverse-related>
             <token>1</token>
@@ -11363,7 +11363,7 @@ Throne of the Dead Three — Reveal the top ten cards of your library. Put a cre
                 <type>Emblem</type>
                 <maintype>Emblem</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/d/0d37b555-5931-4084-8f83-e9853e14eccf.jpg?1594733647">M21</set>
+            <set picURL="https://api.scryfall.com/cards/0d37b555-5931-4084-8f83-e9853e14eccf?format=image">M21</set>
             <related>Soldier Token</related>
             <reverse-related exclude="exclude">Basri Ket</reverse-related>
             <token>1</token>
@@ -11376,7 +11376,7 @@ Throne of the Dead Three — Reveal the top ten cards of your library. Put a cre
                 <type>Emblem</type>
                 <maintype>Emblem</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/7/7/775f2b3e-4e3b-4037-b7bb-117ababf8e51.jpg?1592516016">M20</set>
+            <set picURL="https://api.scryfall.com/cards/775f2b3e-4e3b-4037-b7bb-117ababf8e51?format=image">M20</set>
             <reverse-related>Chandra, Awakened Inferno</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -11388,7 +11388,7 @@ Throne of the Dead Three — Reveal the top ten cards of your library. Put a cre
                 <type>Emblem</type>
                 <maintype>Emblem</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/1/01783a68-4f61-43ff-94ef-eb0eae654cb7.jpg?1636630373">VOW</set>
+            <set picURL="https://api.scryfall.com/cards/01783a68-4f61-43ff-94ef-eb0eae654cb7?format=image">VOW</set>
             <reverse-related>Chandra, Dressed to Kill</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -11400,7 +11400,7 @@ Throne of the Dead Three — Reveal the top ten cards of your library. Put a cre
                 <type>Emblem — Chandra</type>
                 <maintype>Emblem</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/4/a/4a8123a6-7e7b-49fb-9ebc-19d8150852e8.jpg">ORI</set>
+            <set picURL="https://api.scryfall.com/cards/4a8123a6-7e7b-49fb-9ebc-19d8150852e8?format=image">ORI</set>
             <reverse-related exclude="exclude">Chandra, Roaring Flame</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -11412,7 +11412,7 @@ Throne of the Dead Three — Reveal the top ten cards of your library. Put a cre
                 <type>Emblem — Chandra</type>
                 <maintype>Emblem</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/0/50ce1db3-417c-4c22-84e5-c463addde476.jpg?1562639801">KLD</set>
+            <set picURL="https://api.scryfall.com/cards/50ce1db3-417c-4c22-84e5-c463addde476?format=image">KLD</set>
             <reverse-related exclude="exclude">Chandra, Torch of Defiance</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -11424,8 +11424,8 @@ Throne of the Dead Three — Reveal the top ten cards of your library. Put a cre
                 <type>Emblem — Dack</type>
                 <maintype>Emblem</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/9/d92a00d8-ddac-45df-8130-87ac32815984.jpg?1562702384">EMA</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/f/4/f4e0b8d9-4e22-409d-acf1-05afaaac33df.jpg">CNS</set>
+            <set picURL="https://api.scryfall.com/cards/d92a00d8-ddac-45df-8130-87ac32815984?format=image">EMA</set>
+            <set picURL="https://api.scryfall.com/cards/f4e0b8d9-4e22-409d-acf1-05afaaac33df?format=image">CNS</set>
             <reverse-related exclude="exclude">Dack Fayden</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -11437,8 +11437,8 @@ Throne of the Dead Three — Reveal the top ten cards of your library. Put a cre
                 <type>Emblem — Daretti</type>
                 <maintype>Emblem</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/e/0e5578f7-3b45-470d-a5b0-7a2c50b9a333.jpg?1562897957">C16</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/4/3/43a3cfba-50f5-4d8c-96dd-3c4a70cb36ee.jpg">C14</set>
+            <set picURL="https://api.scryfall.com/cards/0e5578f7-3b45-470d-a5b0-7a2c50b9a333?format=image">C16</set>
+            <set picURL="https://api.scryfall.com/cards/43a3cfba-50f5-4d8c-96dd-3c4a70cb36ee?format=image">C14</set>
             <reverse-related exclude="exclude">Daretti, Scrap Savant</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -11450,8 +11450,8 @@ Throne of the Dead Three — Reveal the top ten cards of your library. Put a cre
                 <type>Emblem — Domri</type>
                 <maintype>Emblem</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/7/c/7cf98006-cc53-4a6c-b372-97b0970ffe4d.jpg?1562841183">MM3</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/6/1612f546-1bdb-4861-966c-4eeb7d1e65e8.jpg">GTC</set>
+            <set picURL="https://api.scryfall.com/cards/7cf98006-cc53-4a6c-b372-97b0970ffe4d?format=image">MM3</set>
+            <set picURL="https://api.scryfall.com/cards/1612f546-1bdb-4861-966c-4eeb7d1e65e8?format=image">GTC</set>
             <reverse-related exclude="exclude">Domri Rade</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -11463,7 +11463,7 @@ Throne of the Dead Three — Reveal the top ten cards of your library. Put a cre
                 <type>Emblem — Domri</type>
                 <maintype>Emblem</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/4/4/44717d19-d8c2-45ba-9904-00c0c79ee0c3.jpg?1572892563">RNA</set>
+            <set picURL="https://api.scryfall.com/cards/44717d19-d8c2-45ba-9904-00c0c79ee0c3?format=image">RNA</set>
             <related>Beast Token         </related>
             <reverse-related>Domri, Chaos Bringer</reverse-related>
             <token>1</token>
@@ -11476,7 +11476,7 @@ Throne of the Dead Three — Reveal the top ten cards of your library. Put a cre
                 <type>Emblem — Dovin</type>
                 <maintype>Emblem</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/7/a76ccde7-c78d-4f4a-9fe4-ad6986e2cb8e.jpg?1562639968">KLD</set>
+            <set picURL="https://api.scryfall.com/cards/a76ccde7-c78d-4f4a-9fe4-ad6986e2cb8e?format=image">KLD</set>
             <reverse-related exclude="exclude">Dovin Baan</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -11488,7 +11488,7 @@ Throne of the Dead Three — Reveal the top ten cards of your library. Put a cre
                 <type>Emblem — Ellywick</type>
                 <maintype>Emblem</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/2/8/289bd243-8754-49f8-a4f9-0be477c84ee1.jpg?1626139987">AFR</set>
+            <set picURL="https://api.scryfall.com/cards/289bd243-8754-49f8-a4f9-0be477c84ee1?format=image">AFR</set>
             <reverse-related>Ellywick Tumblestrum</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -11500,8 +11500,8 @@ Throne of the Dead Three — Reveal the top ten cards of your library. Put a cre
                 <type>Emblem — Elspeth</type>
                 <maintype>Emblem</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/8/3/8360fc12-57c0-4701-8e19-0878ed5abb4f.jpg">MD1</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/1/014c0557-11b8-49da-8486-0dd14b919338.jpg">MMA</set>
+            <set picURL="https://api.scryfall.com/cards/8360fc12-57c0-4701-8e19-0878ed5abb4f?format=image">MD1</set>
+            <set picURL="https://api.scryfall.com/cards/014c0557-11b8-49da-8486-0dd14b919338?format=image">MMA</set>
             <reverse-related exclude="exclude">Elspeth, Knight-Errant</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -11513,7 +11513,7 @@ Throne of the Dead Three — Reveal the top ten cards of your library. Put a cre
                 <type>Emblem — Elspeth</type>
                 <maintype>Emblem</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/7/177c37bd-c53d-43b2-88c4-0b80d17a5744.jpg">THS</set>
+            <set picURL="https://api.scryfall.com/cards/177c37bd-c53d-43b2-88c4-0b80d17a5744?format=image">THS</set>
             <reverse-related exclude="exclude">Elspeth, Sun's Champion</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -11525,7 +11525,7 @@ Throne of the Dead Three — Reveal the top ten cards of your library. Put a cre
                 <type>Emblem — Garruk</type>
                 <maintype>Emblem</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/a/5a6fa6ba-045a-43f8-8b04-579ffe24f927.jpg?1562639819">M15</set>
+            <set picURL="https://api.scryfall.com/cards/5a6fa6ba-045a-43f8-8b04-579ffe24f927?format=image">M15</set>
             <reverse-related exclude="exclude">Garruk, Apex Predator</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -11537,7 +11537,7 @@ Throne of the Dead Three — Reveal the top ten cards of your library. Put a cre
                 <type>Emblem — Garruk</type>
                 <maintype>Emblem</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/1/d16429cb-9b00-4411-9ffc-252b38ad0b8c.jpg">M14</set>
+            <set picURL="https://api.scryfall.com/cards/d16429cb-9b00-4411-9ffc-252b38ad0b8c?format=image">M14</set>
             <reverse-related exclude="exclude">Garruk, Caller of Beasts</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -11549,7 +11549,7 @@ Throne of the Dead Three — Reveal the top ten cards of your library. Put a cre
                 <type>Emblem</type>
                 <maintype>Emblem</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/6/d6c65749-1774-4b36-891e-abf762c95cec.jpg?1572489239">ELD</set>
+            <set picURL="https://api.scryfall.com/cards/d6c65749-1774-4b36-891e-abf762c95cec?format=image">ELD</set>
             <reverse-related exclude="exclude">Garruk, Cursed Huntsman</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -11561,7 +11561,7 @@ Throne of the Dead Three — Reveal the top ten cards of your library. Put a cre
                 <type>Emblem</type>
                 <maintype>Emblem</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/b/5/b572a46c-8bd0-4af8-bc76-2c65841c27b9.jpg?1622888316">M21</set>
+            <set picURL="https://api.scryfall.com/cards/b572a46c-8bd0-4af8-bc76-2c65841c27b9?format=image">M21</set>
             <reverse-related exclude="exclude">Garruk, Unleashed</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -11573,7 +11573,7 @@ Throne of the Dead Three — Reveal the top ten cards of your library. Put a cre
                 <type>Emblem — Gideon</type>
                 <maintype>Emblem</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/b/cbebd89c-0b29-44c7-bc99-53dd4b836520.jpg">AKH</set>
+            <set picURL="https://api.scryfall.com/cards/cbebd89c-0b29-44c7-bc99-53dd4b836520?format=image">AKH</set>
             <reverse-related exclude="exclude">Gideon of the Trials</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -11585,7 +11585,7 @@ Throne of the Dead Three — Reveal the top ten cards of your library. Put a cre
                 <type>Emblem — Gideon</type>
                 <maintype>Emblem</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/d/cd8be597-f402-4fb0-9135-897c4a0946f6.jpg">BFZ</set>
+            <set picURL="https://api.scryfall.com/cards/cd8be597-f402-4fb0-9135-897c4a0946f6?format=image">BFZ</set>
             <reverse-related exclude="exclude">Gideon, Ally of Zendikar</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -11597,7 +11597,7 @@ Throne of the Dead Three — Reveal the top ten cards of your library. Put a cre
                 <type>Emblem — Huatli</type>
                 <maintype>Emblem</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/8/5/859f645b-24e0-4c34-ae82-ba0ae9854377.jpg?1561757496">RIX</set>
+            <set picURL="https://api.scryfall.com/cards/859f645b-24e0-4c34-ae82-ba0ae9854377?format=image">RIX</set>
             <reverse-related>Huatli, Radiant Champion</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -11609,7 +11609,7 @@ Throne of the Dead Three — Reveal the top ten cards of your library. Put a cre
                 <type>Emblem — Jace</type>
                 <maintype>Emblem</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/4/5/458e37b1-a849-41ae-b63c-3e09ffd814e4.jpg">ORI</set>
+            <set picURL="https://api.scryfall.com/cards/458e37b1-a849-41ae-b63c-3e09ffd814e4?format=image">ORI</set>
             <reverse-related exclude="exclude">Jace, Telepath Unbound</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -11621,7 +11621,7 @@ Throne of the Dead Three — Reveal the top ten cards of your library. Put a cre
                 <type>Emblem — Jace</type>
                 <maintype>Emblem</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/7/a/7aa30438-3733-467e-aa31-f8e8ad2e62f3.jpg?1562086873">SOI</set>
+            <set picURL="https://api.scryfall.com/cards/7aa30438-3733-467e-aa31-f8e8ad2e62f3?format=image">SOI</set>
             <reverse-related exclude="exclude">Jace, Unraveler of Secrets</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -11633,7 +11633,7 @@ Throne of the Dead Three — Reveal the top ten cards of your library. Put a cre
                 <type>Emblem — Jaya</type>
                 <maintype>Emblem</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/8/f/8fcdb224-d4b3-4d99-abea-467def65ef42.jpg?1562702197">DOM</set>
+            <set picURL="https://api.scryfall.com/cards/8fcdb224-d4b3-4d99-abea-467def65ef42?format=image">DOM</set>
             <reverse-related>Jaya Ballard</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -11645,7 +11645,7 @@ Throne of the Dead Three — Reveal the top ten cards of your library. Put a cre
                 <type>Emblem</type>
                 <maintype>Emblem</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/2/4/243a5830-d7a0-46c9-98c0-4d1dfc3ebc8c.jpg?1658496386">DMU</set>
+            <set picURL="https://api.scryfall.com/cards/243a5830-d7a0-46c9-98c0-4d1dfc3ebc8c?format=image">DMU</set>
             <reverse-related>Jaya, Fiery Negotiator</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -11657,7 +11657,7 @@ Throne of the Dead Three — Reveal the top ten cards of your library. Put a cre
                 <type>Emblem</type>
                 <maintype>Emblem</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/f/df296190-e51b-44a7-ae83-279fee3151a5.jpg?1644543190">NEO</set>
+            <set picURL="https://api.scryfall.com/cards/df296190-e51b-44a7-ae83-279fee3151a5?format=image">NEO</set>
             <reverse-related>Kaito Shizuki</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -11669,7 +11669,7 @@ Throne of the Dead Three — Reveal the top ten cards of your library. Put a cre
                 <type>Emblem — Kaya</type>
                 <maintype>Emblem</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/2/b/2b149bbf-5d2a-4f7e-aa87-23edd5848cde.jpg?1615686871">KHM</set>
+            <set picURL="https://api.scryfall.com/cards/2b149bbf-5d2a-4f7e-aa87-23edd5848cde?format=image">KHM</set>
             <reverse-related exclude="exclude">Kaya the Inexorable</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -11681,7 +11681,7 @@ Throne of the Dead Three — Reveal the top ten cards of your library. Put a cre
                 <type>Emblem — Kiora</type>
                 <maintype>Emblem</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/5/55952cc8-09d8-4260-8387-284df7223d74.jpg">BFZ</set>
+            <set picURL="https://api.scryfall.com/cards/55952cc8-09d8-4260-8387-284df7223d74?format=image">BFZ</set>
             <reverse-related exclude="exclude">Kiora, Master of the Depths</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -11693,7 +11693,7 @@ Throne of the Dead Three — Reveal the top ten cards of your library. Put a cre
                 <type>Emblem — Kiora</type>
                 <maintype>Emblem</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/e/4/e45f7850-2ebb-4530-9859-f87b4e0e27be.jpg">BNG</set>
+            <set picURL="https://api.scryfall.com/cards/e45f7850-2ebb-4530-9859-f87b4e0e27be?format=image">BNG</set>
             <related>Kraken Token</related>
             <reverse-related exclude="exclude">Kiora, the Crashing Wave</reverse-related>
             <token>1</token>
@@ -11706,7 +11706,7 @@ Throne of the Dead Three — Reveal the top ten cards of your library. Put a cre
                 <type>Emblem — Koth</type>
                 <maintype>Emblem</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/8/9/89afdaa4-3555-4adf-b3c4-63f905710c76.jpg">DDI</set>
+            <set picURL="https://api.scryfall.com/cards/89afdaa4-3555-4adf-b3c4-63f905710c76?format=image">DDI</set>
             <reverse-related exclude="exclude">Koth of the Hammer</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -11718,7 +11718,7 @@ Throne of the Dead Three — Reveal the top ten cards of your library. Put a cre
                 <type>Emblem</type>
                 <maintype>Emblem</maintype>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/4/7/4746f904-67f3-450d-93f6-172b3fd50057.jpg?1675097314">ONE</set>
+            <set picURL="https://api.scryfall.com/cards/4746f904-67f3-450d-93f6-172b3fd50057?format=image">ONE</set>
             <reverse-related>Koth, Fire of Resistance</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -11730,8 +11730,8 @@ Throne of the Dead Three — Reveal the top ten cards of your library. Put a cre
                 <type>Emblem — Liliana</type>
                 <maintype>Emblem</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/f/3/f327de6e-c9f1-478d-9940-b500df8cef10.jpg">M14</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/2/b/2bd1b0b9-f1bb-4808-be3f-5b3faf185cf1.jpg">M13</set>
+            <set picURL="https://api.scryfall.com/cards/f327de6e-c9f1-478d-9940-b500df8cef10?format=image">M14</set>
+            <set picURL="https://api.scryfall.com/cards/2bd1b0b9-f1bb-4808-be3f-5b3faf185cf1?format=image">M13</set>
             <reverse-related exclude="exclude">Liliana of the Dark Realms</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -11743,7 +11743,7 @@ Throne of the Dead Three — Reveal the top ten cards of your library. Put a cre
                 <type>Emblem — Liliana</type>
                 <maintype>Emblem</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/7/d75f984f-2e11-4f52-b3b0-dd9d94a2dd74.jpg">ORI</set>
+            <set picURL="https://api.scryfall.com/cards/d75f984f-2e11-4f52-b3b0-dd9d94a2dd74?format=image">ORI</set>
             <reverse-related exclude="exclude">Liliana, Defiant Necromancer</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -11755,7 +11755,7 @@ Throne of the Dead Three — Reveal the top ten cards of your library. Put a cre
                 <type>Emblem — Liliana</type>
                 <maintype>Emblem</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/5/1512fe7b-5e01-424e-9747-8d4840a5d22a.jpg?1562636740">EMN</set>
+            <set picURL="https://api.scryfall.com/cards/1512fe7b-5e01-424e-9747-8d4840a5d22a?format=image">EMN</set>
             <related count="x=2">Zombie Token</related>
             <reverse-related exclude="exclude">Liliana, the Last Hope</reverse-related>
             <token>1</token>
@@ -11768,7 +11768,7 @@ Throne of the Dead Three — Reveal the top ten cards of your library. Put a cre
                 <type>Emblem</type>
                 <maintype>Emblem</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/9/6/968f207e-8e60-4dad-935c-71e0267c2399.jpg?1594733792">M21</set>
+            <set picURL="https://api.scryfall.com/cards/968f207e-8e60-4dad-935c-71e0267c2399?format=image">M21</set>
             <reverse-related>Liliana, Waker of the Dead</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -11780,7 +11780,7 @@ Throne of the Dead Three — Reveal the top ten cards of your library. Put a cre
                 <type>Emblem — Lolth</type>
                 <maintype>Emblem</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/3/c34001fd-0e9b-445b-9c0b-381721dfebc2.jpg?1626140029">AFR</set>
+            <set picURL="https://api.scryfall.com/cards/c34001fd-0e9b-445b-9c0b-381721dfebc2?format=image">AFR</set>
             <reverse-related exclude="exclude">Lolth, Spider Queen</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -11792,7 +11792,7 @@ Throne of the Dead Three — Reveal the top ten cards of your library. Put a cre
                 <type>Emblem — Lukka</type>
                 <maintype>Emblem</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/e/1e090a47-3187-44f2-9dea-c2bc1407b053.jpg?1641306163">STX</set>
+            <set picURL="https://api.scryfall.com/cards/1e090a47-3187-44f2-9dea-c2bc1407b053?format=image">STX</set>
             <reverse-related>Lukka, Wayward Bonder</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -11804,7 +11804,7 @@ Throne of the Dead Three — Reveal the top ten cards of your library. Put a cre
                 <type>Emblem — Mordenkainen</type>
                 <maintype>Emblem</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/7/c/7c63f14a-db47-46aa-addf-7c6fc40169b9.jpg?1626140066">AFR</set>
+            <set picURL="https://api.scryfall.com/cards/7c63f14a-db47-46aa-addf-7c6fc40169b9?format=image">AFR</set>
             <reverse-related exclude="exclude">Mordenkainen</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -11816,7 +11816,7 @@ Throne of the Dead Three — Reveal the top ten cards of your library. Put a cre
                 <type>Emblem</type>
                 <maintype>Emblem</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/d/cdc0849c-3a2b-4666-8fa9-755f3ea27706.jpg?1592516026">M20</set>
+            <set picURL="https://api.scryfall.com/cards/cdc0849c-3a2b-4666-8fa9-755f3ea27706?format=image">M20</set>
             <reverse-related exclude="exclude">Mu Yanling, Sky Dancer</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -11828,7 +11828,7 @@ Throne of the Dead Three — Reveal the top ten cards of your library. Put a cre
                 <type>Emblem — Narset</type>
                 <maintype>Emblem</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/e/0e573150-9f7e-4398-8997-aecb6057a020.jpg?1591225613">IKO</set>
+            <set picURL="https://api.scryfall.com/cards/0e573150-9f7e-4398-8997-aecb6057a020?format=image">IKO</set>
             <reverse-related exclude="exclude">Narset of the Ancient Way</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -11840,7 +11840,7 @@ Throne of the Dead Three — Reveal the top ten cards of your library. Put a cre
                 <type>Emblem — Narset</type>
                 <maintype>Emblem</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/4/a/4a70dfe0-874c-473a-a26e-1f88a842df41.jpg">DTK</set>
+            <set picURL="https://api.scryfall.com/cards/4a70dfe0-874c-473a-a26e-1f88a842df41?format=image">DTK</set>
             <reverse-related exclude="exclude">Narset Transcendent</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -11852,7 +11852,7 @@ Throne of the Dead Three — Reveal the top ten cards of your library. Put a cre
                 <type>Emblem — Nissa</type>
                 <maintype>Emblem</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/4/54986eaa-1bbb-4d34-ae09-fa7de2627ba0.jpg?1562639808">KLD</set>
+            <set picURL="https://api.scryfall.com/cards/54986eaa-1bbb-4d34-ae09-fa7de2627ba0?format=image">KLD</set>
             <reverse-related exclude="exclude">Nissa, Vital Force</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -11864,7 +11864,7 @@ Throne of the Dead Three — Reveal the top ten cards of your library. Put a cre
                 <type>Emblem — Nissa</type>
                 <maintype>Emblem</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/6/56b191fe-7a92-4d08-91a4-036699d08bc4.jpg?1557575997">WAR</set>
+            <set picURL="https://api.scryfall.com/cards/56b191fe-7a92-4d08-91a4-036699d08bc4?format=image">WAR</set>
             <reverse-related>Nissa, Who Shakes the World</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -11876,7 +11876,7 @@ Throne of the Dead Three — Reveal the top ten cards of your library. Put a cre
                 <type>Emblem — Nixilis</type>
                 <maintype>Emblem</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/4/c/4c29f6a1-42a5-433f-9c09-c160b096f8e1.jpg">C14</set>
+            <set picURL="https://api.scryfall.com/cards/4c29f6a1-42a5-433f-9c09-c160b096f8e1?format=image">C14</set>
             <reverse-related exclude="exclude">Ob Nixilis of the Black Oath</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -11888,8 +11888,8 @@ Throne of the Dead Three — Reveal the top ten cards of your library. Put a cre
                 <type>Emblem — Nixilis</type>
                 <maintype>Emblem</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/c/ac90d130-0d98-4e55-90ee-93c2fe8c1ed0.jpg?1568003581">C19</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/8/18a77885-c0de-4487-a920-6fb9ea9bc408.jpg">BFZ</set>
+            <set picURL="https://api.scryfall.com/cards/ac90d130-0d98-4e55-90ee-93c2fe8c1ed0?format=image">C19</set>
+            <set picURL="https://api.scryfall.com/cards/18a77885-c0de-4487-a920-6fb9ea9bc408?format=image">BFZ</set>
             <reverse-related exclude="exclude">Ob Nixilis Reignited</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -11901,7 +11901,7 @@ Throne of the Dead Three — Reveal the top ten cards of your library. Put a cre
                 <type>Emblem — Ral</type>
                 <maintype>Emblem</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/3/03580d3a-4c02-4f2e-b667-f82028ccde0b.jpg?1572892519">GRN</set>
+            <set picURL="https://api.scryfall.com/cards/03580d3a-4c02-4f2e-b667-f82028ccde0b?format=image">GRN</set>
             <reverse-related>Ral, Izzet Viceroy</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -11913,8 +11913,8 @@ Throne of the Dead Three — Reveal the top ten cards of your library. Put a cre
                 <type>Emblem — Rowan</type>
                 <maintype>Emblem</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/b/5b2f81ee-f258-40c4-abc6-0c80421b0837.jpg?1654172327">CLB</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/6/a603338e-8ea4-4952-b88f-97d439594ad9.jpg">BBD</set>
+            <set picURL="https://api.scryfall.com/cards/5b2f81ee-f258-40c4-abc6-0c80421b0837?format=image">CLB</set>
+            <set picURL="https://api.scryfall.com/cards/a603338e-8ea4-4952-b88f-97d439594ad9?format=image">BBD</set>
             <reverse-related exclude="exclude">Rowan Kenrith</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -11926,7 +11926,7 @@ Throne of the Dead Three — Reveal the top ten cards of your library. Put a cre
                 <type>Emblem — Rowan</type>
                 <maintype>Emblem</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/c/cc18b93e-b590-4fbb-be47-d63a25cde811.jpg?1644879927">STX</set>
+            <set picURL="https://api.scryfall.com/cards/cc18b93e-b590-4fbb-be47-d63a25cde811?format=image">STX</set>
             <reverse-related>Rowan, Scholar of Sparks</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -11939,7 +11939,7 @@ Artifact spells you cast cost {1} less to cast.</text>
                 <type>Emblem</type>
                 <maintype>Emblem</maintype>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/9/0/9020571d-97fb-4f46-85ec-6cb3141bfc87.jpg?1667887140">BRO</set>
+            <set picURL="https://api.scryfall.com/cards/9020571d-97fb-4f46-85ec-6cb3141bfc87?format=image">BRO</set>
             <reverse-related exclude="exclude">Saheeli, Filigree Master</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -11952,7 +11952,7 @@ At the beginning of your end step, discard your hand.</text>
                 <type>Emblem — Sarkhan</type>
                 <maintype>Emblem</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/9/d/9d0430bc-5b7e-431e-a8d0-168f679fe79c.jpg">KTK</set>
+            <set picURL="https://api.scryfall.com/cards/9d0430bc-5b7e-431e-a8d0-168f679fe79c?format=image">KTK</set>
             <reverse-related exclude="exclude">Sarkhan, the Dragonspeaker</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -11964,7 +11964,7 @@ At the beginning of your end step, discard your hand.</text>
                 <type>Emblem — Serra</type>
                 <maintype>Emblem</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/8/7/87dbb0b0-d898-491a-8ed9-efefca04e6e6.jpg?1563073252">MH1</set>
+            <set picURL="https://api.scryfall.com/cards/87dbb0b0-d898-491a-8ed9-efefca04e6e6?format=image">MH1</set>
             <reverse-related exclude="exclude">Serra the Benevolent</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -11976,7 +11976,7 @@ At the beginning of your end step, discard your hand.</text>
                 <type>Emblem — Sorin</type>
                 <maintype>Emblem</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/3/2/327ddaaf-b6a7-4c80-9b38-5ab68181b3d6.jpg">DKA</set>
+            <set picURL="https://api.scryfall.com/cards/327ddaaf-b6a7-4c80-9b38-5ab68181b3d6?format=image">DKA</set>
             <reverse-related exclude="exclude">Sorin, Lord of Innistrad</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -11988,7 +11988,7 @@ At the beginning of your end step, discard your hand.</text>
                 <type>Emblem — Sorin</type>
                 <maintype>Emblem</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/8/f/8f6e8950-5b1e-48b6-8d32-2a463455499d.jpg">KTK</set>
+            <set picURL="https://api.scryfall.com/cards/8f6e8950-5b1e-48b6-8d32-2a463455499d?format=image">KTK</set>
             <reverse-related exclude="exclude">Sorin, Solemn Visitor</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -12000,7 +12000,7 @@ At the beginning of your end step, discard your hand.</text>
                 <type>Emblem — Tamiyo</type>
                 <maintype>Emblem</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/2/c2c6e29e-261a-4953-bdbe-cce8790eb5a8.jpg?1562636889">EMN</set>
+            <set picURL="https://api.scryfall.com/cards/c2c6e29e-261a-4953-bdbe-cce8790eb5a8?format=image">EMN</set>
             <reverse-related exclude="exclude">Tamiyo, Field Researcher</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -12013,7 +12013,7 @@ Whenever a card is put into your graveyard from anywhere, you may return it to y
                 <type>Emblem — Tamiyo</type>
                 <maintype>Emblem</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/c/cce7547c-6d3d-4586-83b2-3d208113b045.jpg">AVR</set>
+            <set picURL="https://api.scryfall.com/cards/cce7547c-6d3d-4586-83b2-3d208113b045?format=image">AVR</set>
             <reverse-related exclude="exclude">Tamiyo, the Moon Sage</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -12025,7 +12025,7 @@ Whenever a card is put into your graveyard from anywhere, you may return it to y
                 <type>Emblem — Teferi</type>
                 <maintype>Emblem</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/b/8/b82ac152-5df1-46c9-98e9-ad5585f7e799.jpg?1562702291">DOM</set>
+            <set picURL="https://api.scryfall.com/cards/b82ac152-5df1-46c9-98e9-ad5585f7e799?format=image">DOM</set>
             <reverse-related>Teferi, Hero of Dominaria</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -12037,7 +12037,7 @@ Whenever a card is put into your graveyard from anywhere, you may return it to y
                 <type>Emblem — Teferi</type>
                 <maintype>Emblem</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/c/ccdc8ec0-0c50-4eab-90b3-847498d1612c.jpg">C14</set>
+            <set picURL="https://api.scryfall.com/cards/ccdc8ec0-0c50-4eab-90b3-847498d1612c?format=image">C14</set>
             <reverse-related exclude="exclude">Teferi, Temporal Archmage</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -12050,7 +12050,7 @@ You draw a card during each opponent's end step.</text>
                 <type>Emblem</type>
                 <maintype>Emblem</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/9/a970bebc-08e1-4125-a4c5-8883dfd5a5ca.jpg?1641305885">MID</set>
+            <set picURL="https://api.scryfall.com/cards/a970bebc-08e1-4125-a4c5-8883dfd5a5ca?format=image">MID</set>
             <reverse-related>Teferi, Who Slows the Sunset</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -12062,7 +12062,7 @@ You draw a card during each opponent's end step.</text>
                 <type>Emblem — Tezzeret</type>
                 <maintype>Emblem</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/f/5f136537-1ebe-4018-b406-44ef32ceef04.jpg">AER</set>
+            <set picURL="https://api.scryfall.com/cards/5f136537-1ebe-4018-b406-44ef32ceef04?format=image">AER</set>
             <reverse-related exclude="exclude">Tezzeret the Schemer</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -12074,7 +12074,7 @@ You draw a card during each opponent's end step.</text>
                 <type>Emblem — Tezzeret</type>
                 <maintype>Emblem</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/f/a/faa83538-e94d-4842-ba9c-812187ecfa0b.jpg">M19</set>
+            <set picURL="https://api.scryfall.com/cards/faa83538-e94d-4842-ba9c-812187ecfa0b?format=image">M19</set>
             <reverse-related exclude="exclude">Tezzeret, Artifice Master</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -12086,7 +12086,7 @@ You draw a card during each opponent's end step.</text>
                 <type>Emblem</type>
                 <maintype>Emblem</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/b/d/bdb4fa32-18dd-4530-a529-5477e45413dd.jpg?1644543224">NEO</set>
+            <set picURL="https://api.scryfall.com/cards/bdb4fa32-18dd-4530-a529-5477e45413dd?format=image">NEO</set>
             <reverse-related>Tezzeret, Betrayer of Flesh</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -12098,7 +12098,7 @@ You draw a card during each opponent's end step.</text>
                 <type>Emblem — Tibalt</type>
                 <maintype>Emblem</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/6/c62490ac-4838-4b68-baff-18d9823a2a7f.jpg?1615686895">KHM</set>
+            <set picURL="https://api.scryfall.com/cards/c62490ac-4838-4b68-baff-18d9823a2a7f?format=image">KHM</set>
             <reverse-related>Tibalt, Cosmic Impostor</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -12110,7 +12110,7 @@ You draw a card during each opponent's end step.</text>
                 <type>Emblem — Tyvar</type>
                 <maintype>Emblem</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/3/53162f62-5327-4f2d-8f34-e90de2a1c818.jpg?1615686922">KHM</set>
+            <set picURL="https://api.scryfall.com/cards/53162f62-5327-4f2d-8f34-e90de2a1c818?format=image">KHM</set>
             <reverse-related exclude="exclude">Tyvar Kell</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -12122,7 +12122,7 @@ You draw a card during each opponent's end step.</text>
                 <type>Emblem — Venser</type>
                 <maintype>Emblem</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/9/c9ad6e7a-8ad8-4a35-b6c9-151720d88af9.jpg">DDI</set>
+            <set picURL="https://api.scryfall.com/cards/c9ad6e7a-8ad8-4a35-b6c9-151720d88af9?format=image">DDI</set>
             <reverse-related exclude="exclude">Venser, the Sojourner</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -12134,7 +12134,7 @@ You draw a card during each opponent's end step.</text>
                 <type>Emblem — Vivien</type>
                 <maintype>Emblem</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/c/1cf97003-eef0-4c01-aee1-8a8264d8ef95.jpg">M19</set>
+            <set picURL="https://api.scryfall.com/cards/1cf97003-eef0-4c01-aee1-8a8264d8ef95?format=image">M19</set>
             <reverse-related exclude="exclude">Vivien Reid</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -12146,7 +12146,7 @@ You draw a card during each opponent's end step.</text>
                 <type>Emblem — Vraska</type>
                 <maintype>Emblem</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/d/8/d81478ee-1ddf-44f5-98a0-df6d4eecad7e.jpg?1572892526">GRN</set>
+            <set picURL="https://api.scryfall.com/cards/d81478ee-1ddf-44f5-98a0-df6d4eecad7e?format=image">GRN</set>
             <reverse-related>Vraska, Golgari Queen</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -12158,8 +12158,8 @@ You draw a card during each opponent's end step.</text>
                 <type>Emblem — Will</type>
                 <maintype>Emblem</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/3/d/3de08752-9fc4-4e6b-b30b-2d9d33a1e37b.jpg?1654172317">CLB</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/6/0/606d6a38-e564-45d8-9be1-c83c15647711.jpg">BBD</set>
+            <set picURL="https://api.scryfall.com/cards/3de08752-9fc4-4e6b-b30b-2d9d33a1e37b?format=image">CLB</set>
+            <set picURL="https://api.scryfall.com/cards/606d6a38-e564-45d8-9be1-c83c15647711?format=image">BBD</set>
             <reverse-related exclude="exclude">Will Kenrith</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -12171,7 +12171,7 @@ You draw a card during each opponent's end step.</text>
                 <type>Emblem</type>
                 <maintype>Emblem</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/6/c62eda69-f0c2-4977-8603-150d5d4bec49.jpg?1641305887">MID</set>
+            <set picURL="https://api.scryfall.com/cards/c62eda69-f0c2-4977-8603-150d5d4bec49?format=image">MID</set>
             <reverse-related exclude="exclude">Wrenn and Seven</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -12183,7 +12183,7 @@ You draw a card during each opponent's end step.</text>
                 <type>Emblem — Wrenn</type>
                 <maintype>Emblem</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/8/58c8a9fc-755a-4bff-8e13-41fbf4d9e546.jpg?1563073269">MH1</set>
+            <set picURL="https://api.scryfall.com/cards/58c8a9fc-755a-4bff-8e13-41fbf4d9e546?format=image">MH1</set>
             <reverse-related exclude="exclude">Wrenn and Six</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -12195,7 +12195,7 @@ You draw a card during each opponent's end step.</text>
                 <type>Emblem — Zariel</type>
                 <maintype>Emblem</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/3/c36520c3-627a-40b9-a5c7-42cc4c813b67.jpg?1626140108">AFR</set>
+            <set picURL="https://api.scryfall.com/cards/c36520c3-627a-40b9-a5c7-42cc4c813b67?format=image">AFR</set>
             <reverse-related exclude="exclude">Zariel, Archduke of Avernus</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -12207,7 +12207,7 @@ You draw a card during each opponent's end step.</text>
                 <type>Counter</type>
                 <maintype>Counter</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/e/8/e8fb396f-3ae1-4705-bf94-3e1b0556e910.jpg?1604842479">UND</set>
+            <set picURL="https://api.scryfall.com/cards/e8fb396f-3ae1-4705-bf94-3e1b0556e910?format=image">UND</set>
             <reverse-related exclude="exclude">Acornelia, Fashionable Filcher</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -12218,7 +12218,7 @@ You draw a card during each opponent's end step.</text>
                 <type>Counter</type>
                 <maintype>Counter</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/4/a446b9f8-cb22-408a-93ff-bee44a0dccc0.jpg?1604831723">KLD</set>
+            <set picURL="https://api.scryfall.com/cards/a446b9f8-cb22-408a-93ff-bee44a0dccc0?format=image">KLD</set>
             <reverse-related exclude="exclude">Aether Chaser</reverse-related>
             <reverse-related exclude="exclude">Aether Herder</reverse-related>
             <reverse-related exclude="exclude">Aether Hub</reverse-related>
@@ -12299,7 +12299,7 @@ You draw a card during each opponent's end step.</text>
                 <type>Counter</type>
                 <maintype>Counter</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/7/3/73805b39-7624-4fbd-bcc0-4241e733a97f.jpg?1554069468">C15</set>
+            <set picURL="https://api.scryfall.com/cards/73805b39-7624-4fbd-bcc0-4241e733a97f?format=image">C15</set>
             <reverse-related exclude="exclude">Daxos the Returned</reverse-related>
             <reverse-related exclude="exclude">Ezuri, Claw of Progress</reverse-related>
             <reverse-related exclude="exclude">Kalemne, Disciple of Iroas</reverse-related>
@@ -12317,10 +12317,10 @@ You draw a card during each opponent's end step.</text>
                 <type>Counter</type>
                 <maintype>Counter</maintype>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/4/0/40255bfa-0004-45f1-a31b-17d385f09a95.jpg?1675096257">ONE</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/4/7/470618f6-f67f-44c6-a086-285632508915.jpg">NPH</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/9/2/92fcdd2b-dd90-458d-9b8b-5b1b9a3f8bd3.jpg">MBS</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/8/5/856e308d-6268-4311-9667-c2f761db8f99.jpg">SOM</set>
+            <set picURL="https://api.scryfall.com/cards/40255bfa-0004-45f1-a31b-17d385f09a95?format=image">ONE</set>
+            <set picURL="https://api.scryfall.com/cards/470618f6-f67f-44c6-a086-285632508915?format=image">NPH</set>
+            <set picURL="https://api.scryfall.com/cards/92fcdd2b-dd90-458d-9b8b-5b1b9a3f8bd3?format=image">MBS</set>
+            <set picURL="https://api.scryfall.com/cards/856e308d-6268-4311-9667-c2f761db8f99?format=image">SOM</set>
             <reverse-related exclude="exclude">Annex Sentry</reverse-related>
             <reverse-related exclude="exclude">Aspirant's Ascent</reverse-related>
             <reverse-related exclude="exclude">Bilious Skulldweller</reverse-related>
@@ -12454,7 +12454,7 @@ You draw a card during each opponent's end step.</text>
                 <type>Counter</type>
                 <maintype>Counter</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/5/2/52942a5c-0552-4a9b-9c0f-7a9ffd04d0af.jpg?1664344308">UNF</set>
+            <set picURL="https://api.scryfall.com/cards/52942a5c-0552-4a9b-9c0f-7a9ffd04d0af?format=image">UNF</set>
             <reverse-related exclude="exclude">Aerialephant</reverse-related>
             <reverse-related exclude="exclude">Ambassador Blorpityblorpboop</reverse-related>
             <reverse-related exclude="exclude">Animate Object</reverse-related>
@@ -12493,7 +12493,7 @@ You draw a card during each opponent's end step.</text>
                 <type>State</type>
                 <maintype>State</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/b/a/ba64ed3e-93c5-406f-a38d-65cc68472122.jpg?1561757924">RIX</set>
+            <set picURL="https://api.scryfall.com/cards/ba64ed3e-93c5-406f-a38d-65cc68472122?format=image">RIX</set>
             <reverse-related>Arch of Orazca</reverse-related>
             <reverse-related>Deadeye Brawler</reverse-related>
             <reverse-related>Dusk Charger</reverse-related>
@@ -12529,7 +12529,7 @@ If a player casts no spells during their own turn, it becomes night next turn.</
                 <type>State</type>
                 <maintype>State</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/9/c/9c0f7843-4cbb-4d0f-8887-ec823a9238da.jpg?1630606483">MID</set>
+            <set picURL="https://api.scryfall.com/cards/9c0f7843-4cbb-4d0f-8887-ec823a9238da?format=image">MID</set>
             <reverse-related exclude="exclude">Arlinn, the Pack's Hope</reverse-related>
             <related>Night</related>
             <reverse-related>Baneblade Scoundrel</reverse-related>
@@ -12573,7 +12573,7 @@ If a player casts at least two spells during their own turn, it becomes day next
                 <type>State</type>
                 <maintype>State</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/back/9/c/9c0f7843-4cbb-4d0f-8887-ec823a9238da.jpg?1630606483">MID</set>
+            <set picURL="https://api.scryfall.com/cards/9c0f7843-4cbb-4d0f-8887-ec823a9238da?format=image&amp;face=back">MID</set>
             <related>Day</related>
             <reverse-related>Unnatural Moonrise</reverse-related>
             <token>1</token>
@@ -12586,7 +12586,7 @@ If a player casts at least two spells during their own turn, it becomes day next
                 <type>State</type>
                 <maintype>State</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/f/b/fb02637f-1385-4d3d-8dc0-de513db7633a.jpg?1615690969">KHM</set>
+            <set picURL="https://api.scryfall.com/cards/fb02637f-1385-4d3d-8dc0-de513db7633a?format=image">KHM</set>
             <reverse-related exclude="exclude">Alrund's Epiphany</reverse-related>
             <reverse-related exclude="exclude">Augury Raven</reverse-related>
             <reverse-related exclude="exclude">Battle Mammoth</reverse-related>
@@ -12639,7 +12639,7 @@ When you take the initiative and at the beginning of your upkeep, venture into U
                 <type>State</type>
                 <maintype>State</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/2/c/2c65185b-6cf0-451d-985e-56aa45d9a57d.jpg?1654853128">CLB</set>
+            <set picURL="https://api.scryfall.com/cards/2c65185b-6cf0-451d-985e-56aa45d9a57d?format=image">CLB</set>
             <related>Undercity</related>
             <reverse-related>Aarakocra Sneak</reverse-related>
             <reverse-related>Avenging Hunter</reverse-related>
@@ -12675,9 +12675,9 @@ Whenever a creature deals combat damage to you, its controller becomes the monar
                 <type>State</type>
                 <maintype>State</maintype>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/0/7/07e41000-f743-4928-bdc7-520b0824caec.jpg?1675905882">ONC</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/b/f/bf7f3fc9-35f1-4b8c-b02b-494c71f31107.jpg?1608908685">CMR</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/4/0/40b79918-22a7-4fff-82a6-8ebfe6e87185.jpg?1561897497">CN2</set>
+            <set picURL="https://api.scryfall.com/cards/07e41000-f743-4928-bdc7-520b0824caec?format=image">ONC</set>
+            <set picURL="https://api.scryfall.com/cards/bf7f3fc9-35f1-4b8c-b02b-494c71f31107?format=image">CMR</set>
+            <set picURL="https://api.scryfall.com/cards/40b79918-22a7-4fff-82a6-8ebfe6e87185?format=image">CN2</set>
             <reverse-related>Archon of Coronation</reverse-related>
             <reverse-related>Azure Fleet Admiral</reverse-related>
             <reverse-related>Canal Courier</reverse-related>
@@ -12719,7 +12719,7 @@ Whenever a creature deals combat damage to you, its controller becomes the monar
                 <type>State</type>
                 <maintype>State</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/8/a8d50cf9-03e6-467a-aadf-84a24106ffa9.jpg?1572489247">ELD</set>
+            <set picURL="https://api.scryfall.com/cards/a8d50cf9-03e6-467a-aadf-84a24106ffa9?format=image">ELD</set>
             <reverse-related attach="attach">Altar of Bhaal // Bone Offering</reverse-related>
             <reverse-related attach="attach">Amethyst Dragon // Explosive Crystal</reverse-related>
             <reverse-related attach="attach">Animating Faerie // Bring to Life</reverse-related>
@@ -12786,7 +12786,7 @@ Whenever a creature deals combat damage to you, its controller becomes the monar
                 <type>Companion</type>
                 <maintype>Companion</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/6/b/6b95e8bd-2686-4790-afeb-9b17d482f156.jpg?1600995556">IKO</set>
+            <set picURL="https://api.scryfall.com/cards/6b95e8bd-2686-4790-afeb-9b17d482f156?format=image">IKO</set>
             <reverse-related>Gyruda, Doom of Depths</reverse-related>
             <reverse-related>Jegantha, the Wellspring</reverse-related>
             <reverse-related>Kaheera, the Orphanguard</reverse-related>
@@ -12807,12 +12807,12 @@ Whenever a creature deals combat damage to you, its controller becomes the monar
                 <type>Token</type>
                 <maintype>Token</maintype>
             </prop>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/e/1e6ce56c-ca2e-48e8-a4d9-671cb4de8a9d.jpg?1650819612">SNC</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/c/7/c7ba6540-3743-445c-99bf-feb5af2fd56d.jpg?1641306129">C21</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/1/4/1420c92f-a3f5-461a-b342-3708fa2212d7.jpg?1608908660">CMR</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/0/6/06f62ebf-1600-4eaa-a998-3fd7d1ea2f65.jpg?1604195073">ZNR</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/6/8/6870a2af-80e1-4813-a332-2b1bd789f1c1.jpg?1598312480">2XM</set>
-            <set picURL="https://c1.scryfall.com/file/scryfall-cards/large/front/a/0/a020dc47-3747-4123-9954-f0e87a858b8c.jpg?1639374083">GK1</set>
+            <set picURL="https://api.scryfall.com/cards/1e6ce56c-ca2e-48e8-a4d9-671cb4de8a9d?format=image">SNC</set>
+            <set picURL="https://api.scryfall.com/cards/c7ba6540-3743-445c-99bf-feb5af2fd56d?format=image">C21</set>
+            <set picURL="https://api.scryfall.com/cards/1420c92f-a3f5-461a-b342-3708fa2212d7?format=image">CMR</set>
+            <set picURL="https://api.scryfall.com/cards/06f62ebf-1600-4eaa-a998-3fd7d1ea2f65?format=image">ZNR</set>
+            <set picURL="https://api.scryfall.com/cards/6870a2af-80e1-4813-a332-2b1bd789f1c1?format=image">2XM</set>
+            <set picURL="https://api.scryfall.com/cards/a020dc47-3747-4123-9954-f0e87a858b8c?format=image">GK1</set>
             <token>1</token>
             <tablerow>1</tablerow>
         </card>


### PR DESCRIPTION
Fixes https://github.com/Cockatrice/Magic-Token/issues/201 and should future proof the file against further link change. 

API requests adheres to Scryfall's [/cards/:id endpoint format](https://scryfall.com/docs/api/cards/id). Image size defaults to large and face defaults to front so only format=image and the occasional face=back need to be specified.

I have checked that this file works in Cockatrice (at least for as many tokens as I could stand to look at) but its a huge number of changes so its not impossible that something somewhere broke. I also specifically checked all the back sides had well-formed requests since they required extra bits stuck on the end. 