### PR TITLE
Add On an Adventure relations to FIN/FIC cards

### DIFF
--- a/tokens.xml
+++ b/tokens.xml
@@ -18276,8 +18276,8 @@ Whenever a creature deals combat damage to you, its controller becomes the monar
             <reverse-related attach="attach">Lovestruck Beast // Heart's Desire</reverse-related>
             <reverse-related attach="attach">Merchant of the Vale // Haggle</reverse-related>
             <reverse-related attach="attach">Merfolk Secretkeeper // Venture Deeper</reverse-related>
-            <reverse-related attach="attach">Minecart Daredevil // Ride the Rails</reverse-related>
             <reverse-related attach="attach">Midgar, City of Mako // Reactor Raid</reverse-related>
+            <reverse-related attach="attach">Minecart Daredevil // Ride the Rails</reverse-related>
             <reverse-related attach="attach">Monster Manual // Zoological Study</reverse-related>
             <reverse-related attach="attach">Moonshae Pixie // Pixie Dust</reverse-related>
             <reverse-related attach="attach">Mosswood Dreadknight // Dread Whispers</reverse-related>


### PR DESCRIPTION
First reported in the discord. 

Adds On an Adventure reminder card relations to 6 new adventure cards in FIN and FIC. The two other adventure cards in these sets are reprints and already have relations in the XML.