### PR TITLE
fix url check workflow

### DIFF
--- a/.github/workflows/check_links.yml
+++ b/.github/workflows/check_links.yml
@@ -42,11 +42,8 @@ jobs:
       # Extract picture URLs from tokens.xml
       - name: Extract URLs
         id: tokens_pic_urls
-        uses: lycheeverse/lychee-action@v2
-        with:
-          args: --dump -- tokens.xml
-          output: url_list.md
-          jobSummary: false
+        shell: bash
+        script: grep tokens.xml -oPe '(?<=picURL=")[^"]+(?=")' >url_list.md
 
       # Check dumped URLs
       - name: Check token art URLs

--- a/.github/workflows/check_links.yml
+++ b/.github/workflows/check_links.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Extract URLs
         id: tokens_pic_urls
         shell: bash
-        script: grep tokens.xml -oPe '(?<=picURL=")[^"]+(?=")' >url_list.md
+        run: grep tokens.xml -oPe '(?<=picURL=")[^"]+(?=")' >url_list.md
 
       # Check dumped URLs
       - name: Check token art URLs


### PR DESCRIPTION
lychee v24 now includes parsing xml files, however they don't support arbitrary xmls, we only care about parsing the contents of the picurl so I decided that we do away their parsing and simply extract only the part we care about