### PR TITLE
Update certain DMU tokens to match set symbol

### DIFF
--- a/tokens.xml
+++ b/tokens.xml
@@ -391,7 +391,7 @@ When Angel of Sanctions enters the battlefield, you may exile target nonland per
             <set picURL="https://cards.scryfall.io/large/front/b/b/bb2b69c0-ba32-4db1-bf02-230b6d4802aa.jpg?1742506183">TDC</set>
             <set picURL="https://cards.scryfall.io/large/front/1/a/1a0d80ce-9397-4c6d-9a07-31172d46f42a.jpg?1699017102">LCI</set>
             <set picURL="https://cards.scryfall.io/large/front/0/d/0dd269c7-1333-470d-b8ef-e54add09b350.jpg?1675905855">ONC</set>
-            <set picURL="https://cards.scryfall.io/large/front/f/8/f8ed0c17-c5e4-4d78-8eee-34c57dd7ce55.jpg?1675456162">DMU</set>
+            <set picURL="https://cards.scryfall.io/large/front/f/8/f8ed0c17-c5e4-4d78-8eee-34c57dd7ce55.jpg?1675456162">DMC</set>
             <set picURL="https://cards.scryfall.io/large/front/f/f/ff898688-0a49-4411-85f4-dddaa40788b5.jpg?1651801073">NEC</set>
             <set picURL="https://cards.scryfall.io/large/front/9/1/91808554-23ab-44f9-92a1-87ee7d58cd9a.jpg?1563073000">MH1</set>
             <set picURL="https://cards.scryfall.io/large/front/b/1/b16b81e0-5525-4be3-96db-807146fdc5b3.jpg?1557575869">WAR</set>
@@ -761,7 +761,7 @@ Creature tokens you control have flying and vigilance.</text>
                 <cmc>0</cmc>
                 <pt>3/3</pt>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/4/e/4e42cb2e-578f-4fec-a9a4-33b95b78229c.jpg?1675456276">DMU</set>
+            <set picURL="https://cards.scryfall.io/large/front/4/e/4e42cb2e-578f-4fec-a9a4-33b95b78229c.jpg?1675456276">DMC</set>
             <reverse-related>Greensleeves, Maro-Sorcerer</reverse-related>
             <reverse-related count="x" exclude="exclude">Greensleeves, Maro-Sorcerer</reverse-related>
             <token>1</token>
@@ -1989,7 +1989,7 @@ Whenever this creature attacks, target attacking creature gains flying until end
                 <cmc>0</cmc>
                 <pt>2/2</pt>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/d/8/d886263e-9f46-4389-a543-947d6e51cb1a.jpg?1675456295">DMU</set>
+            <set picURL="https://cards.scryfall.io/large/front/d/8/d886263e-9f46-4389-a543-947d6e51cb1a.jpg?1675456295">DMC</set>
             <set picURL="https://cards.scryfall.io/large/front/0/7/0742ca95-9455-4f56-b26c-2994d12af602.jpg?1592710075">C18</set>
             <set picURL="https://cards.scryfall.io/large/front/2/9/29c4e4f2-0040-4490-b357-660d729ad9cc.jpg?1562636772">C17</set>
             <reverse-related>Jedit Ojanen of Efrava</reverse-related>
@@ -7676,7 +7676,7 @@ Flanking</text>
                 <cmc>0</cmc>
                 <pt>2/2</pt>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/1/9/19e893e5-12a8-4ecb-adcd-9e7b26b01de2.jpg?1675456178">DMU</set>
+            <set picURL="https://cards.scryfall.io/large/front/1/9/19e893e5-12a8-4ecb-adcd-9e7b26b01de2.jpg?1675456178">DMC</set>
             <reverse-related>Rasputin, the Oneiromancer</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -7741,7 +7741,7 @@ Flanking</text>
             <set picURL="https://cards.scryfall.io/large/front/0/a/0a8bc802-2b33-44eb-b93b-624709790279.jpg?1706130357">MKC</set>
             <set picURL="https://cards.scryfall.io/large/front/0/e/0ec422fe-b53e-4ae4-9fab-df2b78134098.jpg?1682211053">MOC</set>
             <set picURL="https://cards.scryfall.io/large/front/6/7/67615047-1b17-4dc1-80d2-2d5da109db94.jpg?1675905868">ONC</set>
