### PR TITLE
Add SLD Token Printings

### DIFF
--- a/tokens.xml
+++ b/tokens.xml
@@ -332,7 +332,6 @@ When Angel of Sanctions enters the battlefield, you may exile target nonland per
                 <cmc>0</cmc>
                 <pt>4/4</pt>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/0/8/089874c5-4f1e-4d03-a4c5-50f6ac0814dd.jpg?1727916087" uuid="089874c5-4f1e-4d03-a4c5-50f6ac0814dd">SLD</set>
             <set picURL="https://cards.scryfall.io/large/front/b/b/bb6d0a6a-3007-47fc-a42c-3db311c9c41f.jpg?1726237011" uuid="bb6d0a6a-3007-47fc-a42c-3db311c9c41f">DSC</set>
             <set picURL="https://cards.scryfall.io/large/front/8/f/8fe9d826-2642-4dc8-9dfd-0526394d43ac.jpg?1717189965" uuid="8fe9d826-2642-4dc8-9dfd-0526394d43ac">MH3</set>
             <set picURL="https://cards.scryfall.io/large/front/b/1/b1b0c498-b457-4865-96da-a69647179456.jpg?1712319499" uuid="b1b0c498-b457-4865-96da-a69647179456">OTC</set>
@@ -344,6 +343,7 @@ When Angel of Sanctions enters the battlefield, you may exile target nonland per
             <set picURL="https://cards.scryfall.io/large/front/f/f/ff0335da-631f-46b8-bfa1-b2f210c91f5f.jpg?1598311447" uuid="ff0335da-631f-46b8-bfa1-b2f210c91f5f">2XM</set>
             <set picURL="https://cards.scryfall.io/large/front/9/e/9e12d954-3ec2-46e3-b01f-1fd63159e8a4.jpg?1594733473" uuid="9e12d954-3ec2-46e3-b01f-1fd63159e8a4">M21</set>
             <set picURL="https://cards.scryfall.io/large/front/2/9/29d42a00-299d-47d3-ba03-e63812d57931.jpg?1591319106" uuid="29d42a00-299d-47d3-ba03-e63812d57931">C20</set>
+            <set picURL="https://cards.scryfall.io/large/front/0/8/089874c5-4f1e-4d03-a4c5-50f6ac0814dd.jpg?1727916087" uuid="089874c5-4f1e-4d03-a4c5-50f6ac0814dd">SLD</set>
             <set picURL="https://cards.scryfall.io/large/front/6/a/6ac609aa-49d1-4330-b718-a90b0560da52.jpg?1592709988" uuid="6ac609aa-49d1-4330-b718-a90b0560da52">C18</set>
             <set picURL="https://cards.scryfall.io/large/front/1/6/1671013a-2c15-44f0-b4bc-057eb5f727db.jpg?1562701916" uuid="1671013a-2c15-44f0-b4bc-057eb5f727db">A25</set>
             <set picURL="https://cards.scryfall.io/large/back/e/2/e2235007-b02e-463b-95e1-a8bea74a0f9d.jpg?1571508092" uuid="e2235007-b02e-463b-95e1-a8bea74a0f9d">UST</set>
@@ -1567,7 +1567,6 @@ Whenever this creature attacks, target attacking creature gains flying until end
                 <maintype>Artifact</maintype>
                 <cmc>0</cmc>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/6/b/6b563165-b97f-42c6-82a8-65d8ee69e381.jpg?1762793559" uuid="6b563165-b97f-42c6-82a8-65d8ee69e381">SLD</set>
             <set picURL="https://cards.scryfall.io/large/front/f/9/f90d1006-e8f9-4f62-b58b-6e711129e992.jpg?1721428107" uuid="f90d1006-e8f9-4f62-b58b-6e711129e992">BLC</set>
             <set picURL="https://cards.scryfall.io/large/front/3/3/3364c1cf-e036-4ba2-a8ae-20e995610311.jpg?1717191968" uuid="3364c1cf-e036-4ba2-a8ae-20e995610311">MH3</set>
             <set picURL="https://cards.scryfall.io/large/front/2/4/24bd6040-0e3f-40fa-98e5-531e82af1b59.jpg?1712320077" uuid="24bd6040-0e3f-40fa-98e5-531e82af1b59">OTC</set>
@@ -1575,6 +1574,7 @@ Whenever this creature attacks, target attacking creature gains flying until end
             <set picURL="https://cards.scryfall.io/large/front/4/d/4d4b2e0c-0e81-4147-aeef-579491d7ebc2.jpg?1698873655" uuid="4d4b2e0c-0e81-4147-aeef-579491d7ebc2">LCC</set>
             <set picURL="https://cards.scryfall.io/large/front/a/c/ac2c781d-cbfe-4d01-be02-9f34fee5d839.jpg?1682211097" uuid="ac2c781d-cbfe-4d01-be02-9f34fee5d839">MOC</set>
             <set picURL="https://cards.scryfall.io/large/front/a/6/a6f374bc-cd29-469f-808a-6a6c004ee8aa.jpg?1675457554" uuid="a6f374bc-cd29-469f-808a-6a6c004ee8aa">VOW</set>
+            <set picURL="https://cards.scryfall.io/large/front/6/b/6b563165-b97f-42c6-82a8-65d8ee69e381.jpg?1762793559" uuid="6b563165-b97f-42c6-82a8-65d8ee69e381">SLD</set>
             <reverse-related>Anje, Maid of Dishonor</reverse-related>
             <reverse-related>Arterial Alchemy</reverse-related>
             <reverse-related>Belligerent Guest</reverse-related>
@@ -1925,8 +1925,8 @@ Whenever this creature attacks, target attacking creature gains flying until end
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/5/c/5c53bf06-f681-4d5c-b303-cc7c050f5b01.jpg?1727776176" uuid="5c53bf06-f681-4d5c-b303-cc7c050f5b01">SLD</set>
             <set picURL="https://cards.scryfall.io/large/front/f/b/fbdf8dc1-1b10-4fce-97b9-1f5600500cc1.jpg?1595212480" uuid="fbdf8dc1-1b10-4fce-97b9-1f5600500cc1">M21</set>
+            <set picURL="https://cards.scryfall.io/large/front/5/c/5c53bf06-f681-4d5c-b303-cc7c050f5b01.jpg?1727776176" uuid="5c53bf06-f681-4d5c-b303-cc7c050f5b01">SLD</set>
             <reverse-related>Rin and Seri, Inseparable</reverse-related>
             <reverse-related count="x">Waiting in the Weeds</reverse-related>
             <token>1</token>
@@ -1942,11 +1942,11 @@ Whenever this creature attacks, target attacking creature gains flying until end
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/3/4/340fb06f-4bb0-4d23-b08c-8b1da4a8c2ad.jpg?1575842281" uuid="340fb06f-4bb0-4d23-b08c-8b1da4a8c2ad">SLD</set>
-            <set picURL="https://cards.scryfall.io/large/front/2/5/255dcc91-7b3d-4b58-85f3-b21be805966e.jpg?1575842279" uuid="255dcc91-7b3d-4b58-85f3-b21be805966e">SLD</set>
             <set picURL="https://cards.scryfall.io/large/front/9/0/902fba98-92b7-461b-ac6e-29cb2c4e307f.jpg?1738355211" uuid="902fba98-92b7-461b-ac6e-29cb2c4e307f">DFT</set>
             <set picURL="https://cards.scryfall.io/large/front/8/6/86701490-17ac-4253-810d-6cfd7a46594c.jpg?1730485666" uuid="86701490-17ac-4253-810d-6cfd7a46594c">FDN</set>
             <set picURL="https://cards.scryfall.io/large/front/d/7/d754e09c-efc0-4536-9f2a-6bd7e2f860ab.jpg?1591225552" uuid="d754e09c-efc0-4536-9f2a-6bd7e2f860ab">IKO</set>
