### PR TITLE
Add ARC Scheme Tokens

### DIFF
--- a/tokens.xml
+++ b/tokens.xml
@@ -3219,7 +3219,7 @@ When Earthshaker Khenra enters the battlefield, target creature with power less 
                 <cmc>0</cmc>
                 <pt>3/3</pt>
             </prop>
-            <set>ARC</set>
+            <set picURL="https://github.com/SlightlyCircuitous/image-storage/blob/main/Elemental.jpeg?raw=true">ARC</set>
             <reverse-related count="7" exclude="exclude">Evil Comes to Fruition</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -4356,7 +4356,7 @@ At the beginning of your upkeep, this creature deals 1 damage to you.</text>
                 <cmc>0</cmc>
                 <pt>4/6</pt>
             </prop>
-            <set>ARC</set>
+            <set picURL="https://github.com/SlightlyCircuitous/image-storage/blob/main/Golem.jpeg?raw=true">ARC</set>
             <reverse-related>The Iron Guardian Stirs</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>


### PR DESCRIPTION
*Progress towards https://github.com/Cockatrice/Magic-Token/issues/85
*Adds a 4/6 golem token and a 3/3 elemental token for The Iron Guardian Stirs and Evil Comes to Fruition, respectively

I looked high and low for some good public domain art to make these tokens with, but I could not find anything suitable, so both these tokens merely use art from their respective cards. I don't know if this is actually a problem for anyone but me, so I figured I would just make this PR and see if anyone raises any objections.