### PR TITLE
Add picture to J22 Zeppelin token

### DIFF
--- a/tokens.xml
+++ b/tokens.xml
@@ -11455,7 +11455,7 @@ Whenever you cast a creature spell, note one of its creature types that hasn't b
                 <cmc>0</cmc>
                 <pt>5/5</pt>
             </prop>
-            <set>J22</set>
+            <set picURL="https://github.com/SlightlyCircuitous/image-storage/blob/main/Zeppelin.jpeg?raw=true">J22</set>
             <reverse-related>Lita, Mechanical Engineer</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>


### PR DESCRIPTION
*Progress on issue https://github.com/Cockatrice/Magic-Token/issues/85
*Adds custom art for the Zeppelin vehicle token made by Lita, Mechanical Engineer

The card art is from the relatively recent painting “The Convoy Brook” by Adolf Dehn, though Wikimedia Commons assures me that it is in the public domain in the US as it was produced by a government employee as a federal museum piece.