### PR TITLE
Fix CLB Ox color

### DIFF
--- a/tokens.xml
+++ b/tokens.xml
@@ -9217,7 +9217,7 @@ Paradox — Whenever you cast a spell from anywhere other than your hand, invest
         <card>
             <name>Ox Token </name>
             <prop>
-                <colors>W</colors>
+                <colors>G</colors>
                 <type>Token Creature — Ox</type>
                 <maintype>Creature</maintype>
                 <cmc>0</cmc>


### PR DESCRIPTION
The CLB Ox token is green, not white.