-            <set picURL="https://cards.scryfall.io/large/front/7/4/74f7dd3d-dbb9-4cbd-8d06-381cb6a0de33.jpg?1675456258">DMU</set>
+            <set picURL="https://cards.scryfall.io/large/front/7/4/74f7dd3d-dbb9-4cbd-8d06-381cb6a0de33.jpg?1675456258">DMC</set>
             <set picURL="https://cards.scryfall.io/large/front/3/c/3c9bfd0a-9a31-4191-a615-a747cbca2015.jpg?1675456020">CLB</set>
             <set picURL="https://cards.scryfall.io/large/front/4/f/4f4e8e64-7caa-4d98-8e20-0a4a20056143.jpg?1641306038">TSR</set>
             <set picURL="https://cards.scryfall.io/large/front/d/f/dfc03591-1114-4e36-a397-0bb3db8a153c.jpg?1562702392">A25</set>
@@ -8245,7 +8245,7 @@ Flying, vigilance, trample, lifelink, haste</text>
             </prop>
             <set picURL="https://cards.scryfall.io/large/front/c/6/c63ce61b-480a-4da6-80f6-63e096902ae6.jpg?1706217007">MKM</set>
             <set picURL="https://cards.scryfall.io/large/front/5/b/5b551cd5-430f-4ff8-9aae-b0614eae7baa.jpg?1698873742">LCC</set>
-            <set picURL="https://cards.scryfall.io/large/front/1/b/1bad1c90-a3ea-469e-ba0b-91c75ea5b1a3.jpg?1675456194">DMU</set>
+            <set picURL="https://cards.scryfall.io/large/front/1/b/1bad1c90-a3ea-469e-ba0b-91c75ea5b1a3.jpg?1675456194">DMC</set>
             <set picURL="https://cards.scryfall.io/large/front/f/b/fb1b292b-2da6-4601-9f93-5eb273ce3a50.jpg?1562636943">ZEN</set>
             <reverse-related>A Killer Among Us</reverse-related>
             <reverse-related>Emperor Mihail II</reverse-related>
@@ -10748,7 +10748,7 @@ Equip {1}</text>
             </prop>
             <set picURL="https://cards.scryfall.io/large/front/1/7/17812f4e-a10c-472b-970f-35a8f392235a.jpg?1717194127">M3C</set>
             <set picURL="https://cards.scryfall.io/large/front/f/3/f3e51b4d-3859-48c2-a409-0fc096a6d484.jpg?1712320029">OTC</set>
-            <set picURL="https://cards.scryfall.io/large/front/1/2/124ea959-742a-4914-9bca-1075ccd0cb22.jpg?1675456322">DMU</set>
+            <set picURL="https://cards.scryfall.io/large/front/1/2/124ea959-742a-4914-9bca-1075ccd0cb22.jpg?1675456322">DMC</set>
             <reverse-related count="x=5">Desert Warfare</reverse-related>
             <reverse-related count="x">Hazezon Tamar</reverse-related>
             <reverse-related count="2">Hazezon, Shaper of Sand</reverse-related>
@@ -12852,7 +12852,7 @@ Cumulative upkeep {G}</text>
                 <cmc>0</cmc>
                 <pt>3/4</pt>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/e/d/edc84f49-86e9-43a2-b98c-a59b1e0c72ed.jpg?1675456330">DMU</set>
