### PR TITLE
Add image to banana token

### DIFF
--- a/tokens.xml
+++ b/tokens.xml
@@ -504,7 +504,7 @@ Creature tokens you control have flying and vigilance.</text>
                 <maintype>Artifact</maintype>
                 <cmc>0</cmc>
             </prop>
-            <set>J22</set>
+            <set picURL="https://github.com/SlightlyCircuitous/image-storage/blob/main/Banana.jpeg?raw=true">J22</set>
             <reverse-related>Kibo, Uktabi Prince</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>


### PR DESCRIPTION
Fixes https://github.com/Cockatrice/Magic-Token/issues/214


The picture used for the card is a public domain picture of a bunch of bananas with a GIMP olify filter applied. I have credited the person who uploaded the picture to Wikimedia Commons anyway.