+            <set picURL="https://cards.scryfall.io/large/front/3/4/340fb06f-4bb0-4d23-b08c-8b1da4a8c2ad.jpg?1575842281" uuid="340fb06f-4bb0-4d23-b08c-8b1da4a8c2ad">SLD</set>
+            <set picURL="https://cards.scryfall.io/large/front/2/5/255dcc91-7b3d-4b58-85f3-b21be805966e.jpg?1575842279" uuid="255dcc91-7b3d-4b58-85f3-b21be805966e">SLD</set>
             <set picURL="https://cards.scryfall.io/large/front/b/3/b31f1580-5bba-4cef-b0c8-f2837a597b7d.jpg?1562702272" uuid="b31f1580-5bba-4cef-b0c8-f2837a597b7d">M19</set>
             <set picURL="https://cards.scryfall.io/large/front/a/f/af0086cd-56b5-450e-818c-e54f45d1a104.jpg?1562844817" uuid="af0086cd-56b5-450e-818c-e54f45d1a104">AKH</set>
             <reverse-related>Basri, Tomorrow's Champion</reverse-related>
@@ -3241,11 +3241,11 @@ When this creature dies, create a colorless Treasure artifact token.</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/e/5/e5d07ad5-0701-4696-91fd-87451997ef23.jpg?1727776183" uuid="e5d07ad5-0701-4696-91fd-87451997ef23">SLD</set>
             <set picURL="https://cards.scryfall.io/large/front/e/f/ef7e3418-03c0-4d27-9f96-6c898f2287ad.jpg?1742506221" uuid="ef7e3418-03c0-4d27-9f96-6c898f2287ad">TDC</set>
             <set picURL="https://cards.scryfall.io/large/front/5/d/5d8da5b2-7e02-494b-8686-c5845286d0b9.jpg?1730485673" uuid="5d8da5b2-7e02-494b-8686-c5845286d0b9">FDN</set>
             <set picURL="https://cards.scryfall.io/large/front/8/a/8aaf03be-294a-4539-954c-79853f4351a9.jpg?1706216959" uuid="8aaf03be-294a-4539-954c-79853f4351a9">MKM</set>
             <set picURL="https://cards.scryfall.io/large/front/4/f/4f8107b3-8539-4b9c-8d0d-c512c940838f.jpg?1595212478" uuid="4f8107b3-8539-4b9c-8d0d-c512c940838f">M21</set>
+            <set picURL="https://cards.scryfall.io/large/front/e/5/e5d07ad5-0701-4696-91fd-87451997ef23.jpg?1727776183" uuid="e5d07ad5-0701-4696-91fd-87451997ef23">SLD</set>
             <reverse-related count="2">Dog Walker</reverse-related>
             <reverse-related count="2">Hunted Bonebrute</reverse-related>
             <reverse-related count="2">Krovod Haunch</reverse-related>
@@ -3707,9 +3707,9 @@ When Earthshaker Khenra enters the battlefield, target creature with power less 
                 <maintype>Creature</maintype>
                 <pt>0/1</pt>
             </prop>
+            <set picURL="https://cards.scryfall.io/large/front/4/8/48cc199d-9596-4d6a-9ed3-b1f599a03741.jpg?1675455593" uuid="48cc199d-9596-4d6a-9ed3-b1f599a03741">DMC</set>
             <set picURL="https://cards.scryfall.io/large/front/4/6/46b36476-71f3-4128-81a6-726ed18c0023.jpg?1708345190" uuid="46b36476-71f3-4128-81a6-726ed18c0023">SLD</set>
             <set picURL="https://cards.scryfall.io/large/front/e/1/e134190e-772a-458d-b0e1-633154f16809.jpg?1708345132" uuid="e134190e-772a-458d-b0e1-633154f16809">SLD</set>
-            <set picURL="https://cards.scryfall.io/large/front/4/8/48cc199d-9596-4d6a-9ed3-b1f599a03741.jpg?1675455593" uuid="48cc199d-9596-4d6a-9ed3-b1f599a03741">DMC</set>
             <set picURL="https://cards.scryfall.io/large/front/b/b/bb66de6b-8815-4e6c-a093-18607b003b88.jpg?1568003463" uuid="bb66de6b-8815-4e6c-a093-18607b003b88">C19</set>
             <reverse-related>Atla Palani, Nest Tender</reverse-related>
             <token>1</token>
@@ -4750,11 +4750,11 @@ This creature's power and toughness are each equal to the number of instant and 
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
+            <set picURL="https://cards.scryfall.io/large/front/d/6/d680c3f1-a3c0-4f38-8958-2402612c8dd1.jpg?1692830285" uuid="d680c3f1-a3c0-4f38-8958-2402612c8dd1">WOC</set>
             <set picURL="https://cards.scryfall.io/large/front/7/d/7df94cc3-fed3-493d-9aa5-c85d6a2aeb05.jpg?1575842044" uuid="7df94cc3-fed3-493d-9aa5-c85d6a2aeb05">SLD</set>
             <set picURL="https://cards.scryfall.io/large/front/d/2/d2f51f4d-eb6d-4503-b9a4-559db1b9b16f.jpg?1575842045" uuid="d2f51f4d-eb6d-4503-b9a4-559db1b9b16f">SLD</set>
             <set picURL="https://cards.scryfall.io/large/front/0/d/0dce18f1-0eff-4354-97b8-cb58295f4865.jpg?1577393119" uuid="0dce18f1-0eff-4354-97b8-cb58295f4865">SLD</set>
             <set picURL="https://cards.scryfall.io/large/front/1/a/1aceb1db-c48f-4985-a0b8-132fe12a5021.jpg?1575842048" uuid="1aceb1db-c48f-4985-a0b8-132fe12a5021">SLD</set>
-            <set picURL="https://cards.scryfall.io/large/front/d/6/d680c3f1-a3c0-4f38-8958-2402612c8dd1.jpg?1692830285" uuid="d680c3f1-a3c0-4f38-8958-2402612c8dd1">WOC</set>
             <set picURL="https://cards.scryfall.io/large/front/6/7/67457137-64f2-413d-b62e-658b3f1b1043.jpg?1547509251" uuid="67457137-64f2-413d-b62e-658b3f1b1043">UMA</set>
             <set picURL="https://cards.scryfall.io/large/front/8/1/81b53311-d007-42e8-94c0-c18052b6ef09.jpg?1562702170" uuid="81b53311-d007-42e8-94c0-c18052b6ef09">MM2</set>
             <set picURL="https://cards.scryfall.io/large/front/1/6/1666cae8-8750-4091-8e45-259e76268db9.jpg?1561756717" uuid="1666cae8-8750-4091-8e45-259e76268db9">MOR</set>
@@ -5042,12 +5042,6 @@ When this creature enters, target creature you control gains flying until end of
                 <type>Token Artifact — Food</type>
                 <maintype>Artifact</maintype>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/f/e/fe954ed4-af64-4997-ae5d-089eaa439d1f.jpg?1741621105" uuid="fe954ed4-af64-4997-ae5d-089eaa439d1f">SLD</set>
