### PR TITLE
CI: Keep image links up to date

### DIFF
--- a/.github/workflows/update_links.yml
+++ b/.github/workflows/update_links.yml
@@ -1,0 +1,66 @@
+name: Image URLs
+
+on:
+  workflow_dispatch:
+  schedule:
+    # runs in the middle of each month
+    - cron: '0 0 15 * *'
+  pull_request:
+    branches: [ master ]
+    paths:
+      - '.github/workflows/update_links.yml'
+      - 'scripts/update_image_links.py'
+
+jobs:
+  update_links:
+    # Do not run the scheduled workflow on forks
+    if: github.event_name != 'schedule' || github.repository_owner == 'Cockatrice'
+
+    name: Update links
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Query Scryfall API and update picURLs
+        shell: bash
+        working-directory: ./scripts
+        run: python3 update_image_links.py ../tokens.xml --inplace
+
+      - name: Create pull request
+        if: github.event_name != 'pull_request'
+        id: create_pr
+        uses: peter-evans/create-pull-request@v5
+        with:
+          add-paths: |
+            tokens.xml
+          commit-message: Update image links
+          # author is the owner of the commit
+          author: github-actions <github-actions@github.com>
+          branch: ci-update_image_links
+          delete-branch: true
+          title: 'Update image links'
+          body: |
+            Update all picURLs in the `tokens.xml` file via Scryfall API.
+            
+            ---
+            *This PR is automatically generated and updated by the workflow at `.github/workflows/update_links.yml`. Review [action runs][1].*<br>
+            
+            [1]: https://github.com/Cockatrice/Magic-Token/actions/workflows/update_links.yml?query=branch%3Amaster
+          labels: |
+            CI
+          draft: false
+
+      - name: PR Status
+        if: github.event_name != 'pull_request'
+        shell: bash
+        env:
+          STATUS: ${{ steps.create_pr.outputs.pull-request-operation }}
+        run: |
+          if [[ "$STATUS" == "" ]]; then
+            echo "PR #${{ steps.create_pr.outputs.pull-request-number }} unchanged!" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "PR #${{ steps.create_pr.outputs.pull-request-number }} $STATUS!" >> $GITHUB_STEP_SUMMARY
+          fi
+          echo "URL: ${{ steps.create_pr.outputs.pull-request-url }}" >> $GITHUB_STEP_SUMMARY

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,13 @@
+## Scripts
+
+[`update_image_links`](https://github.com/Cockatrice/Magic-Token/blob/master/scripts/update_image_links.py)  
+This script changes the links from the old CDN on c1.scryfall.com to the new CDN on cards.scryfall.io.  
+It reads a tokens.xml file containing CDN picURLs of either version, makes requests to the Scryfall API
+to receive the most up-to-date URLs for each token, and generates an output file.  
+`--inplace / -i` will update the input file  
+`--output / -o` will create a new file of your choice
+
+Basic call to run the script:
+```
+python3 update_image_links.py tokens.xml -i
+```

--- a/scripts/update_image_links.py
+++ b/scripts/update_image_links.py
@@ -1,6 +1,6 @@
 """
-This script parses a token.xml file, collects the picURLs within, and replaces
-the URLs to Scryfall cards with up-to-date URLs by querying Scryfall's API.
+This script parses a token.xml file, collects the picURLs of cards within, and replaces
+the links to Scryfall images with up-to-date URLs by querying Scryfall's API.
 """
 
 from xml.sax import saxutils, make_parser, handler


### PR DESCRIPTION
Run the script introduced in #209 on a schedule.
It will check for updated links in the tokens.xml file once a month (15th) and create a PR with the new URLs.

The way PR creation is handled is the same as in the Cockatrice main repo for translation updates btw.

This also moves the script, and adds a small README.

@Elarnon FYI, let me know of any thoughts!