+            <set picURL="https://cards.scryfall.io/large/front/e/d/edc84f49-86e9-43a2-b98c-a59b1e0c72ed.jpg?1675456330">DMC</set>
             <set picURL="https://cards.scryfall.io/large/front/e/b/eba90d37-d7ac-4097-a04d-1f27e4c9e5de.jpg?1562702416">A25</set>
             <reverse-related>Stangg</reverse-related>
             <reverse-related>Stangg, Echo Warrior</reverse-related>
@@ -13485,7 +13485,7 @@ This creature can't be enchanted.</text>
             <set picURL="https://cards.scryfall.io/large/front/4/6/46a2c363-c879-4c36-b08a-dd57e3da19ae.jpg?1705562958">LTR</set>
             <set picURL="https://cards.scryfall.io/large/front/8/6/86e82686-0574-4fb3-8c3b-c6dbe3b24c8d.jpg?1682207166">MOM</set>
             <set picURL="https://cards.scryfall.io/large/front/f/a/fab1ec58-5299-4604-8feb-212a6c5e7ffd.jpg?1675456928">UNF</set>
-            <set picURL="https://cards.scryfall.io/large/front/5/5/55c46e7d-a436-4e61-9fea-d725787b43a9.jpg?1675456468">DMU</set>
+            <set picURL="https://cards.scryfall.io/large/front/5/5/55c46e7d-a436-4e61-9fea-d725787b43a9.jpg?1675456468">DMC</set>
             <set picURL="https://cards.scryfall.io/large/front/7/7/770b988d-4f31-4746-8c23-4ed8d9a6b393.jpg?1675455871">CLB</set>
             <set picURL="https://cards.scryfall.io/large/front/1/b/1be23c27-d8b6-4f59-8ab8-9ce80e9e29dd.jpg?1674337949">SNC</set>
             <set picURL="https://cards.scryfall.io/large/front/b/8/b883958b-1d82-4c1a-9f19-ab20fc01d5f4.jpg?1674337952">SNC</set>
@@ -15170,7 +15170,7 @@ Equip {1}</text>
                 <cmc>0</cmc>
                 <pt>4/4</pt>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/e/d/edcfb468-6389-4e72-80af-d0d4442e6988.jpg?1675456312">DMU</set>
+            <set picURL="https://cards.scryfall.io/large/front/e/d/edcfb468-6389-4e72-80af-d0d4442e6988.jpg?1675456312">DMC</set>
             <reverse-related>Baru, Wurmspeaker</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -15396,7 +15396,7 @@ Equip {1}</text>
             <set picURL="https://cards.scryfall.io/large/front/4/c/4cf9feeb-23c3-4c3b-bc04-f50380d20197.jpg?1689976407">CMM</set>
             <set picURL="https://cards.scryfall.io/large/front/e/b/eb7b2c61-b903-4669-b9a3-110418a35593.jpg?1682207004">MOM</set>
             <set picURL="https://cards.scryfall.io/large/front/c/7/c700cb99-1cee-455f-9a36-d7d9a79fed06.jpg?1675198635">DMR</set>
-            <set picURL="https://cards.scryfall.io/large/front/d/a/dac26fe3-b44c-4385-ad74-d348c33e151c.jpg?1682554661">DMU</set>
+            <set picURL="https://cards.scryfall.io/large/front/d/a/dac26fe3-b44c-4385-ad74-d348c33e151c.jpg?1682554661">DMC</set>
             <set picURL="https://cards.scryfall.io/large/back/1/3/13e4832d-8530-4b85-b738-51d0c18f28ec.jpg?1651951882">CC2</set>
             <set picURL="https://cards.scryfall.io/large/front/c/8/c84e21cd-079d-493f-ab8d-e62f16ec1581.jpg?1675457482">VOW</set>
             <set picURL="https://cards.scryfall.io/large/front/0/b/0b08d210-01cb-46c5-9150-4dfb47f50ae7.jpg?1641306243">AFR</set>


### PR DESCRIPTION
Certain tokens listed under DMU have the DMC set symbol in their art (see https://github.com/Cockatrice/Magic-Token/pull/321 for why this is). This PR updates their set codes to match.