### PR TITLE
Replace set-output in updateversion.yml

### DIFF
--- a/.github/workflows/updateversion.yml
+++ b/.github/workflows/updateversion.yml
@@ -101,6 +101,7 @@ jobs:
         id: version
         shell: python
         run: |
+          import os
           import re
           previous = "${{steps.date.outputs.previous}}"
           date = "${{steps.date.outputs.date}}"
@@ -124,7 +125,8 @@ jobs:
             else:
               charlist.append("a")
             version += "".join(reversed(charlist))
-          print(f"::set-output name=version::{version}")
+          with open(os.environ['GITHUB_OUTPUT'], 'a') as envFile:
+            print(f"version={version}", file=envFile)
 
       - name: Update date in files
         if: steps.check.outputs.update == 'true'

--- a/.github/workflows/updateversion.yml
+++ b/.github/workflows/updateversion.yml
@@ -125,7 +125,7 @@ jobs:
             else:
               charlist.append("a")
             version += "".join(reversed(charlist))
-          with open(os.environ['GITHUB_OUTPUT'], 'a') as envFile:
+          with open(os.environ["GITHUB_OUTPUT"], "a") as envFile:
             print(f"version={version}", file=envFile)
 
       - name: Update date in files

--- a/.github/workflows/updateversion.yml
+++ b/.github/workflows/updateversion.yml
@@ -51,11 +51,11 @@ jobs:
             UPSTREAM="$(jq -r ".base.repo.clone_url" "$tmp")"
             LINK="${{github.event.issue.html_url}}"
           fi
-          echo "::set-output name=link::$LINK"
-          echo "::set-output name=ref::$REF"
-          echo "::set-output name=page::$REPO_PAGE"
-          echo "::set-output name=name::$REPO_NAME"
-          echo "::set-output name=upstream::$UPSTREAM"
+          echo "link=$LINK" >> $GITHUB_OUTPUT
+          echo "ref=$REF" >> $GITHUB_OUTPUT
+          echo "page=$REPO_PAGE" >> $GITHUB_OUTPUT
+          echo "name=$REPO_NAME" >> $GITHUB_OUTPUT
+          echo "upstream=$UPSTREAM" >> $GITHUB_OUTPUT
 
       - name: Checkout pull request
         uses: actions/checkout@v4
@@ -79,9 +79,9 @@ jobs:
             echo "::notice::you can resolve merge conflicts at $LINK/conflicts"
             exit 2
           elif git diff --quiet FETCH_HEAD tokens.xml; then
-            echo "::set-output name=update::false"
+            echo "update=false" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=update::true"
+            echo "update=true" >> $GITHUB_OUTPUT
           fi
 
       - name: Get date
@@ -93,8 +93,8 @@ jobs:
           previous="$(<version.txt)"
           date="$(date --utc +%Y%m%d)"
           echo "it is currently $date"
-          echo "::set-output name=date::$date"
-          echo "::set-output name=previous::$previous"
+          echo "date=$date" >> $GITHUB_OUTPUT
+          echo "previous=$previous" >> $GITHUB_OUTPUT
 
       - name: Check for suffix used when multiple changes happen in a day
         if: steps.check.outputs.update == 'true'


### PR DESCRIPTION
- Fixes https://github.com/Cockatrice/Magic-Token/issues/262
- Updated the lines that use `set-output` in the beginning and in the Bash shell based on [Github's instructions ](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)
- Updated the line that uses `set-output` in the Python shell based on [this discussion](https://github.com/orgs/community/discussions/28146)

I'm not really sure how to test changes to Github Actions, so please let me know what I need to do to make sure the new code works.