-            <set picURL="https://cards.scryfall.io/large/front/7/9/7917a093-44b8-407e-a9f1-8adc1a59d27c.jpg?1742987948" uuid="7917a093-44b8-407e-a9f1-8adc1a59d27c">SLD</set>
-            <set picURL="https://cards.scryfall.io/large/front/e/8/e8db2269-0d77-4d0c-881c-67b05fd22c1d.jpg?1742987922" uuid="e8db2269-0d77-4d0c-881c-67b05fd22c1d">SLD</set>
-            <set picURL="https://cards.scryfall.io/large/front/2/3/234d2493-0fdc-4fc2-b241-a9370f340cff.jpg?1742987895" uuid="234d2493-0fdc-4fc2-b241-a9370f340cff">SLD</set>
-            <set picURL="https://cards.scryfall.io/large/front/7/7/7774606b-2584-4c17-8fc1-f8e196643f1f.jpg?1742987838" uuid="7774606b-2584-4c17-8fc1-f8e196643f1f">SLD</set>
-            <set picURL="https://cards.scryfall.io/large/front/c/6/c6002fe4-a5c0-426d-860b-59f66896c75c.jpg?1749117392" uuid="c6002fe4-a5c0-426d-860b-59f66896c75c">SLD</set>
             <set picURL="https://cards.scryfall.io/large/front/d/0/d0e54f01-1301-481f-ace0-87966b5135f0.jpg?1764117767" uuid="d0e54f01-1301-481f-ace0-87966b5135f0">TLA</set>
             <set picURL="https://cards.scryfall.io/large/front/0/f/0fb2c5a4-859e-40ac-8091-7ba44f57b878.jpg?1757379328" uuid="0fb2c5a4-859e-40ac-8091-7ba44f57b878">SPM</set>
             <set picURL="https://cards.scryfall.io/large/front/4/8/4853f6f5-476d-4109-a1c6-f98f4d332db3.jpg?1748704103" uuid="4853f6f5-476d-4109-a1c6-f98f4d332db3">FIN</set>
@@ -5065,6 +5059,12 @@ When this creature enters, target creature you control gains flying until end of
             <set picURL="https://cards.scryfall.io/large/front/0/1/01136e91-1ad3-4e01-8f7e-2718c3a9da27.jpg?1675456902" uuid="01136e91-1ad3-4e01-8f7e-2718c3a9da27">UNF</set>
             <set picURL="https://cards.scryfall.io/large/front/3/7/37e32ba6-108a-421f-9dad-3d03f7ebe239.jpg?1641306206" uuid="37e32ba6-108a-421f-9dad-3d03f7ebe239">MH2</set>
             <set picURL="https://cards.scryfall.io/large/front/9/6/965bef73-eb93-4512-91b4-bf2ce7d27d42.jpg?1641306116" uuid="965bef73-eb93-4512-91b4-bf2ce7d27d42">C21</set>
+            <set picURL="https://cards.scryfall.io/large/front/f/e/fe954ed4-af64-4997-ae5d-089eaa439d1f.jpg?1741621105" uuid="fe954ed4-af64-4997-ae5d-089eaa439d1f">SLD</set>
+            <set picURL="https://cards.scryfall.io/large/front/7/9/7917a093-44b8-407e-a9f1-8adc1a59d27c.jpg?1742987948" uuid="7917a093-44b8-407e-a9f1-8adc1a59d27c">SLD</set>
+            <set picURL="https://cards.scryfall.io/large/front/e/8/e8db2269-0d77-4d0c-881c-67b05fd22c1d.jpg?1742987922" uuid="e8db2269-0d77-4d0c-881c-67b05fd22c1d">SLD</set>
+            <set picURL="https://cards.scryfall.io/large/front/2/3/234d2493-0fdc-4fc2-b241-a9370f340cff.jpg?1742987895" uuid="234d2493-0fdc-4fc2-b241-a9370f340cff">SLD</set>
+            <set picURL="https://cards.scryfall.io/large/front/7/7/7774606b-2584-4c17-8fc1-f8e196643f1f.jpg?1742987838" uuid="7774606b-2584-4c17-8fc1-f8e196643f1f">SLD</set>
+            <set picURL="https://cards.scryfall.io/large/front/c/6/c6002fe4-a5c0-426d-860b-59f66896c75c.jpg?1749117392" uuid="c6002fe4-a5c0-426d-860b-59f66896c75c">SLD</set>
             <set picURL="https://cards.scryfall.io/large/front/b/f/bf36408d-ed85-497f-8e68-d3a922c388a0.jpg?1744533637" uuid="bf36408d-ed85-497f-8e68-d3a922c388a0">ELD</set>
             <set picURL="https://cards.scryfall.io/large/front/1/3/13e8f518-1c0d-4c01-a397-71481839d02b.jpg?1674409652" uuid="13e8f518-1c0d-4c01-a397-71481839d02b">ELD</set>
             <set picURL="https://cards.scryfall.io/large/front/4/6/46582e55-c6f4-46e4-a78e-2c586ca4cf4d.jpg?1744533628" uuid="46582e55-c6f4-46e4-a78e-2c586ca4cf4d">ELD</set>
@@ -5663,7 +5663,6 @@ At the beginning of your upkeep, this creature deals 1 damage to you.</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/d/9/d99cc0a4-4868-47f3-bd1d-f46b7cb74650.jpg?1681768986" uuid="d99cc0a4-4868-47f3-bd1d-f46b7cb74650">SLD</set>
             <set picURL="https://cards.scryfall.io/large/front/e/2/e265ca24-96c0-4654-a8f3-bbffe288970a.jpg?1742506636" uuid="e265ca24-96c0-4654-a8f3-bbffe288970a">TDM</set>
             <set picURL="https://cards.scryfall.io/large/front/7/0/7072dea6-0d99-47fa-a83d-c8607e6a4bbd.jpg?1738355229" uuid="7072dea6-0d99-47fa-a83d-c8607e6a4bbd">DFT</set>
             <set picURL="https://cards.scryfall.io/large/front/7/0/70f8a1de-cd4c-4afa-bf03-0245d375d42e.jpg?1732803363" uuid="70f8a1de-cd4c-4afa-bf03-0245d375d42e">FDN</set>
@@ -5681,6 +5680,7 @@ At the beginning of your upkeep, this creature deals 1 damage to you.</text>
             <set picURL="https://cards.scryfall.io/large/front/4/1/41268b47-df00-41db-92d7-991c7945e4c6.jpg?1641306189" uuid="41268b47-df00-41db-92d7-991c7945e4c6">MH2</set>
             <set picURL="https://cards.scryfall.io/large/front/2/3/234007e2-624f-42d0-af7f-9788f9f35fab.jpg?1641306034" uuid="234007e2-624f-42d0-af7f-9788f9f35fab">TSR</set>
             <set picURL="https://cards.scryfall.io/large/front/6/0/60f874f9-7ac2-4d1a-97e3-722db719cd1c.jpg?1584752869" uuid="60f874f9-7ac2-4d1a-97e3-722db719cd1c">UND</set>
+            <set picURL="https://cards.scryfall.io/large/front/d/9/d99cc0a4-4868-47f3-bd1d-f46b7cb74650.jpg?1681768986" uuid="d99cc0a4-4868-47f3-bd1d-f46b7cb74650">SLD</set>
             <set picURL="https://cards.scryfall.io/large/front/c/5/c5522b39-802a-4508-a671-2f73b0633032.jpg?1563073114" uuid="c5522b39-802a-4508-a671-2f73b0633032">MH1</set>
             <set picURL="https://cards.scryfall.io/large/front/c/0/c0861b13-6cf8-4078-9178-e223a4041a8b.jpg?1557575963" uuid="c0861b13-6cf8-4078-9178-e223a4041a8b">WAR</set>
             <set picURL="https://cards.scryfall.io/large/front/9/9/993613a6-09a9-45a5-b35f-5a5fdb6d14ec.jpg?1572892502" uuid="993613a6-09a9-45a5-b35f-5a5fdb6d14ec">RNA</set>
