### PR TITLE
Rework automated version bumps

### DIFF
--- a/.github/workflows/updateversion.yml
+++ b/.github/workflows/updateversion.yml
@@ -1,159 +1,83 @@
-name: Update version on pr approval
+name: Update version on tokens.xml changes
 
 on:
-  pull_request_review:
-    types: [submitted]
-  issue_comment:
-    types: [created]
-  pull_request:
-    paths: '.github/workflows/updateversion.yml'
+  push:
+    branches: [ master ]
+    paths:
+      - 'tokens.xml'
+
+concurrency:
+  group: version-bump-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   update_version:
-    if: >
-      ( github.event_name == 'pull_request_review' &&
-        github.event.review.state == 'approved' &&
-        ( github.event.review.author_association == 'OWNER' ||
-          github.event.review.author_association == 'MEMBER'
-        ) &&
-        ! contains( github.event.review.body, '@github-actions noop' )
-      ) ||
-      ( github.event_name == 'issue_comment' &&
-        github.event.issue.pull_request &&
-        ( github.event.comment.author_association == 'OWNER' ||
-          github.event.comment.author_association == 'MEMBER'
-        ) &&
-        endsWith( github.event.comment.body, '@github-actions update version' )
-      ) ||
-      ( github.event_name == 'pull_request' )
+    if: "!startsWith(github.event.head_commit.message, 'Update version to ')"
     runs-on: ubuntu-latest
     steps:
-      - name: Get proper pr info
-        id: configure
-        env:
-          EVENT: ${{github.event_name}}
-          NUMBER: ${{github.event.issue.number}}
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-          REF: ${{github.event.pull_request.head.ref}}
-          REPO_PAGE: ${{github.event.pull_request.head.repo.svn_url}}
-          REPO_NAME: ${{github.event.pull_request.head.repo.full_name}}
-          UPSTREAM: ${{github.event.pull_request.base.repo.clone_url}}
-          LINK: ${{github.event.pull_request.html}}
-        run: |
-          if [[ $EVENT == "issue_comment" ]]; then
-            tmp="$(mktemp)"
-            api="$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/pulls/$NUMBER"
-            echo "fetching $api"
-            gh api "$api" >"$tmp"
-            REF="$(jq -r ".head.ref" "$tmp")"
-            REPO_PAGE="$(jq -r ".head.repo.svn_url" "$tmp")"
-            REPO_NAME="$(jq -r ".head.repo.full_name" "$tmp")"
-            UPSTREAM="$(jq -r ".base.repo.clone_url" "$tmp")"
-            LINK="${{github.event.issue.html_url}}"
-          fi
-          echo "link=$LINK" >> $GITHUB_OUTPUT
-          echo "ref=$REF" >> $GITHUB_OUTPUT
-          echo "page=$REPO_PAGE" >> $GITHUB_OUTPUT
-          echo "name=$REPO_NAME" >> $GITHUB_OUTPUT
-          echo "upstream=$UPSTREAM" >> $GITHUB_OUTPUT
-
-      - name: Checkout pull request
+      - name: Checkout repo
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          repository: ${{steps.configure.outputs.name}}
-          ref: ${{steps.configure.outputs.ref}}
 
-      - name: Check for changes
-        id: check
-        shell: bash
-        env:
-          UPSTREAM: ${{steps.configure.outputs.upstream}}
-          LINK: ${{steps.configure.outputs.link}}
-        run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
-          git fetch "$UPSTREAM"
-          if ! git merge FETCH_HEAD; then
-            echo "::error::failed to merge pull request"
-            echo "::notice::you can resolve merge conflicts at $LINK/conflicts"
-            exit 2
-          elif git diff --quiet FETCH_HEAD tokens.xml; then
-            echo "update=false" >> $GITHUB_OUTPUT
-          else
-            echo "update=true" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Get date
-        if: steps.check.outputs.update == 'true'
-        id: date
+      - name: Get previous version
+        id: get_versions
         shell: bash
         run: |
-          git checkout FETCH_HEAD version.txt
-          previous="$(<version.txt)"
-          date="$(date --utc +%Y%m%d)"
-          echo "it is currently $date"
-          echo "date=$date" >> $GITHUB_OUTPUT
-          echo "previous=$previous" >> $GITHUB_OUTPUT
+          old_version="$(<version.txt)"
+          current_date="$(date --utc +%Y%m%d)"
+          echo "old_version=$old_version" >> $GITHUB_OUTPUT
+          echo "current_date=$current_date" >> $GITHUB_OUTPUT
 
