### PR TITLE
Move surrogate 'Phyrexian' tokens to their normal entries

### DIFF
--- a/tokens.xml
+++ b/tokens.xml
@@ -1018,6 +1018,7 @@ Creature tokens you control have flying and vigilance.</text>
             <set picURL="https://cards.scryfall.io/large/front/d/2/d2bfef17-6e00-4097-b27a-4e3c7e19ca03.jpg?1682211062">MOC</set>
             <set picURL="https://cards.scryfall.io/large/front/f/5/f55c70b8-0fa5-4d08-9061-f53d6f949908.jpg?1653273209">MID</set>
             <set picURL="https://cards.scryfall.io/large/front/a/1/a1eff7f8-b645-41cb-bcd9-3dc1ab10200e.jpg?1641306190">MH2</set>
+            <set picURL="https://cards.scryfall.io/large/front/0/6/06b5e4d2-7eac-4ee9-82aa-80a668705679.jpg?1641306088">C21</set>
             <set picURL="https://cards.scryfall.io/large/front/5/0/50d90039-6e75-4c76-893d-cd1686a36be9.jpg?1620573811">CMR</set>
             <set picURL="https://cards.scryfall.io/large/front/e/9/e952eed6-0243-4f32-b6a5-64c2d3ab0ef8.jpg?1591319203">C20</set>
             <set picURL="https://cards.scryfall.io/large/front/9/9/99f37b65-06ec-47dc-a299-6e65d1254995.jpg?1572370715">C19</set>
@@ -5730,9 +5731,13 @@ At the beginning of your upkeep, this creature deals 1 damage to you.</text>
             <set picURL="https://cards.scryfall.io/large/front/b/c/bc1c56b2-69f3-42d9-81f4-3dbd40dd8f5d.jpg?1752946440">EOC</set>
             <set picURL="https://cards.scryfall.io/large/front/4/0/406e2960-f560-48bb-b4a6-4bd35889a8f8.jpg?1712318018">BIG</set>
             <set picURL="https://cards.scryfall.io/large/front/9/6/96d831eb-8d5f-4436-bbc6-3d1a90f3d2ed.jpg?1682211141">MOC</set>
+	        <set picURL="https://cards.scryfall.io/large/front/a/f/af7c6e4c-4980-4b1b-8156-fd17dd6f47c9.jpg?1608908566">CMR</set>
             <set picURL="https://cards.scryfall.io/large/front/7/b/7becaa04-f142-4163-9286-00018b95c4ca.jpg?1601138543">2XM</set>
             <set picURL="https://cards.scryfall.io/large/front/7/8/78ea4711-a951-4a1b-88cb-f628f97b6164.jpg?1592516001">M20</set>
+            <set picURL="https://cards.scryfall.io/large/front/d/c/dc77b308-9d0c-492f-b3fe-e00d60470767.jpg?1563073222">MH1</set>
+            <set picURL="https://cards.scryfall.io/large/front/5/0/509be7b3-490d-4229-ba10-999921a6b977.jpg?1562841177">MM3</set>
             <set picURL="https://cards.scryfall.io/large/front/a/e/ae65394e-0c97-4cde-8591-13d081192e26.jpg?1562702257">MM2</set>
+            <set picURL="https://cards.scryfall.io/large/front/f/e/fe9e8d3b-ebc0-448b-bd14-a9f418e196e7.jpg?1561758492">NPH</set>
             <set picURL="https://cards.scryfall.io/large/front/c/7/c705b843-ca62-47bb-95dd-f303c60088bb.jpg?1562164868">SOM</set>
             <reverse-related>Cavalier of Dawn</reverse-related>
             <reverse-related>Golem Foundry</reverse-related>
@@ -8740,7 +8745,9 @@ A card with morph can be turned face up any time for its morph cost.)</text>
             <set picURL="https://cards.scryfall.io/large/front/f/3/f32ad93f-3fd5-465c-ac6a-6f8fb57c19bd.jpg?1561758422">BBD</set>
             <set picURL="https://cards.scryfall.io/large/front/7/9/799070d9-2e04-49a0-ba2d-fe149f23fa4a.jpg?1562919412">C16</set>
             <set picURL="https://cards.scryfall.io/large/front/c/1/c1a8c1a6-a88a-4b23-bd80-95769ea4917c.jpg?1562702314">MM2</set>
-            <set picURL="https://cards.scryfall.io/large/front/d/b/dbad9b20-0b13-41b9-a84a-06b691ee6c71.jpg?1562542415">C14</set>
+	        <set picURL="https://cards.scryfall.io/large/front/d/b/dbad9b20-0b13-41b9-a84a-06b691ee6c71.jpg?1562542415">C14</set>
+	        <set picURL="https://cards.scryfall.io/large/front/d/f/dfe197cf-6f36-424e-a544-cbe7a56f8a32.jpg?1561758258">MD1</set>
+            <set picURL="https://cards.scryfall.io/large/front/5/c/5c087beb-99c0-403e-bb44-33cfc549a831.jpg?1561757228">NPH</set>
             <set picURL="https://cards.scryfall.io/large/front/1/8/182308b3-86e0-46d8-9104-95576a3d3921.jpg?1562164855">SOM</set>
             <set picURL="https://cards.scryfall.io/large/front/1/8/187cf6d5-c352-48f2-b8bf-fe1bf946e2ac.jpg?1561756726">MRD</set>
             <reverse-related>Genesis Chamber</reverse-related>
