### PR TITLE
Correct TFTH oracle text

### DIFF
--- a/tokens.xml
+++ b/tokens.xml
@@ -18450,7 +18450,7 @@ Rewards
         <card>
             <name>Shrieking Titan Head</name>
             <text>At the beginning of the Hydra's end step, each player discards a card.
-Hero's Reward — When Savage Vigor Head leaves the battlefield, each player gains 4 life and draws a card.</text>
+Hero's Reward — When Shrieking Titan Head leaves the battlefield, each player gains 4 life and draws a card.</text>
             <prop>
                 <cmc>0</cmc>
                 <type>Elite Creature — Head</type>
@@ -18462,7 +18462,7 @@ Hero's Reward — When Savage Vigor Head leaves the battlefield, each player gai
         <card>
             <name>Snapping Fang Head</name>
             <text>At the beginning of the Hydra's end step, Snapping Fang Head deals 1 damage to each player.
-Hero's Reward — When Savage Vigor Head leaves the battlefield, each player gains 4 life and draws a card.</text>
+Hero's Reward — When Snapping Fang Head leaves the battlefield, each player gains 4 life and draws a card.</text>
             <prop>
                 <cmc>0</cmc>
                 <type>Elite Creature — Head</type>


### PR DESCRIPTION
Corrected two of the Head cards that were incorrectly referring to 'Vigor Head' and 'Savage Vigor Head' rather than their names.