### PR TITLE
Add all prinitings of TLA tokens

### DIFF
--- a/tokens.xml
+++ b/tokens.xml
@@ -274,6 +274,10 @@ Whenever an opponent casts a creature spell, this permanent isn't a creature unt
                 <pt>1/1</pt>
             </prop>
             <set picURL="https://cards.scryfall.io/large/front/f/8/f842c52a-04b6-4625-ba58-45b043ada340.jpg?1764117659" uuid="f842c52a-04b6-4625-ba58-45b043ada340" num="4">TLA</set>
+            <set picURL="https://cards.scryfall.io/large/front/c/a/cae9c13e-fda2-4591-bd52-888d12194e4d.jpg?1764117666" uuid="cae9c13e-fda2-4591-bd52-888d12194e4d" num="5">TLA</set>
+            <set picURL="https://cards.scryfall.io/large/front/3/f/3f9ab0ca-fe08-4d90-9c54-3137620647cb.jpg?1764117673" uuid="3f9ab0ca-fe08-4d90-9c54-3137620647cb" num="6">TLA</set>
+            <set picURL="https://cards.scryfall.io/large/front/b/5/b52bae4c-3831-442a-a944-b1f3548dbd39.jpg?1764117680" uuid="b52bae4c-3831-442a-a944-b1f3548dbd39" num="7">TLA</set>
+            <set picURL="https://cards.scryfall.io/large/front/0/1/01439983-8394-4a0c-9e9e-92a3f1927fe3.jpg?1764117686" uuid="01439983-8394-4a0c-9e9e-92a3f1927fe3" num="8">TLA</set>
             <reverse-related count="x">Aang and Katara</reverse-related>
             <reverse-related count="x">Aang, Airbending Master</reverse-related>
             <reverse-related>Allied Teamwork</reverse-related>
@@ -2330,7 +2334,11 @@ Cloud Sprite can block only creatures with flying.</text>
                 <cmc>0</cmc>
             </prop>
             <set picURL="https://cards.scryfall.io/large/front/c/3/c321b9e4-ab7e-4e8a-988f-5463c776d685.jpg?1771590258" uuid="c321b9e4-ab7e-4e8a-988f-5463c776d685" num="2">TMC</set>
+            <set picURL="https://cards.scryfall.io/large/front/8/2/82016bc3-8905-454a-b4aa-b9eac69d42c4.jpg?1764117725" uuid="82016bc3-8905-454a-b4aa-b9eac69d42c4" num="14">TLA</set>
+            <set picURL="https://cards.scryfall.io/large/front/3/3/33648889-2715-40f0-81fa-b6571d0bb0c9.jpg?1764117731" uuid="33648889-2715-40f0-81fa-b6571d0bb0c9" num="15">TLA</set>
+            <set picURL="https://cards.scryfall.io/large/front/4/c/4c9669e6-e093-4f88-9699-a1a32793bfa9.jpg?1764117737" uuid="4c9669e6-e093-4f88-9699-a1a32793bfa9" num="16">TLA</set>
             <set picURL="https://cards.scryfall.io/large/front/9/8/98bdb578-e81e-40f9-9c06-b2867158baef.jpg?1764117743" uuid="98bdb578-e81e-40f9-9c06-b2867158baef" num="17">TLA</set>
+            <set picURL="https://cards.scryfall.io/large/front/8/d/8db9a248-d380-48e9-850c-38b2907332c1.jpg?1764117749" uuid="8db9a248-d380-48e9-850c-38b2907332c1" num="18">TLA</set>
             <set picURL="https://cards.scryfall.io/large/front/1/5/15866ed4-1ca3-427f-99ba-ee26ede9ae18.jpg?1752946432" uuid="15866ed4-1ca3-427f-99ba-ee26ede9ae18" num="10">EOC</set>
             <set picURL="https://cards.scryfall.io/large/front/6/e/6e886e0b-2ce7-4231-a47c-a39bda50e8fd.jpg?1749245699" uuid="6e886e0b-2ce7-4231-a47c-a39bda50e8fd" num="9">FIC</set>
             <set picURL="https://cards.scryfall.io/large/front/5/1/5117d654-dabb-4f97-b3d7-b6e1e3157758.jpg?1721428139" uuid="5117d654-dabb-4f97-b3d7-b6e1e3157758" num="37">BLC</set>