@@ -7022,9 +7022,9 @@ When this creature enters the battlefield, it deals 1 damage to any target.</tex
                 <cmc>0</cmc>
                 <pt>0/0</pt>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/5/7/57cad0da-ac47-4324-9810-cf2ae94fd5e0.jpg?1762360009" uuid="57cad0da-ac47-4324-9810-cf2ae94fd5e0">SLD</set>
             <set picURL="https://cards.scryfall.io/large/front/d/5/d50eb149-015c-49c9-a3de-c62189c5582d.jpg?1675455611" uuid="d50eb149-015c-49c9-a3de-c62189c5582d">DMC</set>
             <set picURL="https://cards.scryfall.io/large/front/e/b/ebe2f431-75b6-4c3c-a601-15814752ea6c.jpg?1591319211" uuid="ebe2f431-75b6-4c3c-a601-15814752ea6c">C20</set>
+            <set picURL="https://cards.scryfall.io/large/front/5/7/57cad0da-ac47-4324-9810-cf2ae94fd5e0.jpg?1762360009" uuid="57cad0da-ac47-4324-9810-cf2ae94fd5e0">SLD</set>
             <reverse-related>Zaxara, the Exemplary</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -7054,8 +7054,8 @@ Equip {2}</text>
                 <maintype>Artifact</maintype>
                 <cmc>0</cmc>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/1/3/13cb668a-c8f8-491f-8534-08a7f94baf19.jpg?1739790669" uuid="13cb668a-c8f8-491f-8534-08a7f94baf19">SLD</set>
             <set picURL="https://cards.scryfall.io/large/front/a/9/a9c981c9-3376-4f6e-b30d-859e5fc7347e.jpg?1641306230" uuid="a9c981c9-3376-4f6e-b30d-859e5fc7347e">AFR</set>
+            <set picURL="https://cards.scryfall.io/large/front/1/3/13cb668a-c8f8-491f-8534-08a7f94baf19.jpg?1739790669" uuid="13cb668a-c8f8-491f-8534-08a7f94baf19">SLD</set>
             <reverse-related>Icingdeath, Frost Tyrant</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -8356,11 +8356,11 @@ A manifested creature card can be turned face up any time for its mana cost. A f
                 <cmc>0</cmc>
                 <pt>20/20</pt>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/a/5/a5dd2627-3118-4643-83e2-4637f8821ab4.jpg?1725750781" uuid="a5dd2627-3118-4643-83e2-4637f8821ab4">SLD</set>
             <set picURL="https://cards.scryfall.io/large/front/d/c/dcff76fb-e23d-4333-a770-b1d616f98486.jpg?1764117779" uuid="dcff76fb-e23d-4333-a770-b1d616f98486">TLE</set>
             <set picURL="https://cards.scryfall.io/large/front/2/5/25fca5a7-3b61-4e1e-83a3-a312c06fd922.jpg?1717193716" uuid="25fca5a7-3b61-4e1e-83a3-a312c06fd922">M3C</set>
             <set picURL="https://cards.scryfall.io/large/front/3/4/34db5e62-4792-4207-b008-7d62bae683a7.jpg?1675198627" uuid="34db5e62-4792-4207-b008-7d62bae683a7">DMR</set>
             <set picURL="https://cards.scryfall.io/large/front/f/b/fb248ba0-2ee7-4994-be57-2bcc8df29680.jpg?1598311645" uuid="fb248ba0-2ee7-4994-be57-2bcc8df29680">2XM</set>
+            <set picURL="https://cards.scryfall.io/large/front/a/5/a5dd2627-3118-4643-83e2-4637f8821ab4.jpg?1725750781" uuid="a5dd2627-3118-4643-83e2-4637f8821ab4">SLD</set>
             <set picURL="https://cards.scryfall.io/large/front/7/b/7b993828-e139-4cb6-a329-487accc1c515.jpg?1563073064" uuid="7b993828-e139-4cb6-a329-487accc1c515">MH1</set>
             <set picURL="https://cards.scryfall.io/large/front/1/0/105e687e-7196-4010-a6b7-cfa42d998fa4.jpg?1560096976" uuid="105e687e-7196-4010-a6b7-cfa42d998fa4">UMA</set>
             <set picURL="https://cards.scryfall.io/large/front/8/f/8f5c3863-c876-48a8-9bc8-be20cd61074c.jpg?1606847376" uuid="8f5c3863-c876-48a8-9bc8-be20cd61074c">CSP</set>
@@ -8410,8 +8410,8 @@ Flying, vigilance, trample, lifelink, haste</text>
                 <cmc>0</cmc>
                 <pt>10/10</pt>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/5/d/5d02dee4-2071-448f-9fd3-58d63635d712.jpg?1762360125" uuid="5d02dee4-2071-448f-9fd3-58d63635d712">SLD</set>
             <set picURL="https://cards.scryfall.io/large/front/0/2/0281825d-9d38-4b56-b522-a8d3cf8c77c9.jpg?1762360143" uuid="0281825d-9d38-4b56-b522-a8d3cf8c77c9">NEO</set>
+            <set picURL="https://cards.scryfall.io/large/front/5/d/5d02dee4-2071-448f-9fd3-58d63635d712.jpg?1762360125" uuid="5d02dee4-2071-448f-9fd3-58d63635d712">SLD</set>
             <reverse-related>Mechtitan Core</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -8971,7 +8971,6 @@ A card with morph can be turned face up any time for its morph cost.)</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/9/d/9d54ed64-573d-45cc-9d5c-94c5d0fc88ec.jpg?1751360027" uuid="9d54ed64-573d-45cc-9d5c-94c5d0fc88ec">SLD</set>
             <set picURL="https://cards.scryfall.io/large/front/c/f/cf455c08-adf5-486b-9661-d6c0099afce3.jpg?1742506352" uuid="cf455c08-adf5-486b-9661-d6c0099afce3">TDC</set>
             <set picURL="https://cards.scryfall.io/large/front/1/5/159ba2ca-1972-4bf8-9dbd-8bed5f33bfb7.jpg?1717194153" uuid="159ba2ca-1972-4bf8-9dbd-8bed5f33bfb7">M3C</set>
             <set picURL="https://cards.scryfall.io/large/front/5/b/5b911529-052a-457b-b1a0-b3f498c2cbe0.jpg?1689976009" uuid="5b911529-052a-457b-b1a0-b3f498c2cbe0">CMM</set>
@@ -8981,6 +8980,7 @@ A card with morph can be turned face up any time for its morph cost.)</text>
             <set picURL="https://cards.scryfall.io/large/front/e/b/eb47cd56-8f1f-49c9-8f19-8b1507063a9a.jpg?1651801182" uuid="eb47cd56-8f1f-49c9-8f19-8b1507063a9a">NEC</set>
             <set picURL="https://cards.scryfall.io/large/front/a/4/a4ca03f7-3442-4256-a830-fc2cbcd356db.jpg?1641306122" uuid="a4ca03f7-3442-4256-a830-fc2cbcd356db">C21</set>
             <set picURL="https://cards.scryfall.io/large/front/d/5/d57daa4d-c6d2-4d36-bb7b-2cc705d1a659.jpg?1601138602" uuid="d57daa4d-c6d2-4d36-bb7b-2cc705d1a659">2XM</set>
