### PR TITLE
Add reminder token for warped cards

### DIFF
--- a/tokens.xml
+++ b/tokens.xml
@@ -17863,8 +17863,8 @@ If a player casts at least two spells during their own turn, it becomes day next
             <reverse-related attach="attach" exclude="exclude">Rayblade Trooper</reverse-related>
             <reverse-related attach="attach">Red Tiger Mechan</reverse-related>
             <reverse-related attach="attach">Sinister Cryologist</reverse-related>
-            <reverse-related attach="attach" exclude="exclude">Sliver Weftwinder</reverse-related>
             <reverse-related exclude="exclude">Sliver Weftwinder</reverse-related>
+            <reverse-related attach="attach" exclude="exclude">Sliver Weftwinder</reverse-related>
             <reverse-related attach="attach">Spirited Simulacrum</reverse-related>
             <reverse-related attach="attach">Starbreach Whale</reverse-related>
             <reverse-related attach="attach">Starfield Shepherd</reverse-related>


### PR DESCRIPTION
Warped cards can be cast from exile, but WotC did not print a reminder card like Adventure or Foretell cards. Users requested a way to denoted warped cards in the Discord and I have attempted to oblige.