### PR TITLE
Update Schema URI to https

### DIFF
--- a/tokens.xml
+++ b/tokens.xml
@@ -4,7 +4,7 @@
     We have made a new user-editable file for token modifications.
     Currently this file is "TK.xml" and can be found in your customsets directory.
 -->
-<cockatrice_carddatabase version="4" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/Cockatrice/Cockatrice/master/doc/carddatabase_v4/cards.xsd">
+<cockatrice_carddatabase version="4" xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/Cockatrice/Cockatrice/master/doc/carddatabase_v4/cards.xsd">
     <info>
         <author>Cockatrice/Magic-Token</author>
         <createdAt></createdAt>


### PR DESCRIPTION
The picture health checker threw an error about using http in https://github.com/Cockatrice/Magic-Token/pull/313 and exited abruptly. I am updating the URI to avoid the error, please let me know if there is some reason we cannot use https here. I vaguely remember there being a reason, maybe?