+            <set picURL="https://cards.scryfall.io/large/front/9/d/9d54ed64-573d-45cc-9d5c-94c5d0fc88ec.jpg?1751360027" uuid="9d54ed64-573d-45cc-9d5c-94c5d0fc88ec">SLD</set>
             <set picURL="https://cards.scryfall.io/large/front/3/2/323e26b2-1f7d-4a30-a0ef-1aa91e91d551.jpg?1563073235" uuid="323e26b2-1f7d-4a30-a0ef-1aa91e91d551">MH1</set>
             <set picURL="https://cards.scryfall.io/large/front/e/9/e9c49fa9-6f8b-4d3a-9b11-edbf4c8b8baa.jpg?1592710137" uuid="e9c49fa9-6f8b-4d3a-9b11-edbf4c8b8baa">C18</set>
             <set picURL="https://cards.scryfall.io/large/front/f/3/f32ad93f-3fd5-465c-ac6a-6f8fb57c19bd.jpg?1561758422" uuid="f32ad93f-3fd5-465c-ac6a-6f8fb57c19bd">BBD</set>
@@ -11015,7 +11015,6 @@ Equip {1}</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/5/a/5a88aa73-baca-49c2-a6c3-0a1624b6078b.jpg?1670376092" uuid="5a88aa73-baca-49c2-a6c3-0a1624b6078b">SLD</set>
             <set picURL="https://cards.scryfall.io/large/front/3/4/34032448-fe31-44c7-845c-37fea0b8e762.jpg?1767955055" uuid="34032448-fe31-44c7-845c-37fea0b8e762">ECC</set>
             <set picURL="https://cards.scryfall.io/large/front/5/9/590abe94-9c71-4429-b1b5-8b5de877de03.jpg?1721427861" uuid="590abe94-9c71-4429-b1b5-8b5de877de03">BLC</set>
             <set picURL="https://cards.scryfall.io/large/front/3/e/3ef1b559-ec63-4775-824f-bef0b3094807.jpg?1717193977" uuid="3ef1b559-ec63-4775-824f-bef0b3094807">M3C</set>
@@ -11032,6 +11031,7 @@ Equip {1}</text>
             <set picURL="https://cards.scryfall.io/large/front/9/5/95483574-95b7-42a3-b700-616189163b0a.jpg?1598312392" uuid="95483574-95b7-42a3-b700-616189163b0a">2XM</set>
             <set picURL="https://cards.scryfall.io/large/front/d/7/d71a5aa4-a960-4c42-b8ac-7003f6e83e95.jpg?1594733634" uuid="d71a5aa4-a960-4c42-b8ac-7003f6e83e95">M21</set>
             <set picURL="https://cards.scryfall.io/large/front/1/e/1e584eb2-fa22-4d75-b612-e25ecf827918.jpg?1591319226" uuid="1e584eb2-fa22-4d75-b612-e25ecf827918">C20</set>
+            <set picURL="https://cards.scryfall.io/large/front/5/a/5a88aa73-baca-49c2-a6c3-0a1624b6078b.jpg?1670376092" uuid="5a88aa73-baca-49c2-a6c3-0a1624b6078b">SLD</set>
             <set picURL="https://cards.scryfall.io/large/front/f/8/f8e4cbaa-95bc-424c-ac80-9e3e6d41d273.jpg?1572370767" uuid="f8e4cbaa-95bc-424c-ac80-9e3e6d41d273">C19</set>
             <set picURL="https://cards.scryfall.io/large/front/3/5/3543a88a-ed81-4dec-a616-43f9367516de.jpg?1552078539" uuid="3543a88a-ed81-4dec-a616-43f9367516de">GK2</set>
             <set picURL="https://cards.scryfall.io/large/front/c/0/c06bcc5b-4ccd-452d-8579-beee6c5cbe98.jpg?1654766742" uuid="c06bcc5b-4ccd-452d-8579-beee6c5cbe98">GK1</set>
@@ -11409,16 +11409,16 @@ Equip {1}</text>
                 <cmc>0</cmc>
                 <pt>2/2</pt>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/1/4/140142e2-0cfa-48a8-aab9-b0a399c48435.jpg?1745844549" uuid="140142e2-0cfa-48a8-aab9-b0a399c48435">SLD</set>
-            <set picURL="https://cards.scryfall.io/large/front/0/5/052a742b-e602-406f-82af-4ee36cf1e291.jpg?1745844523" uuid="052a742b-e602-406f-82af-4ee36cf1e291">SLD</set>
-            <set picURL="https://cards.scryfall.io/large/front/b/5/b5ff6dba-952e-432c-a73e-dd4c5353ab17.jpg?1745844501" uuid="b5ff6dba-952e-432c-a73e-dd4c5353ab17">SLD</set>
-            <set picURL="https://cards.scryfall.io/large/front/e/2/e2f533d5-6835-444f-bdbf-ada3d0d402d8.jpg?1745844469" uuid="e2f533d5-6835-444f-bdbf-ada3d0d402d8">SLD</set>
             <set picURL="https://cards.scryfall.io/large/front/5/a/5ac36b5d-07d5-4d5c-8de0-0300e6b874d9.jpg?1738355136" uuid="5ac36b5d-07d5-4d5c-8de0-0300e6b874d9">DRC</set>
             <set picURL="https://cards.scryfall.io/large/front/0/e/0e0f1e76-ccc0-4643-b4f2-c8e3042230ee.jpg?1721427307" uuid="0e0f1e76-ccc0-4643-b4f2-c8e3042230ee">BLC</set>
             <set picURL="https://cards.scryfall.io/large/front/a/d/ad46aa41-47e6-498d-8004-9127c21229a9.jpg?1717193635" uuid="ad46aa41-47e6-498d-8004-9127c21229a9">M3C</set>
             <set picURL="https://cards.scryfall.io/large/front/a/b/ab451fcc-15c9-4c19-9624-af0af741bba6.jpg?1682210921" uuid="ab451fcc-15c9-4c19-9624-af0af741bba6">MOC</set>
             <set picURL="https://cards.scryfall.io/large/front/c/e/ce94fb42-cde4-4637-b938-13f17793bf1f.jpg?1675455965" uuid="ce94fb42-cde4-4637-b938-13f17793bf1f">CLB</set>
             <set picURL="https://cards.scryfall.io/large/front/e/f/ef775ad0-b1a9-4254-ab6f-304558bb77a1.jpg?1615686300" uuid="ef775ad0-b1a9-4254-ab6f-304558bb77a1">KHM</set>
+            <set picURL="https://cards.scryfall.io/large/front/1/4/140142e2-0cfa-48a8-aab9-b0a399c48435.jpg?1745844549" uuid="140142e2-0cfa-48a8-aab9-b0a399c48435">SLD</set>
+            <set picURL="https://cards.scryfall.io/large/front/0/5/052a742b-e602-406f-82af-4ee36cf1e291.jpg?1745844523" uuid="052a742b-e602-406f-82af-4ee36cf1e291">SLD</set>
+            <set picURL="https://cards.scryfall.io/large/front/b/5/b5ff6dba-952e-432c-a73e-dd4c5353ab17.jpg?1745844501" uuid="b5ff6dba-952e-432c-a73e-dd4c5353ab17">SLD</set>
+            <set picURL="https://cards.scryfall.io/large/front/e/2/e2f533d5-6835-444f-bdbf-ada3d0d402d8.jpg?1745844469" uuid="e2f533d5-6835-444f-bdbf-ada3d0d402d8">SLD</set>
             <reverse-related>Littjara</reverse-related>
             <reverse-related>Maskwood Nexus</reverse-related>
             <reverse-related>The Bears of Littjara</reverse-related>
@@ -11553,8 +11553,8 @@ Deathtouch</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/4/1/41648b36-154c-4907-8571-9461e45a9e00.jpg?1732731853" uuid="41648b36-154c-4907-8571-9461e45a9e00">SLD</set>
             <set picURL="https://cards.scryfall.io/large/front/9/0/900340a5-7517-4ec4-a51e-762e15a29470.jpg?1681156222" uuid="900340a5-7517-4ec4-a51e-762e15a29470">NEC</set>