-      - name: Check for suffix used when multiple changes happen in a day
-        if: steps.check.outputs.update == 'true'
-        id: version
+      - name: Compute new version
+        id: compute_version
         shell: python
         run: |
-          import os
-          import re
-          previous = "${{steps.date.outputs.previous}}"
-          date = "${{steps.date.outputs.date}}"
-          version = date
-          if previous.startswith(date):
-            match = re.search(r"[a-z]+", previous)
-            if match is None:
-              suffix = "a" # the first a is actually hidden
-            else:
-              suffix = match[0]
-            charlist = []
-            rev = reversed(suffix)
-            for char in rev:
-              if char == "z":
-                charlist.append("a")
+          import os, re
+          old_version = "${{steps.get_versions.outputs.old_version}}"
+          current_date = "${{steps.get_versions.outputs.current_date}}"
+          new_version = current_date
+          if old_version.startswith(current_date):
+              match = re.search(r"[a-z]+", old_version)
+              if match is None:
+                  suffix = "a"   # the first a is actually hidden
               else:
-                nextchar = chr(ord(char) + 1)
-                charlist.append(nextchar)
-                charlist.extend(rev)
-                break
-            else:
-              charlist.append("a")
-            version += "".join(reversed(charlist))
+                  suffix = match[0]
+              charlist = []
+              rev = reversed(suffix)
+              for char in rev:
+                  if char == "z":
+                      charlist.append("a")
+                  else:
+                      nextchar = chr(ord(char) + 1)
+                      charlist.append(nextchar)
+                      charlist.extend(rev)
+                      break
+              else:
+                  charlist.append("a")
+              new_version += "".join(reversed(charlist))
           with open(os.environ["GITHUB_OUTPUT"], "a") as envFile:
-            print(f"version={version}", file=envFile)
+              print(f"new_version={new_version}", file=envFile)
 
-      - name: Update date in files
-        if: steps.check.outputs.update == 'true'
+      - name: Update version in files
         shell: bash
         env:
-          VERSION: ${{steps.version.outputs.version}}
-          PREVIOUS: ${{steps.date.outputs.previous}}
+          VERSION_OLD: ${{steps.get_versions.outputs.old_version}}
+          VERSION_NEW: ${{steps.compute_version.outputs.new_version}}
         run: |
-          echo "updating version from $PREVIOUS to $VERSION"
+          echo "Updating version from $VERSION_OLD to $VERSION_NEW"
           tag="sourceVersion"
-          sed -i "s?<$tag>.*</$tag>?<$tag>$VERSION</$tag>?" tokens.xml
-          echo "$VERSION" >version.txt
+          sed -i "s?<$tag>.*</$tag>?<$tag>$VERSION_NEW</$tag>?" tokens.xml
+          echo "$VERSION_NEW" >version.txt
 
-      - name: Push changes
-        if: github.event_name != 'pull_request'
+      - name: Commit and push changes
         shell: bash
         env:
-          REPO_PAGE: ${{steps.configure.outputs.page}}
-          VERSION: ${{steps.version.outputs.version}}
+          VERSION_NEW: ${{steps.compute_version.outputs.new_version}}
         run: |
-          if git diff --quiet tokens.xml; then
-            echo "there are no changes to tokens.xml"
-            echo "::notice::no commit created"
-            exit 0
-          fi
+          echo "::notice::Triggering commit: https://github.com/${GITHUB_REPOSITORY}/commit/$GITHUB_SHA"
+          git config user.name github-actions
+          git config user.email github-actions@github.com
           git add tokens.xml version.txt
-          git commit -m "update version to $VERSION"
+          git commit -m "Update version to $VERSION_NEW" -m "Bump triggered by commit $GITHUB_SHA"
           git push
-          commit="$(git rev-parse HEAD)"
-          echo "::notice::pushed commit: $REPO_PAGE/commit/$commit"
+          commit_hash="$(git rev-parse HEAD)"
+          echo "::notice::Pushed commit: https://github.com/${GITHUB_REPOSITORY}/commit/$commit_hash"


### PR DESCRIPTION
Fixes #220

The script and comparison logic is kept unchanged, but the workflow around changed.

Pushes a new version to master branch for each change to the tokens.xml file on the same.
The workflow only runs for pushes that are not created by itself by checking the commit message to prevent loops.