### PR TITLE
CI: Small change in version update action

### DIFF
--- a/.github/workflows/updateversion.yml
+++ b/.github/workflows/updateversion.yml
@@ -5,6 +5,8 @@ on:
     types: [submitted]
   issue_comment:
     types: [created]
+  pull_request:
+    paths: '.github/workflows/updateversion.yml'
 
 jobs:
   update_version:
@@ -22,7 +24,8 @@ jobs:
           github.event.comment.author_association == 'MEMBER'
         ) &&
         endsWith( github.event.comment.body, '@github-actions update version' )
-      )
+      ) ||
+      ( github.event_name == 'pull_request' )
     runs-on: ubuntu-latest
     steps:
       - name: Get proper pr info
@@ -136,6 +139,7 @@ jobs:
           echo "$VERSION" >version.txt
 
       - name: Push changes
+        if: github.event_name != 'pull_request'
         shell: bash
         env:
           REPO_PAGE: ${{steps.configure.outputs.page}}


### PR DESCRIPTION
- Run action on PR's changing/updating the action config.
  Useful to verify changes, and see if e.g. dependency updates break it:
E.g. in #240 there is no test run triggered

- Prevent it to push changes in such cases

<br>

Note: Just realized that this action is outdated and uses old commands:

>Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

That needs a fix in a different PR.