+            <set picURL="https://cards.scryfall.io/large/front/4/1/41648b36-154c-4907-8571-9461e45a9e00.jpg?1732731853" uuid="41648b36-154c-4907-8571-9461e45a9e00">SLD</set>
             <reverse-related>Go-Shintai of Life's Origin</reverse-related>
             <reverse-related count="x" exclude="exclude">Go-Shintai of Life's Origin</reverse-related>
             <token>1</token>
@@ -12535,7 +12535,6 @@ At the beginning of the end step, sacrifice Spark Elemental.</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/1/d/1d9b18e5-d842-4114-b395-ff5dd42c94d9.jpg?1707764489" uuid="1d9b18e5-d842-4114-b395-ff5dd42c94d9">SLD</set>
             <set picURL="https://cards.scryfall.io/large/front/0/0/004f2ea4-0477-49b2-ad06-5aac7991103d.jpg?1749245677" uuid="004f2ea4-0477-49b2-ad06-5aac7991103d">FIC</set>
             <set picURL="https://cards.scryfall.io/large/front/6/3/639b70ba-a421-47aa-b356-3b261444e79a.jpg?1742506514" uuid="639b70ba-a421-47aa-b356-3b261444e79a">TDC</set>
             <set picURL="https://cards.scryfall.io/large/front/2/7/278adad2-49a6-4baa-8dbe-93474545eef7.jpg?1730485596" uuid="278adad2-49a6-4baa-8dbe-93474545eef7">FDN</set>
@@ -12551,6 +12550,7 @@ At the beginning of the end step, sacrifice Spark Elemental.</text>
             <set picURL="https://cards.scryfall.io/large/front/9/5/95694c03-2b3b-455c-8361-0799c078bf04.jpg?1615686192" uuid="95694c03-2b3b-455c-8361-0799c078bf04">KHM</set>
             <set picURL="https://cards.scryfall.io/large/front/2/1/21e580cb-6092-48b7-ba3e-d64ec28860da.jpg?1608908446" uuid="21e580cb-6092-48b7-ba3e-d64ec28860da">CMR</set>
             <set picURL="https://cards.scryfall.io/large/front/9/8/9858cbdb-cf4a-4d72-b1c1-a151f6a3e794.jpg?1591319157" uuid="9858cbdb-cf4a-4d72-b1c1-a151f6a3e794">C20</set>
+            <set picURL="https://cards.scryfall.io/large/front/1/d/1d9b18e5-d842-4114-b395-ff5dd42c94d9.jpg?1707764489" uuid="1d9b18e5-d842-4114-b395-ff5dd42c94d9">SLD</set>
             <set picURL="https://cards.scryfall.io/large/front/d/1/d1ac09a7-239b-43af-ac7a-8c79618dc9e3.jpg?1572370476" uuid="d1ac09a7-239b-43af-ac7a-8c79618dc9e3">C19</set>
             <set picURL="https://cards.scryfall.io/large/front/7/9/79b17be6-2ee7-4f3b-88df-f298bb058f46.jpg?1592515948" uuid="79b17be6-2ee7-4f3b-88df-f298bb058f46">M20</set>
             <set picURL="https://cards.scryfall.io/large/front/e/1/e11d6572-0398-490d-8790-7d2b7e9fbca5.jpg?1552078541" uuid="e11d6572-0398-490d-8790-7d2b7e9fbca5">GK2</set>
@@ -12725,9 +12725,9 @@ At the beginning of the end step, sacrifice Spark Elemental.</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/3/e/3e55bca3-43a3-44a8-b673-b1d0cf3f203f.jpg?1732731890" uuid="3e55bca3-43a3-44a8-b673-b1d0cf3f203f">SLD</set>
             <set picURL="https://cards.scryfall.io/large/front/c/a/ca20548f-6324-4858-adbe-87303ff1ca52.jpg?1674338502" uuid="ca20548f-6324-4858-adbe-87303ff1ca52">NEO</set>
             <set picURL="https://cards.scryfall.io/large/front/8/3/83497714-97ae-4846-8096-f7f1524f0e09.jpg?1675456491" uuid="83497714-97ae-4846-8096-f7f1524f0e09">VOC</set>
+            <set picURL="https://cards.scryfall.io/large/front/3/e/3e55bca3-43a3-44a8-b673-b1d0cf3f203f.jpg?1732731890" uuid="3e55bca3-43a3-44a8-b673-b1d0cf3f203f">SLD</set>
             <set picURL="https://cards.scryfall.io/large/front/e/f/ef264a95-afe4-4b8c-9648-e8f95bfaed2a.jpg?1562702434" uuid="ef264a95-afe4-4b8c-9648-e8f95bfaed2a">A25</set>
             <set picURL="https://cards.scryfall.io/large/front/5/0/5009729f-6365-42ca-979f-d854a10e463b.jpg?1562911219" uuid="5009729f-6365-42ca-979f-d854a10e463b">C16</set>
             <set picURL="https://cards.scryfall.io/large/front/0/8/082c3bad-3fea-4c3f-8263-4b16139bb32a.jpg?1562701890" uuid="082c3bad-3fea-4c3f-8263-4b16139bb32a">EMA</set>
@@ -13126,7 +13126,6 @@ Cumulative upkeep {G}</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/e/2/e2311cf5-ab73-48d6-9fa0-54c19a7ae98f.jpg?1707764496" uuid="e2311cf5-ab73-48d6-9fa0-54c19a7ae98f">SLD</set>
             <set picURL="https://cards.scryfall.io/large/front/5/a/5a6ec62e-0e9b-4312-bfe8-cc85d76fd9e0.jpg?1721425294" uuid="5a6ec62e-0e9b-4312-bfe8-cc85d76fd9e0">BLB</set>
             <set picURL="https://cards.scryfall.io/large/front/f/9/f90bb066-79fd-48cd-ab5a-eaed71139b4e.jpg?1708711084" uuid="f90bb066-79fd-48cd-ab5a-eaed71139b4e">PIP</set>
             <set picURL="https://cards.scryfall.io/large/front/2/7/27f8ccb9-32b2-4562-a60f-843e82795984.jpg?1675198698" uuid="27f8ccb9-32b2-4562-a60f-843e82795984">DMR</set>
@@ -13135,6 +13134,7 @@ Cumulative upkeep {G}</text>
             <set picURL="https://cards.scryfall.io/large/front/9/7/977ddd05-1aae-46fc-95ce-866710d1c5c6.jpg?1641306196" uuid="977ddd05-1aae-46fc-95ce-866710d1c5c6">MH2</set>
             <set picURL="https://cards.scryfall.io/large/front/a/a/aa846cf5-c618-4304-bb92-5df936ebca9b.jpg?1598312396" uuid="aa846cf5-c618-4304-bb92-5df936ebca9b">2XM</set>
             <set picURL="https://cards.scryfall.io/large/front/6/6/66c6d816-d9b2-4b11-b0e1-ab00be74cbda.jpg?1584741599" uuid="66c6d816-d9b2-4b11-b0e1-ab00be74cbda">UND</set>
+            <set picURL="https://cards.scryfall.io/large/front/e/2/e2311cf5-ab73-48d6-9fa0-54c19a7ae98f.jpg?1707764496" uuid="e2311cf5-ab73-48d6-9fa0-54c19a7ae98f">SLD</set>
             <set picURL="https://cards.scryfall.io/large/front/7/b/7b997fe7-69f3-4ccd-b3a7-ef5e0cb7db46.jpg?1563073181" uuid="7b997fe7-69f3-4ccd-b3a7-ef5e0cb7db46">MH1</set>
             <set picURL="https://cards.scryfall.io/large/front/5/3/53500f0f-ef65-4534-a8db-80ce73030bc1.jpg?1562910261" uuid="53500f0f-ef65-4534-a8db-80ce73030bc1">UST</set>
             <set picURL="https://cards.scryfall.io/large/front/3/a/3af9733f-192f-4028-8ad6-aa1187dd15e7.jpg?1561756945" uuid="3af9733f-192f-4028-8ad6-aa1187dd15e7">CNS</set>
