### PR TITLE
Scryfall API: Add headers and enhance logging

### DIFF
--- a/.github/workflows/update_links.yml
+++ b/.github/workflows/update_links.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Query Scryfall API and update picURLs
         shell: bash
         working-directory: ./scripts
-        run: python3 -u update_image_links.py ../tokens.xml --inplace
+        run: python3 update_image_links.py ../tokens.xml --inplace
 
       - name: Create pull request
         if: github.event_name != 'pull_request'

--- a/.github/workflows/update_links.yml
+++ b/.github/workflows/update_links.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Query Scryfall API and update picURLs
         shell: bash
         working-directory: ./scripts
-        run: python3 update_image_links.py ../tokens.xml --inplace
+        run: python3 -u update_image_links.py ../tokens.xml --inplace
 
       - name: Create pull request
         if: github.event_name != 'pull_request'

--- a/scripts/update_image_links.py
+++ b/scripts/update_image_links.py
@@ -39,8 +39,10 @@ def cards_collection(identifiers):
 
         payload = json.dumps({'identifiers': chunk}).encode('utf-8')
         req = Request('https://api.scryfall.com/cards/collection', payload,
-                      headers={'Content-Type': 'application/json'})
-
+                      headers={
+                          'Content-Type': 'application/json',
+                          'User-Agent': 'Magic-Token',
+                          'Accept': 'application/json'})
         # Rate limiting
         cur_time = time.time()
         delta_time = cur_time - start_time
@@ -52,7 +54,6 @@ def cards_collection(identifiers):
             with urlopen(req) as f:
                 list_obj = json.load(f)
         except HTTPError as e:
-            print(f"HTTP {e.code}")
             print(e.read().decode())
             raise
         

--- a/scripts/update_image_links.py
+++ b/scripts/update_image_links.py
@@ -6,6 +6,7 @@ the links to Scryfall images with up-to-date URLs by querying Scryfall's API.
 from xml.sax import saxutils, make_parser, handler
 from urllib.parse import urlsplit
 from urllib.request import Request, urlopen
+from urllib.error import HTTPError
 import itertools
 import json
 import sys
@@ -47,12 +48,18 @@ def cards_collection(identifiers):
             time.sleep(0.1 - delta_time)
         start_time = time.time()
 
-        with urlopen(req) as f:
-            list_obj = json.load(f)
-            assert not list_obj.get('has_more', False)
-            assert 'warnings' not in list_obj
-
-            yield from list_obj['data']
+        try:
+            with urlopen(req) as f:
+                list_obj = json.load(f)
+        except HTTPError as e:
+            print(f"HTTP {e.code}")
+            print(e.read().decode())
+            raise
+        
+        assert not list_obj.get('has_more', False)
+        assert 'warnings' not in list_obj
+        
+        yield from list_obj['data']
 
 def parse_picurl(picurl):
     """

--- a/scripts/update_image_links.py
+++ b/scripts/update_image_links.py
@@ -19,7 +19,7 @@ import shutil
 SCRYFALL_MAX_LIST_SIZE = 75
 SCRYFALL_API_HEADERS = {
     'Content-Type': 'application/json',
-    'User-Agent': 'Magic-Token',
+    'User-Agent': 'Magic-Token/1.0',
     'Accept': 'application/json',
 }
 

--- a/scripts/update_image_links.py
+++ b/scripts/update_image_links.py
@@ -17,6 +17,11 @@ import pathlib
 import shutil
 
 SCRYFALL_MAX_LIST_SIZE = 75
+SCRYFALL_API_HEADERS = {
+    'Content-Type': 'application/json',
+    'User-Agent': 'Magic-Token',
+    'Accept': 'application/json',
+}
 
 def cards_collection(identifiers):
     """
@@ -38,11 +43,7 @@ def cards_collection(identifiers):
         n += SCRYFALL_MAX_LIST_SIZE
 
         payload = json.dumps({'identifiers': chunk}).encode('utf-8')
-        req = Request('https://api.scryfall.com/cards/collection', payload,
-                      headers={
-                          'Content-Type': 'application/json',
-                          'User-Agent': 'Magic-Token',
-                          'Accept': 'application/json'})
+        req = Request('https://api.scryfall.com/cards/collection', payload, headers=SCRYFALL_API_HEADERS)
         # Rate limiting
         cur_time = time.time()
         delta_time = cur_time - start_time
@@ -54,8 +55,8 @@ def cards_collection(identifiers):
             with urlopen(req) as f:
                 list_obj = json.load(f)
         except HTTPError as e:
-            print(e.read().decode())
-            raise
+            error_body = e.read().decode()
+            raise RuntimeError(f"Scryfall API request failed: {error_body}") from e
         
         assert not list_obj.get('has_more', False)
         assert 'warnings' not in list_obj


### PR DESCRIPTION
Fixes #357

- [Scryfall API now requires certain header](https://scryfall.com/blog/user-agent-and-accept-header-now-required-on-the-api-225):
  - user-agent
  - accept
- Add some logging to find such issues next time easier:
  - Instead `urllib.error.HTTPError: HTTP Error 400: Bad Request`
  - Show
    ```
    RuntimeError: Scryfall API request failed: {
     "object": "error",
     "code": "bad_request",
     "status": 400,
     "details": "You submitted an invalid request. HTTP requests to api.scryfall.com must contain a User-Agent and Accept header. More info: https://scryfall.com/docs/api"
    }
    ```
