### PR TITLE
Use direct links for GitHub hosted images

### DIFF
--- a/tokens.xml
+++ b/tokens.xml
@@ -16123,7 +16123,7 @@ Equip {1}</text>
                 <cmc>0</cmc>
                 <pt>0/1</pt>
             </prop>
-            <set picURL="ttps://raw.githubusercontent.com/SlightlyCircuitous/image-storage/refs/heads/main/Wood.jpeg">MIR</set>
+            <set picURL="https://raw.githubusercontent.com/SlightlyCircuitous/image-storage/refs/heads/main/Wood.jpeg">MIR</set>
             <reverse-related>Jungle Patrol</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>

--- a/tokens.xml
+++ b/tokens.xml
@@ -886,7 +886,7 @@ Creature tokens you control have flying and vigilance.</text>
                 <maintype>Artifact</maintype>
                 <cmc>0</cmc>
             </prop>
-            <set picURL="https://github.com/SlightlyCircuitous/image-storage/blob/main/Banana.jpeg?raw=true">J22</set>
+            <set picURL="https://raw.githubusercontent.com/SlightlyCircuitous/image-storage/refs/heads/main/Banana.jpeg">J22</set>
             <reverse-related>Kibo, Uktabi Prince</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -4428,7 +4428,7 @@ When Earthshaker Khenra enters the battlefield, target creature with power less 
                 <cmc>0</cmc>
                 <pt>3/3</pt>
             </prop>
-            <set picURL="https://github.com/SlightlyCircuitous/image-storage/blob/main/Elemental.jpeg?raw=true">ARC</set>
+            <set picURL="https://raw.githubusercontent.com/SlightlyCircuitous/image-storage/refs/heads/main/Elemental.jpeg">ARC</set>
             <reverse-related count="7" exclude="exclude">Evil Comes to Fruition</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -6169,7 +6169,7 @@ At the beginning of your upkeep, this creature deals 1 damage to you.</text>
                 <cmc>0</cmc>
                 <pt>4/6</pt>
             </prop>
-            <set picURL="https://github.com/SlightlyCircuitous/image-storage/blob/main/Golem.jpeg?raw=true">ARC</set>
+            <set picURL="https://raw.githubusercontent.com/SlightlyCircuitous/image-storage/refs/heads/main/Golem.jpeg">ARC</set>
             <reverse-related>The Iron Guardian Stirs</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -7978,7 +7978,7 @@ Trample</text>
                 <cmc>0</cmc>
                 <pt>0/1</pt>
             </prop>
-            <set picURL="https://github.com/SlightlyCircuitous/image-storage/blob/main/Kelp.jpeg?raw=true">ME2</set>
+            <set picURL="https://raw.githubusercontent.com/SlightlyCircuitous/image-storage/refs/heads/main/Kelp.jpeg">ME2</set>
             <reverse-related>Wall of Kelp</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -8204,7 +8204,7 @@ Flanking</text>
                 <cmc>0</cmc>
                 <pt>3/1</pt>
             </prop>
-            <set picURL="https://github.com/SlightlyCircuitous/image-storage/blob/main/Knight.jpeg?raw=true">WOC</set>
+            <set picURL="https://raw.githubusercontent.com/SlightlyCircuitous/image-storage/refs/heads/main/Knight.jpeg">WOC</set>
             <reverse-related>Court of Embereth</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -10603,7 +10603,7 @@ Creatures you control attack each combat if able.</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://github.com/SlightlyCircuitous/image-storage/blob/main/Pirate.jpeg?raw=true">J22</set>
+            <set picURL="https://raw.githubusercontent.com/SlightlyCircuitous/image-storage/refs/heads/main/Pirate.jpeg">J22</set>
             <reverse-related>Daring Piracy</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -12229,7 +12229,7 @@ Deathtouch</text>
                 <cmc>0</cmc>
                 <pt>4/4</pt>
             </prop>