@@ -13800,11 +13800,6 @@ This creature can't be enchanted.</text>
                 <maintype>Artifact</maintype>
                 <cmc>0</cmc>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/c/b/cb7c6d71-c575-4c1b-a161-a4d4186ea9c6.jpg?1699887997" uuid="cb7c6d71-c575-4c1b-a161-a4d4186ea9c6">SLD</set>
-            <set picURL="https://cards.scryfall.io/large/front/8/8/88bae2c8-9d6d-42d4-a63b-c1133d772fec.jpg?1748136409" uuid="88bae2c8-9d6d-42d4-a63b-c1133d772fec">SLD</set>
-            <set picURL="https://cards.scryfall.io/large/front/1/c/1c655521-cc2c-48d2-8683-16ac77dd40d3.jpg?1748136403" uuid="1c655521-cc2c-48d2-8683-16ac77dd40d3">SLD</set>
-            <set picURL="https://cards.scryfall.io/large/front/f/6/f69d028b-5d25-432d-a2b2-d11479320af1.jpg?1749117400" uuid="f69d028b-5d25-432d-a2b2-d11479320af1">SLD</set>
-            <set picURL="https://cards.scryfall.io/large/front/7/3/73f94f72-a689-41ca-b1af-6004e2a57e9c.jpg?1752436207" uuid="73f94f72-a689-41ca-b1af-6004e2a57e9c">SLD</set>
             <set picURL="https://cards.scryfall.io/large/front/a/c/ac4384b7-853c-417d-b3b4-f54cd0b5d361.jpg?1767955781" uuid="ac4384b7-853c-417d-b3b4-f54cd0b5d361">ECL</set>
             <set picURL="https://cards.scryfall.io/large/front/e/e/ee9ffe19-fea7-4dcc-a673-26be06d2f1be.jpg?1764117773" uuid="ee9ffe19-fea7-4dcc-a673-26be06d2f1be">TLA</set>
             <set picURL="https://cards.scryfall.io/large/front/d/5/d52efeb3-661d-45e9-97c3-af167f889684.jpg?1757379348" uuid="d52efeb3-661d-45e9-97c3-af167f889684">SPM</set>
@@ -13844,6 +13839,11 @@ This creature can't be enchanted.</text>
             <set picURL="https://cards.scryfall.io/large/front/7/9/791f5fa0-f972-455e-9802-ff299853607f.jpg?1601138787" uuid="791f5fa0-f972-455e-9802-ff299853607f">2XM</set>
             <set picURL="https://cards.scryfall.io/large/front/4/3/4306be80-d7c9-4bcf-a3de-4bf159475546.jpg?1594733644" uuid="4306be80-d7c9-4bcf-a3de-4bf159475546">M21</set>
             <set picURL="https://cards.scryfall.io/large/front/2/8/2888d3ed-0719-4e1d-9de7-3da6fbde0c48.jpg?1591319265" uuid="2888d3ed-0719-4e1d-9de7-3da6fbde0c48">C20</set>
+            <set picURL="https://cards.scryfall.io/large/front/c/b/cb7c6d71-c575-4c1b-a161-a4d4186ea9c6.jpg?1699887997" uuid="cb7c6d71-c575-4c1b-a161-a4d4186ea9c6">SLD</set>
+            <set picURL="https://cards.scryfall.io/large/front/8/8/88bae2c8-9d6d-42d4-a63b-c1133d772fec.jpg?1748136409" uuid="88bae2c8-9d6d-42d4-a63b-c1133d772fec">SLD</set>
+            <set picURL="https://cards.scryfall.io/large/front/1/c/1c655521-cc2c-48d2-8683-16ac77dd40d3.jpg?1748136403" uuid="1c655521-cc2c-48d2-8683-16ac77dd40d3">SLD</set>
+            <set picURL="https://cards.scryfall.io/large/front/f/6/f69d028b-5d25-432d-a2b2-d11479320af1.jpg?1749117400" uuid="f69d028b-5d25-432d-a2b2-d11479320af1">SLD</set>
+            <set picURL="https://cards.scryfall.io/large/front/7/3/73f94f72-a689-41ca-b1af-6004e2a57e9c.jpg?1752436207" uuid="73f94f72-a689-41ca-b1af-6004e2a57e9c">SLD</set>
             <set picURL="https://cards.scryfall.io/large/front/2/e/2e752ca8-5404-4898-8b75-a0848e3850f2.jpg?1646479340" uuid="2e752ca8-5404-4898-8b75-a0848e3850f2">SLD</set>
             <set picURL="https://cards.scryfall.io/large/front/e/6/e6fa7d35-9a7a-40fc-9b97-b479fc157ab0.jpg?1568003548" uuid="e6fa7d35-9a7a-40fc-9b97-b479fc157ab0">C19</set>
             <set picURL="https://cards.scryfall.io/large/front/4/2/42e54aad-ec80-4914-9ba8-91bd53924778.jpg?1592516008" uuid="42e54aad-ec80-4914-9ba8-91bd53924778">M20</set>
@@ -14991,10 +14991,10 @@ Whenever you cast a creature spell, note one of its creature types that hasn't b
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/3/0/3053e02b-7157-4fb6-9427-d64a68ea29c3.jpg?1748136448" uuid="3053e02b-7157-4fb6-9427-d64a68ea29c3">SLD</set>
             <set picURL="https://cards.scryfall.io/large/front/a/2/a263a442-8ca6-4c69-a841-4a590ff2e729.jpg?1708716474" uuid="a263a442-8ca6-4c69-a841-4a590ff2e729">PIP</set>
             <set picURL="https://cards.scryfall.io/large/front/4/1/41567b9a-80cf-44fc-9c82-5a5f95014428.jpg?1696625023" uuid="41567b9a-80cf-44fc-9c82-5a5f95014428">WHO</set>
             <set picURL="https://cards.scryfall.io/large/front/9/f/9feb9fa0-29d3-4cf7-a996-e7cb718f02b6.jpg?1682210903" uuid="9feb9fa0-29d3-4cf7-a996-e7cb718f02b6">MOC</set>
+            <set picURL="https://cards.scryfall.io/large/front/3/0/3053e02b-7157-4fb6-9427-d64a68ea29c3.jpg?1748136448" uuid="3053e02b-7157-4fb6-9427-d64a68ea29c3">SLD</set>
             <set picURL="https://cards.scryfall.io/large/front/d/3/d36e3c0e-a759-4adc-aa2f-61b13c0f786d.jpg?1561758133" uuid="d36e3c0e-a759-4adc-aa2f-61b13c0f786d">BBD</set>
             <set picURL="https://cards.scryfall.io/large/front/6/7/677a1d9d-86fd-49db-9573-8cd2cbc1a096.jpg?1561757326" uuid="677a1d9d-86fd-49db-9573-8cd2cbc1a096">DTK</set>
             <set picURL="https://cards.scryfall.io/large/front/a/f/af4c9101-85bf-4a4f-a496-ff6db7b531b7.jpg?1562639979" uuid="af4c9101-85bf-4a4f-a496-ff6db7b531b7">KTK</set>