@@ -9384,7 +9391,6 @@ Whenever a creature you control becomes the target of a spell or ability an oppo
             <set picURL="https://cards.scryfall.io/large/front/c/b/cb06a798-4808-476b-bc0f-1f432b431464.jpg?1726237832">DSC</set>
             <set picURL="https://cards.scryfall.io/large/front/2/e/2e981bbc-7690-4020-aa28-f06295ee8ff8.jpg?1689976104">CMM</set>
             <set picURL="https://cards.scryfall.io/large/front/6/5/65f64d14-c203-4401-a379-c6227d1cbac2.jpg?1675456067">CLB</set>
-            <set picURL="https://cards.scryfall.io/large/front/0/6/06b5e4d2-7eac-4ee9-82aa-80a668705679.jpg?1641306088">C21</set>
             <reverse-related count="x">Ezuri's Predation</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -9486,10 +9492,6 @@ Whenever a creature you control becomes the target of a spell or ability an oppo
             <set picURL="https://cards.scryfall.io/large/front/e/7/e7a91956-e351-4533-9f0d-4a578617f88b.jpg?1689883510">CMM</set>
             <set picURL="https://cards.scryfall.io/large/front/a/7/a760c72c-2883-492e-8d38-548825efdd00.jpg?1682211158">MOC</set>
             <set picURL="https://cards.scryfall.io/large/front/6/3/63ace2fa-8cfb-4641-a05c-d12830378e03.jpg?1675957569">ONE</set>
-            <set picURL="https://cards.scryfall.io/large/front/a/f/af7c6e4c-4980-4b1b-8156-fd17dd6f47c9.jpg?1608908566">CMR</set>
-            <set picURL="https://cards.scryfall.io/large/front/d/c/dc77b308-9d0c-492f-b3fe-e00d60470767.jpg?1563073222">MH1</set>
-            <set picURL="https://cards.scryfall.io/large/front/5/0/509be7b3-490d-4229-ba10-999921a6b977.jpg?1562841177">MM3</set>
-            <set picURL="https://cards.scryfall.io/large/front/f/e/fe9e8d3b-ebc0-448b-bd14-a9f418e196e7.jpg?1561758492">NPH</set>
             <reverse-related>Blade Splicer</reverse-related>
             <reverse-related>Conversion Chamber</reverse-related>
             <reverse-related count="x">Darksteel Splicer</reverse-related>
@@ -9518,11 +9520,6 @@ Whenever a creature you control becomes the target of a spell or ability an oppo
             <set picURL="https://cards.scryfall.io/large/front/a/a/aa53489d-7e4e-461c-9eed-406ecf7c7abc.jpg?1682211167">MOC</set>
             <set picURL="https://cards.scryfall.io/large/front/6/6/661297e0-f8cb-402c-be33-67d3d218ce98.jpg?1675905880">ONC</set>
             <set picURL="https://cards.scryfall.io/large/front/8/b/8baa11ac-c774-4faf-8bc3-e8e1fb945c01.jpg?1675456434">BRC</set>
-            <set picURL="https://cards.scryfall.io/large/front/7/d/7db68985-a1d5-4bd5-bfc6-c7208689d7df.jpg?1608908587">CMR</set>
-            <set picURL="https://cards.scryfall.io/large/front/6/1/6188c0f0-0346-46d4-8a45-ae2749bf246f.jpg?1572370790">C19</set>
-            <set picURL="https://cards.scryfall.io/large/front/a/e/ae98a532-2e83-46bc-b391-cc0ab20ea0da.jpg?1592710130">C18</set>
-            <set picURL="https://cards.scryfall.io/large/front/2/4/248ae300-40cc-4e6f-8fa6-2bd6ab85fee6.jpg?1562902339">C16</set>
-            <set picURL="https://cards.scryfall.io/large/front/5/a/5a4c5954-da2b-498a-9e86-eb4d6dc95cb8.jpg?1561757207">MBS</set>
             <reverse-related>Phyrexian Rebirth</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -9657,8 +9654,6 @@ This creature can't block.</text>
                 <pt>1/1</pt>
             </prop>
             <set picURL="https://cards.scryfall.io/large/front/f/4/f4ef9889-e61d-4733-b27c-9e78aea8e84b.jpg?1690040703">CMM</set>
-            <set picURL="https://cards.scryfall.io/large/front/d/f/dfe197cf-6f36-424e-a544-cbe7a56f8a32.jpg?1561758258">MD1</set>
-            <set picURL="https://cards.scryfall.io/large/front/5/c/5c087beb-99c0-403e-bb44-33cfc549a831.jpg?1561757228">NPH</set>
             <reverse-related>Myr Sire</reverse-related>
             <reverse-related>Parasitic Implant</reverse-related>
             <reverse-related count="x">Shrine of Loyal Legions</reverse-related>


### PR DESCRIPTION
As mentioned in https://github.com/Cockatrice/Magic-Token/issues/151, some tokens are listed under 'Phyrexian' entries that do not have a Phyrexian type line. With the release of recent Phyrexian-focused sets, some actual Phyrexian tokens now exist and no longer need their surrogates. 

This PR moves any surrogate token that has a Phyrexian reprint and also has a normal entry it could exist in instead. I'm not sure yet what to do with cards that don't have other entries to go to. The Horror tokens were already duplicated in the XML so I merely removed them.