-            <set picURL="https://github.com/SlightlyCircuitous/image-storage/blob/main/sketch%20token.jpeg?raw=true">UNF</set>
+            <set picURL="https://raw.githubusercontent.com/SlightlyCircuitous/image-storage/refs/heads/main/sketch%20token.jpeg">UNF</set>
             <reverse-related>D00-DL, Caricaturist</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -13314,7 +13314,7 @@ At the beginning of the end step, sacrifice Spark Elemental.</text>
                 <cmc>0</cmc>
                 <pt>*/*</pt>
             </prop>
-            <set picURL="https://github.com/SlightlyCircuitous/image-storage/blob/main/Spirit.jpeg?raw=true">ME2</set>
+            <set picURL="https://raw.githubusercontent.com/SlightlyCircuitous/image-storage/refs/heads/main/Spirit.jpeg">ME2</set>
             <reverse-related>Broken Visage</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -15088,7 +15088,7 @@ Sacrifice this creature: This creature deals 1 damage to any target.</text>
                 <cmc>0</cmc>
                 <pt>2/2</pt>
             </prop>
-            <set picURL="https://github.com/SlightlyCircuitous/image-storage/blob/main/Unicorn.jpeg?raw=true">JMP</set>
+            <set picURL="https://raw.githubusercontent.com/SlightlyCircuitous/image-storage/refs/heads/main/Unicorn.jpeg">JMP</set>
             <reverse-related>Blessed Sanctuary</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -16108,7 +16108,7 @@ Equip {1}</text>
                 <cmc>0</cmc>
                 <pt>1/1</pt>
             </prop>
-            <set picURL="https://github.com/SlightlyCircuitous/image-storage/blob/main/Wolves%20of%20the%20Hunt.jpeg?raw=true">M10</set>
+            <set picURL="https://raw.githubusercontent.com/SlightlyCircuitous/image-storage/refs/heads/main/Wolves%20of%20the%20Hunt.jpeg">M10</set>
             <reverse-related>Master of the Hunt</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -16123,7 +16123,7 @@ Equip {1}</text>
                 <cmc>0</cmc>
                 <pt>0/1</pt>
             </prop>
-            <set picURL="https://github.com/SlightlyCircuitous/image-storage/blob/main/Wood.jpeg?raw=true">MIR</set>
+            <set picURL="ttps://raw.githubusercontent.com/SlightlyCircuitous/image-storage/refs/heads/main/Wood.jpeg">MIR</set>
             <reverse-related>Jungle Patrol</reverse-related>
             <token>1</token>
             <tablerow>2</tablerow>
@@ -16313,7 +16313,7 @@ Equip {1}</text>
                 <cmc>0</cmc>
                 <pt>5/5</pt>
             </prop>
-            <set picURL="https://github.com/SlightlyCircuitous/image-storage/blob/main/Zeppelin.jpeg?raw=true">J22</set>
+            <set picURL="https://raw.githubusercontent.com/SlightlyCircuitous/image-storage/refs/heads/main/Zeppelin.jpeg">J22</set>
             <reverse-related>Lita, Mechanical Engineer</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -17461,7 +17461,7 @@ Whenever an opponent draws a card, this emblem deals 1 damage to them.</text>
                 <type>Emblem</type>
                 <maintype>Emblem</maintype>
             </prop>
-            <set picURL="https://github.com/SlightlyCircuitous/image-storage/blob/main/karn_emblem_arena.png?raw=true">DMU</set>
+            <set picURL="https://raw.githubusercontent.com/SlightlyCircuitous/image-storage/refs/heads/main/karn_emblem_arena.png">DMU</set>
             <reverse-related>Karn, Living Legacy</reverse-related>
             <token>1</token>
             <tablerow>1</tablerow>
@@ -18818,7 +18818,7 @@ At the beginning of your upkeep, if you control a Contraption, move the CRANK! c
                 <type>State</type>
                 <maintype>State</maintype>
             </prop>
-            <set picURL="https://github.com/SlightlyCircuitous/image-storage/blob/main/CRANK!.png?raw=true">UST</set>
+            <set picURL="https://raw.githubusercontent.com/SlightlyCircuitous/image-storage/refs/heads/main/CRANK!.png">UST</set>
             <reverse-related>Accessories to Murder</reverse-related>
             <reverse-related>Applied Aeronautics</reverse-related>
             <reverse-related>Arms Depot</reverse-related>


### PR DESCRIPTION
Avoids two redirects per link, see e.g. https://github.com/Cockatrice/Magic-Token/actions/runs/28797616691/attempts/1#summary-85392146296

There were a few places in the file that used the "final" githubusercontent links already.

<br>

The health check is still failing due to #371.