@@ -5120,6 +5128,8 @@ When this creature enters, target creature you control gains flying until end of
             </prop>
             <set picURL="https://cards.scryfall.io/large/front/d/a/da1fca2e-4ea7-4c5f-bd58-f9529dfb6f37.jpg?1775827284" uuid="da1fca2e-4ea7-4c5f-bd58-f9529dfb6f37" num="27">SOC</set>
             <set picURL="https://cards.scryfall.io/large/front/e/2/e2b62092-57df-4d95-b2b9-961794e7c20b.jpg?1771590558" uuid="e2b62092-57df-4d95-b2b9-961794e7c20b" num="8">TMT</set>
+            <set picURL="https://cards.scryfall.io/large/front/d/b/db202f04-61e7-4e12-848e-6c1761956a58.jpg?1764117755" uuid="db202f04-61e7-4e12-848e-6c1761956a58" num="19">TLA</set>
+            <set picURL="https://cards.scryfall.io/large/front/6/f/6fb7cf0b-48d1-4a35-be63-a331987400de.jpg?1764117761" uuid="6fb7cf0b-48d1-4a35-be63-a331987400de" num="20">TLA</set>
             <set picURL="https://cards.scryfall.io/large/front/d/0/d0e54f01-1301-481f-ace0-87966b5135f0.jpg?1764117767" uuid="d0e54f01-1301-481f-ace0-87966b5135f0" num="21">TLA</set>
             <set picURL="https://cards.scryfall.io/large/front/0/f/0fb2c5a4-859e-40ac-8091-7ba44f57b878.jpg?1757379328" uuid="0fb2c5a4-859e-40ac-8091-7ba44f57b878" num="5">SPM</set>
             <set picURL="https://cards.scryfall.io/large/front/4/8/4853f6f5-476d-4109-a1c6-f98f4d332db3.jpg?1748704103" uuid="4853f6f5-476d-4109-a1c6-f98f4d332db3" num="22">FIN</set>
@@ -19179,6 +19189,7 @@ Whenever a creature deals combat damage to you, its controller becomes the monar
             <set picURL="https://cards.scryfall.io/large/front/3/e/3e28bc58-b616-4a65-8d33-7cdd07405d41.jpg?1771590336" uuid="3e28bc58-b616-4a65-8d33-7cdd07405d41" num="1">TMT</set>
             <set picURL="https://cards.scryfall.io/large/front/6/1/61328aec-ba26-4142-a774-96924303786d.jpg?1772966703" uuid="61328aec-ba26-4142-a774-96924303786d" num="1">ECC</set>
             <set picURL="https://cards.scryfall.io/large/front/2/b/2b3d7795-3fc3-4b78-bdf4-0a79981f1eee.jpg?1764117639" uuid="2b3d7795-3fc3-4b78-bdf4-0a79981f1eee" num="1">TLA</set>
+            <set picURL="https://cards.scryfall.io/large/front/6/f/6f361ecd-045d-43a3-bb1b-83c23f070ff8.jpg?1764117646" uuid="6f361ecd-045d-43a3-bb1b-83c23f070ff8" num="2">TLA</set>
             <set picURL="https://cards.scryfall.io/large/front/e/9/e980eddf-92f8-4dc4-8bad-b2f3dcaf03ef.jpg?1757379290" uuid="e980eddf-92f8-4dc4-8bad-b2f3dcaf03ef" num="1">SPM</set>
             <set picURL="https://cards.scryfall.io/large/front/0/9/09d6521e-438a-4d16-992f-f2ab27b26ce4.jpg?1752946393" uuid="09d6521e-438a-4d16-992f-f2ab27b26ce4" num="1">EOC</set>
             <set picURL="https://cards.scryfall.io/large/front/f/c/fcde6a95-37f1-4bb4-9cea-5b65dbc9c76a.jpg?1749244795" uuid="fcde6a95-37f1-4bb4-9cea-5b65dbc9c76a" num="1">FIN</set>


### PR DESCRIPTION
Since the introduction of the printing selector for tokens, it is now becoming standard to include all printings for each token in a set. TLA predates this change so I am adding them now. This was additionally requested on our Discord. 