@@ -15242,7 +15242,6 @@ Equip {1}</text>
                 <cmc>0</cmc>
                 <pt>2/2</pt>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/c/1/c1ffdaf6-472e-46be-a74a-4be985b29df4.jpg?1719002293" uuid="c1ffdaf6-472e-46be-a74a-4be985b29df4">SLD</set>
             <set picURL="https://cards.scryfall.io/large/front/e/7/e7fcf482-2241-4263-acf8-3c34a498bfd5.jpg?1721427912" uuid="e7fcf482-2241-4263-acf8-3c34a498bfd5">BLC</set>
             <set picURL="https://cards.scryfall.io/large/front/8/1/81605b8d-cf1d-49dc-aebb-a857d6796a77.jpg?1675456083" uuid="81605b8d-cf1d-49dc-aebb-a857d6796a77">CLB</set>
             <set picURL="https://cards.scryfall.io/large/front/d/5/d5f1e139-3054-4273-8a4d-faaaa9c383a8.jpg?1675457530" uuid="d5f1e139-3054-4273-8a4d-faaaa9c383a8">VOW</set>
@@ -15250,6 +15249,7 @@ Equip {1}</text>
             <set picURL="https://cards.scryfall.io/large/front/1/8/1864d5b9-7151-42f0-8d37-8c319c3ab264.jpg?1641306253" uuid="1864d5b9-7151-42f0-8d37-8c319c3ab264">AFR</set>
             <set picURL="https://cards.scryfall.io/large/front/c/f/cf371056-43dd-41ab-8d05-b16a8bdc8d28.jpg?1598312579" uuid="cf371056-43dd-41ab-8d05-b16a8bdc8d28">2XM</set>
             <set picURL="https://cards.scryfall.io/large/front/4/1/411f4bf6-7f09-4e24-b483-0068d2f974e5.jpg?1581902126" uuid="411f4bf6-7f09-4e24-b483-0068d2f974e5">THB</set>
+            <set picURL="https://cards.scryfall.io/large/front/c/1/c1ffdaf6-472e-46be-a74a-4be985b29df4.jpg?1719002293" uuid="c1ffdaf6-472e-46be-a74a-4be985b29df4">SLD</set>
             <set picURL="https://cards.scryfall.io/large/front/b/d/bd05e304-1a16-436d-a05c-4a38a839759b.jpg?1592515991" uuid="bd05e304-1a16-436d-a05c-4a38a839759b">M20</set>
             <set picURL="https://cards.scryfall.io/large/front/5/5/551f3219-3e98-4354-abcd-db22c3253105.jpg?1557575971" uuid="551f3219-3e98-4354-abcd-db22c3253105">WAR</set>
             <set picURL="https://cards.scryfall.io/large/front/4/f/4ff5727c-7001-45db-9e0c-771824e849b0.jpg?1562702060" uuid="4ff5727c-7001-45db-9e0c-771824e849b0">A25</set>
@@ -15489,8 +15489,8 @@ Equip {1}</text>
                 <cmc>0</cmc>
                 <pt>5/5</pt>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/7/e/7e82b125-df5e-4e5f-8759-51c32c447c1d.jpg?1687814073" uuid="7e82b125-df5e-4e5f-8759-51c32c447c1d">SLD</set>
             <set picURL="https://cards.scryfall.io/large/front/5/4/54d5e60d-559d-49e0-a65e-80db721b142a.jpg?1726237911" uuid="54d5e60d-559d-49e0-a65e-80db721b142a">DSC</set>
+            <set picURL="https://cards.scryfall.io/large/front/7/e/7e82b125-df5e-4e5f-8759-51c32c447c1d.jpg?1687814073" uuid="7e82b125-df5e-4e5f-8759-51c32c447c1d">SLD</set>
             <set picURL="https://cards.scryfall.io/large/front/d/0/d0c052ed-c761-4f1d-816b-092cdd6cb0fa.jpg?1541007588" uuid="d0c052ed-c761-4f1d-816b-092cdd6cb0fa">GK1</set>
             <set picURL="https://cards.scryfall.io/large/front/3/f/3fd53493-ac85-4dd0-b1db-0ae0130ea2d4.jpg?1562841174" uuid="3fd53493-ac85-4dd0-b1db-0ae0130ea2d4">MM3</set>
             <set picURL="https://cards.scryfall.io/large/front/3/3/33ee3f6c-5df6-4271-b2f9-86b9afffab7b.jpg?1562539804" uuid="33ee3f6c-5df6-4271-b2f9-86b9afffab7b">RTR</set>
@@ -15758,7 +15758,6 @@ Equip {1}</text>
                 <cmc>0</cmc>
                 <pt>2/2</pt>
             </prop>
-            <set picURL="https://cards.scryfall.io/large/front/8/1/8150833a-9c83-4d00-ae2f-470088700fdb.jpg?1708345305" uuid="8150833a-9c83-4d00-ae2f-470088700fdb">SLD</set>
             <set picURL="https://cards.scryfall.io/large/front/1/7/17f001ab-514b-49e7-a657-b2872ad7a1de.jpg?1767954964" uuid="17f001ab-514b-49e7-a657-b2872ad7a1de">ECC</set>
             <set picURL="https://cards.scryfall.io/large/front/4/c/4cecd5c6-d6c8-4cd5-97a3-cddaf051af15.jpg?1749245686" uuid="4cecd5c6-d6c8-4cd5-97a3-cddaf051af15">FIC</set>
             <set picURL="https://cards.scryfall.io/large/front/b/8/b82be730-c63b-4c2b-99f4-476befdb95cb.jpg?1738355219" uuid="b82be730-c63b-4c2b-99f4-476befdb95cb">DFT</set>
@@ -15779,6 +15778,7 @@ Equip {1}</text>
             <set picURL="https://cards.scryfall.io/large/front/3/f/3f170f84-6c36-43e2-91e6-3c7a136944b1.jpg?1594733533" uuid="3f170f84-6c36-43e2-91e6-3c7a136944b1">M21</set>
             <set picURL="https://cards.scryfall.io/large/front/3/e/3e8a0b96-9add-406a-bf10-bc943141edf5.jpg?1591319184" uuid="3e8a0b96-9add-406a-bf10-bc943141edf5">C20</set>
             <set picURL="https://cards.scryfall.io/large/front/6/b/6b3e6b4d-d798-4c6a-8a09-255be2a6df2c.jpg?1581901997" uuid="6b3e6b4d-d798-4c6a-8a09-255be2a6df2c">THB</set>
+            <set picURL="https://cards.scryfall.io/large/front/8/1/8150833a-9c83-4d00-ae2f-470088700fdb.jpg?1708345305" uuid="8150833a-9c83-4d00-ae2f-470088700fdb">SLD</set>
             <set picURL="https://cards.scryfall.io/large/front/8/e/8e214f84-01ee-49c1-8801-4e550b5ade5d.jpg?1572370688" uuid="8e214f84-01ee-49c1-8801-4e550b5ade5d">C19</set>
             <set picURL="https://cards.scryfall.io/large/front/5/9/59bad855-ff86-4f98-bf18-0982c7aea9c5.jpg?1568003399" uuid="59bad855-ff86-4f98-bf18-0982c7aea9c5">C19</set>
             <set picURL="https://cards.scryfall.io/large/front/1/8/18f0436e-9328-4266-9cf8-80b557a0c17c.jpg?1592515969" uuid="18f0436e-9328-4266-9cf8-80b557a0c17c">M20</set>


### PR DESCRIPTION
Now that Cockatrice can display and select multiple printings of tokens, it makes more sense to include some alternate art and promo tokens. This PR adds the token printings from the various Secret Lairs that have come out, helpfully collected by Scryfall into one set (SLD). Cockatrice already has all the Secret Lair printings of cards, so it seems reasonable to have the tokens to match.